### PR TITLE
Fix/TAO-8318/Proctor terminated session 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "displayName": "TAO Core SDK",
   "description": "Core libraries of TAO",
   "homepage": "https://github.com/oat-sa/tao-core-sdk-fe#readme",

--- a/src/core/dataProvider/request.js
+++ b/src/core/dataProvider/request.js
@@ -25,6 +25,7 @@
  *   - the responseBody:
  *      { success : true, data : [the results]}
  *      { success : false, data : {Exception}, message : 'Something went wrong' }
+ *      { success : false, code : X, message : 'Something went wrong' }
  *   - 204 for empty content
  *   - 403 if CSRF token validation fails
  *
@@ -57,11 +58,16 @@ export default function request(url, data, method, headers, background, noToken)
         background: background,
         noToken: noToken === false ? false : true
     }).then(function(response) {
-        if (!_.isUndefined(response)) {
-            if (response.success) {
-                return response.data;
-            }
-            throw new Error(response.data);
+        if (_.isUndefined(response)) { // in case 204 empty content
+            return Promise.resolve();
+        } else if (response.success) {
+            return Promise.resolve(response.data);
         }
+        else {
+            return Promise.reject(response); // in case success:false different types of response
+        }
+    })
+    .catch(function(error) {
+        return Promise.reject(error);
     });
 }

--- a/src/core/request.js
+++ b/src/core/request.js
@@ -183,7 +183,7 @@ export default function request(options) {
                                     );
                                 }
 
-                                if (response && response.success === true) {
+                                if (xhr.status === 200 || (response && response.success === true)) {
                                     // there's some data
                                     return resolve(response);
                                 }

--- a/src/core/request.js
+++ b/src/core/request.js
@@ -25,6 +25,7 @@
  *   - the responseBody:
  *      { success : true, data : [the results]}
  *      { success : false, data : {Exception}, message : 'Something went wrong' }
+ *      { success : false, code : X, message : 'Something went wrong' }
  *   - 204 for empty content
  *   - 403 if CSRF token validation fails
  *

--- a/test/core/dataProvider/request/test.js
+++ b/test/core/dataProvider/request/test.js
@@ -167,24 +167,6 @@ define(['jquery', 'lodash', 'core/dataProvider/request', 'core/promise'], functi
             url: '//500',
             reject: true,
             err: new Error('500 : Server Error')
-        },
-        {
-            title: '200 error 1',
-            url: '//200/error/1',
-            reject: true,
-            err: new Error('1 : oops')
-        },
-        {
-            title: '200 error 2',
-            url: '//200/error/2',
-            reject: true,
-            err: new Error('2 : woops')
-        },
-        {
-            title: '200 error fallback',
-            url: '//200/error/fallback',
-            reject: true,
-            err: new Error('The server has sent an empty response')
         }
     ];
 
@@ -220,5 +202,39 @@ define(['jquery', 'lodash', 'core/dataProvider/request', 'core/promise'], functi
                     ready();
                 });
         }
+    });
+
+    requestCases = [
+        {
+            title: '200 error 1',
+            url: '//200/error/1'
+        },
+        {
+            title: '200 error 2',
+            url: '//200/error/2'
+        },
+        {
+            title: '200 error fallback',
+            url: '//200/error/fallback'
+        }
+    ];
+
+    QUnit.cases.init(requestCases).test('request with ', function(data, assert) {
+        var ready = assert.async();
+
+        var result = request(data.url, data.data, data.method, data.headers, data.background, data.noToken);
+        assert.ok(result instanceof Promise, 'The request function returns a promise');
+
+        assert.expect(2);
+
+        result
+            .then(function() {
+                assert.ok(false, 'Should reject');
+                ready();
+            })
+            .catch(function(response) {
+                assert.deepEqual(response, responses[data.url][0], 'Reject response is correct');
+                ready();
+            });
     });
 });

--- a/test/core/request/test.js
+++ b/test/core/request/test.js
@@ -395,15 +395,15 @@ define(['jquery', 'lodash', 'core/request', 'core/promise', 'core/tokenHandler',
         .init([
             {
                 title: '200 error 1',
-                url: '//200/error/1',
+                url: '//200/error/1'
             },
             {
                 title: '200 error 2',
-                url: '//200/error/2',
+                url: '//200/error/2'
             },
             {
                 title: '200 error fallback',
-                url: '//200/error/fallback',
+                url: '//200/error/fallback'
             }
         ])
         .test('request with success: false', function(caseData, assert) {
@@ -459,7 +459,7 @@ define(['jquery', 'lodash', 'core/request', 'core/promise', 'core/tokenHandler',
 
                     result
                         .then(function(response) {
-                            assert.deepEqual(response.content, caseData.content, 'The given result is correct');
+                            assert.deepEqual(response, responses[caseData.url][0], 'The given result is correct');
 
                             tokenHandler.getToken().then(function(storedToken) {
                                 assert.equal(storedToken, 'token2', 'The token was updated with the next in sequence');


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8318
Review and comments here https://github.com/oat-sa/tao-core/pull/2136

**Solution:**
Case with code 200 and response.success === false is considered as a correct response and promise will be resolved

Changed logic in src/core/dataProvider/request.js  for this case ( related to  https://github.com/oat-sa/tao-core/commit/c3975d3ccd1d69c04b9bc306863b0ae8d4508ec6)