### PR TITLE
Fix/tao 8468 detect indexeddb2 correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "displayName": "TAO Core SDK",
   "description": "Core libraries of TAO",
   "homepage": "https://github.com/oat-sa/tao-core-sdk-fe#readme",

--- a/src/core/store/indexeddb.js
+++ b/src/core/store/indexeddb.js
@@ -55,7 +55,7 @@ var idStoreName = 'id';
  * Check if we're using the v2 of IndexedDB
  * @type {Boolean}
  */
-var isIndexedDB2 = 'getAll' in IDBObjectStore.prototype;
+var isIndexedDB2 = typeof IDBObjectStore !== 'undefined' && 'getAll' in IDBObjectStore.prototype;
 
 /**
  * Opens a store


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TAO-8468

Fix the detection of IndexedDb version 2 in Edge private mode. It appears that the `IDBObjectStore` object is not available at all. 

How to test, 
```
npm build
npm test
```
And along with  `tao-core`, by opening a test session in Edge private mode. 