### PR TITLE
Fix/tao 8631/accept token lifetime from config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "displayName": "TAO Core SDK",
   "description": "Core libraries of TAO",
   "homepage": "https://github.com/oat-sa/tao-core-sdk-fe#readme",

--- a/src/core/tokenHandler.js
+++ b/src/core/tokenHandler.js
@@ -116,7 +116,8 @@ export default function tokenHandlerFactory(options) {
          * @returns {Promise<Boolean>} - resolves true when completed
          */
         getClientConfigTokens() {
-            const clientTokens = _.map(module.config().tokens, serverToken => ({
+            const {tokens} = module.config();
+            const clientTokens = (tokens || []).map(serverToken => ({
                 value: serverToken,
                 receivedAt: Date.now()
             }));
@@ -130,9 +131,7 @@ export default function tokenHandlerFactory(options) {
                     // Uses a promiseQueue to ensure synchronous adding
                     const setTokenQueue = promiseQueue();
 
-                    _.forEach(newTokens, token => {
-                        setTokenQueue.serie(() => this.setToken(token));
-                    });
+                    newTokens.forEach(token => setTokenQueue.serie(() => this.setToken(token)));
 
                     return setTokenQueue.serie(() => true);
                 });

--- a/src/core/tokenHandler.js
+++ b/src/core/tokenHandler.js
@@ -48,7 +48,7 @@ export default function tokenHandlerFactory(options) {
             initialToken: options
         };
     }
-    options = _.defaults({}, options, defaults);
+    options = _.defaults({}, options, _.omit(module.config(), 'tokens'), defaults);
     // Initialise storage for tokens:
     const tokenStore = tokenStoreFactory(options);
 

--- a/src/core/tokenHandler.js
+++ b/src/core/tokenHandler.js
@@ -65,15 +65,15 @@ export default function tokenHandlerFactory(options) {
         getToken() {
             const initialToken = options.initialToken;
 
-            const getFirstTokenValue = () => {
-                return tokenStore.dequeue()
+            const getFirstTokenValue = () => (
+                tokenStore.dequeue()
                     .then(currentToken => {
                         if (currentToken) {
                             return currentToken.value;
                         }
                         return null;
-                    });
-            };
+                    })
+            );
 
             // If set, initialToken will be provided directly, without using store:
             if (initialToken) {

--- a/src/core/tokenHandler.js
+++ b/src/core/tokenHandler.js
@@ -22,7 +22,6 @@
 import _ from 'lodash';
 import module from 'module';
 import tokenStoreFactory from 'core/tokenStore';
-import Promise from 'core/promise';
 import promiseQueue from 'core/promiseQueue';
 
 let clientConfigFetched = false;

--- a/src/core/tokenHandler.js
+++ b/src/core/tokenHandler.js
@@ -146,7 +146,7 @@ export default function tokenHandlerFactory(options) {
 
         /**
          * Getter for the current queue length
-         * @returns {Promise<Integer>}
+         * @returns {Promise<Number>}
          */
         getQueueLength() {
             return tokenStore.getSize();
@@ -154,7 +154,7 @@ export default function tokenHandlerFactory(options) {
 
         /**
          * Setter for maximum pool size
-         * @param {Integer} size
+         * @param {Number} size
          */
         setMaxSize(size) {
             tokenStore.setMaxSize(size);

--- a/src/core/tokenStore.js
+++ b/src/core/tokenStore.js
@@ -27,9 +27,15 @@ import Promise from 'core/promise';
 import store from 'core/store';
 
 /**
+ * @typedef {Object} token - A token object
+ * @property {String} value - Long alphanumeric string
+ * @property {Number} receivedAt - Creation timestamp
+ */
+
+/**
  * The default number of tokens to store
  */
-var defaultConfig = {
+const defaultConfig = {
     maxSize: 6,
     tokenTimeLimit: 1000 * 60 * 24
 };
@@ -42,13 +48,11 @@ var defaultConfig = {
  * @returns {tokenStore}
  */
 export default function tokenStoreFactory(options) {
-    var config = _.defaults(options || {}, defaultConfig);
+    const config = _.defaults(options || {}, defaultConfig);
 
     // In memory storage
     // For security reasons, this is preferred over the indexeddb or localStorage implementations
-    var getStore = function getStore() {
-        return store('tokenStore.tokens', store.backends.memory);
-    };
+    const getStore = () => store('tokenStore.tokens', store.backends.memory);
 
     /**
      * @typedef tokenStore
@@ -60,35 +64,30 @@ export default function tokenStoreFactory(options) {
          *
          * @returns {Promise<Object>} the token object
          */
-        dequeue: function dequeue() {
-            var self = this;
-            return self.getIndex().then(function(latestIndex) {
-                var key = _.first(latestIndex);
-                if (!key) return Promise.resolve();
+        dequeue() {
+            return this.getIndex()
+                .then(latestIndex => {
+                    const key = _.first(latestIndex);
+                    if (!key) {
+                        return Promise.resolve();
+                    }
 
-                return getStore()
-                    .then(function(storage) {
-                        return storage.getItem(key);
-                    })
-                    .then(function(token) {
-                        return self.remove(key).then(function() {
-                            return token;
-                        });
-                    });
-            });
+                    return getStore()
+                        .then(storage => storage.getItem(key))
+                        .then(token => this.remove(key).then(() => token));
+                });
         },
 
         /**
          * Add a new token object to the queue
          * Add an entry to the store as well
          *
-         * @param {Object} token - the token object
+         * @param {token} token - the token object
          * @param {String} token.value - long alphanumeric string
          * @param {Number} token.receivedAt - timestamp
          * @returns {Promise<Boolean>} - true if added
          */
-        enqueue: function enqueue(token) {
-            var self = this;
+        enqueue(token) {
             // Handle legacy param type:
             if (_.isString(token)) {
                 token = {
@@ -97,14 +96,11 @@ export default function tokenStoreFactory(options) {
                 };
             }
             return getStore()
-                .then(function(storage) {
-                    return storage.setItem(token.value, token);
-                })
-                .then(function(updated) {
+                .then(storage => storage.setItem(token.value, token))
+                .then(updated => {
                     if (updated) {
-                        return self.enforceMaxSize().then(function() {
-                            return true;
-                        });
+                        return this.enforceMaxSize()
+                            .then(() => true);
                     }
                     return false;
                 });
@@ -116,28 +112,26 @@ export default function tokenStoreFactory(options) {
          *
          * @returns {Promise<Array>}
          */
-        getIndex: function getIndex() {
-            return this.getTokens().then(function(tokens) {
-                return _.chain(tokens)
-                    .values()
-                    .sort(function(t1, t2) {
-                        return t1.receivedAt - t2.receivedAt;
-                    })
-                    .map('value')
-                    .value();
-            });
+        getIndex() {
+            return this.getTokens()
+                .then(tokens => {
+                    return _.chain(tokens)
+                        .values()
+                        .sort((t1, t2) => t1.receivedAt - t2.receivedAt)
+                        .map('value')
+                        .value();
+                });
         },
 
         /**
          * Check whether the given token is in the store
          *
          * @param {String} key - token string
-         * @returns {Boolean}
+         * @returns {Promise<Boolean>}
          */
-        has: function has(key) {
-            return this.getIndex().then(function(latestIndex) {
-                return _.contains(latestIndex, key);
-            });
+        has(key) {
+            return this.getIndex()
+                .then(latestIndex => _.contains(latestIndex, key));
         },
 
         /**
@@ -146,56 +140,52 @@ export default function tokenStoreFactory(options) {
          * @param {String} key - token string
          * @returns {Promise<Boolean>} resolves once removed
          */
-        remove: function remove(key) {
-            return this.has(key).then(function(result) {
-                if (result) {
-                    return getStore().then(function(storage) {
-                        return storage.removeItem(key);
-                    });
-                }
-                return false;
-            });
+        remove(key) {
+            return this.has(key)
+                .then(result => {
+                    if (result) {
+                        return getStore()
+                            .then(storage => storage.removeItem(key));
+                    }
+                    return false;
+                });
         },
 
         /**
          * Empty the queue and store
          * @returns {Promise}
          */
-        clear: function clear() {
-            return getStore().then(function(storage) {
-                return storage.clear();
-            });
+        clear() {
+            return getStore()
+                .then(storage => storage.clear());
         },
 
         /**
          * Gets all tokens in the store
          * @returns {Promise<Array>} - token objects
          */
-        getTokens: function getTokens() {
-            return getStore().then(function(storage) {
-                return storage.getItems();
-            });
+        getTokens() {
+            return getStore()
+                .then(storage => storage.getItems());
         },
 
         /**
          * Gets the current size of the store
          * @returns {Promise<Integer>}
          */
-        getSize: function getSize() {
-            return this.getIndex().then(function(latestIndex) {
-                return latestIndex.length;
-            });
+        getSize() {
+            return this.getIndex()
+                .then(latestIndex => latestIndex.length);
         },
 
         /**
          * Setter for maximum pool size
          * @param {Integer} size
          */
-        setMaxSize: function setMaxSize(size) {
-            var self = this;
+        setMaxSize(size) {
             if (_.isNumber(size) && size > 0 && size !== config.maxSize) {
                 config.maxSize = size;
-                self.enforceMaxSize();
+                this.enforceMaxSize();
             }
         },
 
@@ -204,56 +194,46 @@ export default function tokenStoreFactory(options) {
          * (Could happen if maxSize is reduced during the life of the tokenStore)
          * @returns {Promise} - resolves when done
          */
-        enforceMaxSize: function enforceMaxSize() {
-            var self = this;
-            return this.getIndex().then(function(latestIndex) {
-                var keysToRemove;
-                var excess = latestIndex.length - config.maxSize;
-                if (excess > 0) {
-                    keysToRemove = latestIndex.slice(0, excess);
-                    return Promise.all(
-                        _.map(keysToRemove, function(key) {
-                            return self.remove(key);
-                        })
-                    );
-                }
-                return true;
-            });
+        enforceMaxSize() {
+            return this.getIndex()
+                .then(latestIndex => {
+                    const excess = latestIndex.length - config.maxSize;
+                    if (excess > 0) {
+                        const keysToRemove = latestIndex.slice(0, excess);
+                        return Promise.all(
+                            _.map(keysToRemove, key => this.remove(key))
+                        );
+                    }
+                    return true;
+                });
         },
 
         /**
          * Checks one token and removes it from the store if expired
-         * @param {Object} token - the token object
+         * @param {token} token - the token object
          * @returns {Promise<Boolean>}
          */
-        checkExpiry: function checkExpiry(token) {
+        checkExpiry(token) {
             if (Date.now() - token.receivedAt > config.tokenTimeLimit) {
                 return this.remove(token.value);
             }
-            return true;
+            return Promise.resolve(true);
         },
 
         /**
          * Checks all the tokens in the store to see if they expired
          * @returns {Promise<Boolean>} - resolves to true
          */
-        expireOldTokens: function expireOldTokens() {
-            var self = this;
-            return self.getTokens().then(function(tokens) {
+        expireOldTokens() {
+            return this.getTokens()
                 // Check each token's expiry, synchronously:
-                return _.reduce(
+                .then(tokens => _.reduce(
                     tokens,
-                    function(previousPromise, nextToken) {
-                        return previousPromise.then(function() {
-                            return self.checkExpiry(nextToken);
-                        });
-                    },
+                    (previousPromise, nextToken) => previousPromise.then(() => this.checkExpiry(nextToken)),
                     Promise.resolve()
-                ).then(function() {
-                    // All done
-                    return true;
-                });
-            });
+                ))
+                // All done
+                .then(() => true);
         }
     };
 }

--- a/src/core/tokenStore.js
+++ b/src/core/tokenStore.js
@@ -209,12 +209,14 @@ export default function tokenStoreFactory(options) {
         },
 
         /**
-         * Checks one token and removes it from the store if expired
+         * Checks one token and removes it from the store if expired.
+         * If the timeLimit is lesser than or equal to 0, no time limit is applied.
          * @param {token} token - the token object
          * @returns {Promise<Boolean>}
          */
         checkExpiry(token) {
-            if (Date.now() - token.receivedAt > config.tokenTimeLimit) {
+            const {tokenTimeLimit} = config;
+            if (tokenTimeLimit > 0 && Date.now() - token.receivedAt > tokenTimeLimit) {
                 return this.remove(token.value);
             }
             return Promise.resolve(true);

--- a/src/core/tokenStore.js
+++ b/src/core/tokenStore.js
@@ -23,7 +23,6 @@
  * @author Martin Nicholson <martin@taotesting.com>
  */
 import _ from 'lodash';
-import Promise from 'core/promise';
 import store from 'core/store';
 
 /**

--- a/src/core/tokenStore.js
+++ b/src/core/tokenStore.js
@@ -168,7 +168,7 @@ export default function tokenStoreFactory(options) {
 
         /**
          * Gets the current size of the store
-         * @returns {Promise<Integer>}
+         * @returns {Promise<Number>}
          */
         getSize() {
             return this.getIndex()
@@ -177,7 +177,7 @@ export default function tokenStoreFactory(options) {
 
         /**
          * Setter for maximum pool size
-         * @param {Integer} size
+         * @param {Number} size
          */
         setMaxSize(size) {
             if (_.isNumber(size) && size > 0 && size !== config.maxSize) {

--- a/src/core/tokenStore.js
+++ b/src/core/tokenStore.js
@@ -114,13 +114,11 @@ export default function tokenStoreFactory(options) {
          */
         getIndex() {
             return this.getTokens()
-                .then(tokens => {
-                    return _.chain(tokens)
-                        .values()
+                .then(tokens => (
+                    Object.values(tokens)
                         .sort((t1, t2) => t1.receivedAt - t2.receivedAt)
-                        .map('value')
-                        .value();
-                });
+                        .map(token => token.value)
+                ));
         },
 
         /**
@@ -131,7 +129,7 @@ export default function tokenStoreFactory(options) {
          */
         has(key) {
             return this.getIndex()
-                .then(latestIndex => _.contains(latestIndex, key));
+                .then(latestIndex => latestIndex.includes(key));
         },
 
         /**
@@ -201,7 +199,7 @@ export default function tokenStoreFactory(options) {
                     if (excess > 0) {
                         const keysToRemove = latestIndex.slice(0, excess);
                         return Promise.all(
-                            _.map(keysToRemove, key => this.remove(key))
+                            keysToRemove.map(key => this.remove(key))
                         );
                     }
                     return true;
@@ -229,10 +227,14 @@ export default function tokenStoreFactory(options) {
         expireOldTokens() {
             return this.getTokens()
                 // Check each token's expiry, synchronously:
-                .then(tokens => _.reduce(
-                    tokens,
-                    (previousPromise, nextToken) => previousPromise.then(() => this.checkExpiry(nextToken)),
-                    Promise.resolve()
+                .then(tokens => (
+                    Object.values(tokens)
+                        .reduce(
+                            (previousPromise, nextToken) => (
+                                previousPromise.then(() => this.checkExpiry(nextToken))
+                            ),
+                            Promise.resolve()
+                        )
                 ))
                 // All done
                 .then(() => true);

--- a/test/core/tokenStore/test.js
+++ b/test/core/tokenStore/test.js
@@ -386,13 +386,25 @@ define(['lodash', 'core/promise', 'core/tokenStore'], function(_, Promise, token
             });
     });
 
-    QUnit.test('expireOldTokens', function(assert) {
+    QUnit.cases.init([{
+        title: 'with time limit',
+        options: {
+            tokenTimeLimit: 100
+        },
+        shouldExpire: true
+    }, {
+        title: 'without time limit',
+        options: {
+            tokenTimeLimit: 0
+        },
+        shouldExpire: false
+    }]).test('expireOldTokens ', function(data, assert) {
         var ready = assert.async();
         var tokenStore;
 
         assert.expect(2);
 
-        tokenStore = tokenStoreFactory({ tokenTimeLimit: 100 });
+        tokenStore = tokenStoreFactory(data.options);
 
         tokenStore
             .clear()
@@ -421,7 +433,11 @@ define(['lodash', 'core/promise', 'core/tokenStore'], function(_, Promise, token
                 return tokenStore.getSize();
             })
             .then(function(size) {
-                assert.equal(size, 1, 'A single token remains after small time delay');
+                if (data.shouldExpire) {
+                    assert.equal(size, 1, 'A single token remains after small time delay');
+                } else {
+                    assert.equal(size, 4, 'No token have expired');
+                }
                 ready();
             })
             .catch(function(err) {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8631

This PR aims to fix the following lacks in the anti-CSRF  tokens handling:
- In `core/tokenStore` it was impossible to set unlimited time for tokens, as it is in the backend implementation.
- In `core/tokenHandler` the platform options were ignored.

At the same time, those modules have been converted to ES6.

Impacted unit tests:
- `/test/core/tokenHandler/test.html`
- `/test/core/tokenStore/test.html`

To test:
```
npm run prepare
npm run test
```

**Edit:** to ease the review, actual changes are in those commits:
- `core/tokenStore`: https://github.com/oat-sa/tao-core-sdk-fe/pull/24/commits/d06796d3b0232df07f7c738ee04d8178e83a47f5
- `core/tokenHandler`: https://github.com/oat-sa/tao-core-sdk-fe/pull/24/commits/b9553f00d661ad66d87a3de7f382d08e520f165c