### PR TITLE
Fix/nex 19 provider name and module error reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "displayName": "TAO Core SDK",
   "description": "Core libraries of TAO",
   "homepage": "https://github.com/oat-sa/tao-core-sdk-fe#readme",

--- a/src/core/communicator/poll.js
+++ b/src/core/communicator/poll.js
@@ -79,7 +79,13 @@ var defaults = {
  * @param {String} [config.token] - An optional initial security token
  * @type {Object}
  */
-var pollProvider = {
+const pollProvider = {
+
+    /**
+     * The provider name
+     */
+    name : 'poll',
+
     /**
      * Initializes the communication implementation
      * @returns {Promise}

--- a/src/core/communicator/request.js
+++ b/src/core/communicator/request.js
@@ -29,58 +29,61 @@ import pollProvider from 'core/communicator/poll';
  * 'request' provider for {@link core/communicator}
  * @extends {core/communicator/poll} never start nor stop the polling
  */
-var requestProvider = _.defaults(
-    {
-        /**
-         * @returns {Promise}
-         */
-        destroy: function destroy() {
-            this.throttledSend = null;
-            this.messagesQueue = null;
+const requestProvider = _.defaults({
 
-            return Promise.resolve();
-        },
+    /**
+     * the provider name
+     */
+    name: 'request',
 
-        /**
-         * @returns {Promise}
-         */
-        open: function open() {
-            return Promise.resolve();
-        },
+    /**
+     * @returns {Promise}
+     */
+    destroy: function destroy() {
+        this.throttledSend = null;
+        this.messagesQueue = null;
 
-        /**
-         * @returns {Promise}
-         */
-        close: function close() {
-            return Promise.resolve();
-        },
-
-        /**
-         * Sends an messages through the communication implementation
-         * @param {String} channel - The name of the communication channel to use
-         * @param {Object} message - The message to send
-         * @returns {Promise}
-         */
-        send: function send(channel, message) {
-            // queue the message, it will be sent soon
-            var pending = {
-                channel: channel,
-                message: message
-            };
-            var promise = new Promise(function(resolve, reject) {
-                pending.promise = {
-                    resolve: resolve,
-                    reject: reject
-                };
-            });
-            this.messagesQueue.push(pending);
-
-            this.request();
-
-            return promise;
-        }
+        return Promise.resolve();
     },
-    pollProvider
-);
+
+    /**
+     * @returns {Promise}
+     */
+    open: function open() {
+        return Promise.resolve();
+    },
+
+    /**
+     * @returns {Promise}
+     */
+    close: function close() {
+        return Promise.resolve();
+    },
+
+    /**
+     * Sends an messages through the communication implementation
+     * @param {String} channel - The name of the communication channel to use
+     * @param {Object} message - The message to send
+     * @returns {Promise}
+     */
+    send: function send(channel, message) {
+        // queue the message, it will be sent soon
+        var pending = {
+            channel: channel,
+            message: message
+        };
+        var promise = new Promise(function(resolve, reject) {
+            pending.promise = {
+                resolve: resolve,
+                reject: reject
+            };
+        });
+        this.messagesQueue.push(pending);
+
+        this.request();
+
+        return promise;
+    }
+}, pollProvider );
 
 export default requestProvider;

--- a/test/core/moduleLoader/test.js
+++ b/test/core/moduleLoader/test.js
@@ -278,7 +278,7 @@ define(['lodash', 'core/moduleLoader', 'core/promise'], function(_, moduleLoader
             })
             .catch( err => {
                 assert.ok(err instanceof TypeError);
-                assert.equal(err.message, `The module from 'test/core/moduleLoader/mockModule' is not valid`);
+                assert.equal(err.message, `The module 'test/core/moduleLoader/mockModule' is not valid`);
             })
             .then( ready );
     });

--- a/test/core/moduleLoader/test.js
+++ b/test/core/moduleLoader/test.js
@@ -13,11 +13,11 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2017-2019 (original work) Open Assessment Technologies SA ;
  */
 
 /**
- * Module loade\'s test
+ * Module loader's test
  *
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
@@ -259,7 +259,7 @@ define(['lodash', 'core/moduleLoader', 'core/promise'], function(_, moduleLoader
         };
         var loader, promise;
 
-        assert.expect(5);
+        assert.expect(6);
 
         loader = moduleLoader();
 
@@ -275,12 +275,12 @@ define(['lodash', 'core/moduleLoader', 'core/promise'], function(_, moduleLoader
         promise
             .then(function() {
                 assert.ok(false, 'The promise should fail since the loaded provider is wrong');
-                ready();
             })
-            .catch(function(e) {
-                assert.ok(true, e);
-                ready();
-            });
+            .catch( err => {
+                assert.ok(err instanceof TypeError);
+                assert.equal(err.message, `The module from 'test/core/moduleLoader/mockModule' is not valid`);
+            })
+            .then( ready );
     });
 
     QUnit.test('load a bundle', function(assert) {


### PR DESCRIPTION
 - missing `name` property in the communicator providers to comply with the validation (plus minor code style fixes)
 - the `moduleLoader` errors where too generic and didn't gave you a clue of which module was in error

How to test : 
Covered by `npm test`
