### PR TITLE
Fix/tao 8657/reuse rejected token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "displayName": "TAO Core SDK",
   "description": "Core libraries of TAO",
   "homepage": "https://github.com/oat-sa/tao-core-sdk-fe#readme",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "displayName": "TAO Core SDK",
   "description": "Core libraries of TAO",
   "homepage": "https://github.com/oat-sa/tao-core-sdk-fe#readme",

--- a/src/core/request.js
+++ b/src/core/request.js
@@ -36,7 +36,6 @@ import _ from 'lodash';
 import __ from 'i18n';
 import module from 'module';
 import context from 'context';
-import Promise from 'core/promise';
 import promiseQueue from 'core/promiseQueue';
 import tokenHandlerFactory from 'core/tokenHandler';
 import loggerFactory from 'core/logger';

--- a/src/core/request.js
+++ b/src/core/request.js
@@ -158,7 +158,7 @@ export default function request(options) {
 
         return computeHeaders().then(customHeaders => {
             return new Promise((resolve, reject) => {
-                let noop;
+                const noop = void(0);
                 $.ajax({
                     url: options.url,
                     method: options.method || 'GET',

--- a/src/core/request.js
+++ b/src/core/request.js
@@ -145,7 +145,7 @@ export default function request(options) {
          * @param {Object} xhr
          * @returns {Promise} - resolves when done
          */
-        const setTokenFromXhr = (xhr) => {
+        const setTokenFromXhr = xhr => {
             if (_.isFunction(xhr.getResponseHeader)) {
                 const token = xhr.getResponseHeader(tokenHeaderName);
                 logger.debug('received %s header %s', tokenHeaderName, token);
@@ -157,8 +157,8 @@ export default function request(options) {
             return Promise.resolve();
         };
 
-        return computeHeaders().then(customHeaders => {
-            return new Promise((resolve, reject) => {
+        return computeHeaders()
+            .then(customHeaders => new Promise((resolve, reject) => {
                 const noop = undefined; // eslint-disable-line no-undefined
                 $.ajax({
                     url: options.url,
@@ -169,7 +169,7 @@ export default function request(options) {
                     dataType: options.dataType || 'json',
                     async: true,
                     timeout: options.timeout * 1000 || context.timeout * 1000 || 0,
-                    beforeSend: () => {
+                    beforeSend() {
                         if (!_.isEmpty(customHeaders)) {
                             logger.debug(
                                 'sending %s header %s',
@@ -242,7 +242,7 @@ export default function request(options) {
                         type: 'error',
                         textStatus: textStatus,
                         message: errorThrown || __('An error occurred!')
-                    }
+                    };
 
                     const enhancedResponse = {...responseExtras, ...response};
 
@@ -270,9 +270,8 @@ export default function request(options) {
                         reject(createError(enhancedResponse, error, xhr.status, xhr.readyState > 0));
                     });
                 });
-            });
-        });
-    }
+            }));
+    };
 
     // Decide how to launch the request based on certain params:
     return tokenHandler.getQueueLength().then(queueLength => {

--- a/src/core/request.js
+++ b/src/core/request.js
@@ -48,8 +48,6 @@ const queue = promiseQueue();
 
 const logger = loggerFactory('core/request');
 
-let tempToken;
-
 /**
  * Create a new error based on the given response
  * @param {Object} response - the server body response as plain object
@@ -105,6 +103,9 @@ export default function request(options) {
      * @returns {Promise} resolves with response, or rejects if something went wrong
      */
     const runRequest = () => {
+
+        let tempToken;
+
         /**
          * Fetches a security token and appends it to headers, if required
          * Also saves the retrieved token in a temporary constiable, in case we need to re-enqueue it

--- a/src/core/request.js
+++ b/src/core/request.js
@@ -158,7 +158,7 @@ export default function request(options) {
 
         return computeHeaders().then(customHeaders => {
             return new Promise((resolve, reject) => {
-                const noop = void(0);
+                const noop = undefined; // eslint-disable-line no-undefined
                 $.ajax({
                     url: options.url,
                     method: options.method || 'GET',

--- a/src/core/request.js
+++ b/src/core/request.js
@@ -244,7 +244,7 @@ export default function request(options) {
                         message: errorThrown || __('An error occurred!')
                     }
 
-                    const enhancedResponse = {...response, ...responseExtras};
+                    const enhancedResponse = {...responseExtras, ...response};
 
                     // if the request failed because the browser is offline,
                     // we need to recycle the used request token

--- a/test/core/request/test.js
+++ b/test/core/request/test.js
@@ -76,6 +76,15 @@ define(['jquery', 'lodash', 'core/request', 'core/promise', 'core/tokenHandler',
                 status: 200
             }
         ],
+        '//202': [
+            {
+                success: false
+            },
+            'Accepted',
+            {
+                status: 202
+            }
+        ],
 
         '//403': [
             {
@@ -554,6 +563,12 @@ define(['jquery', 'lodash', 'core/request', 'core/promise', 'core/tokenHandler',
             source: 'network',
             message: '0 : timeout'
         },
+        '//202': {
+            code: 202,
+            sent: true,
+            source: 'request',
+            message: 'The server has sent an empty response'
+        },
         '//403': {
             code: 403,
             sent: true,
@@ -571,6 +586,10 @@ define(['jquery', 'lodash', 'core/request', 'core/promise', 'core/tokenHandler',
             {
                 title: '403 response',
                 url: '//403'
+            },
+            {
+                title: '2xx catch-all',
+                url: '//202'
             }
         ])
         .test('error-throwing cases ', function(caseData, assert) {

--- a/test/core/request/test.js
+++ b/test/core/request/test.js
@@ -109,6 +109,25 @@ define(['jquery', 'lodash', 'core/request', 'core/promise', 'core/tokenHandler',
         '//204': [null, 'No Content', { status: 204 }]
     };
 
+    var standardMockResponse = function(settings, caseData, context) {
+        var response = _.cloneDeep(responses[settings.url][0]);
+        var content;
+        if (response) {
+            content = response.data || {};
+            if (caseData.headers) {
+                content.requestHeaders = settings.headers;
+            }
+            if (response.success === false) {
+                context.responseText = JSON.stringify(response);
+            } else {
+                context.responseText = JSON.stringify({
+                    success: true,
+                    content: content
+                });
+            }
+        }
+    };
+
     QUnit.module('API');
 
     QUnit.test('module', function(assert) {
@@ -170,22 +189,7 @@ define(['jquery', 'lodash', 'core/request', 'core/promise', 'core/tokenHandler',
                     url: /^\/\/200.*$/,
                     status: 200,
                     response: function(settings) {
-                        var response = _.cloneDeep(responses[settings.url][0]);
-                        var content;
-                        if (response) {
-                            content = response.data || {};
-                            if (caseData.headers) {
-                                content.requestHeaders = settings.headers;
-                            }
-                            if (response.success === false) {
-                                this.responseText = JSON.stringify(response);
-                            } else {
-                                this.responseText = JSON.stringify({
-                                    success: true,
-                                    content: content
-                                });
-                            }
-                        }
+                        return standardMockResponse(settings, caseData, this);
                     }
                 }
             ]);
@@ -243,23 +247,7 @@ define(['jquery', 'lodash', 'core/request', 'core/promise', 'core/tokenHandler',
                         'X-CSRF-Token': 'token2'
                     },
                     response: function(settings) {
-                        var response = _.cloneDeep(responses[settings.url][0]);
-                        var content;
-
-                        if (response) {
-                            content = response.data || {};
-                            if (caseData.headers) {
-                                content.requestHeaders = settings.headers;
-                            }
-                            if (response.success === false) {
-                                this.responseText = JSON.stringify(response);
-                            } else {
-                                this.responseText = JSON.stringify({
-                                    success: true,
-                                    content: content
-                                });
-                            }
-                        }
+                        return standardMockResponse(settings, caseData, this);
                     }
                 }
             ]);
@@ -311,23 +299,7 @@ define(['jquery', 'lodash', 'core/request', 'core/promise', 'core/tokenHandler',
                     'X-CSRF-Token': 'token3'
                 },
                 response: function(settings) {
-                    var response = _.cloneDeep(responses[settings.url][0]);
-                    var content;
-
-                    if (response) {
-                        content = response.data || {};
-                        if (data.headers) {
-                            content.requestHeaders = settings.headers;
-                        }
-                        if (response.success === false) {
-                            this.responseText = JSON.stringify(response);
-                        } else {
-                            this.responseText = JSON.stringify({
-                                success: true,
-                                content: content
-                            });
-                        }
-                    }
+                    return standardMockResponse(settings, data, this);
                 }
             }
         ]);
@@ -505,22 +477,7 @@ define(['jquery', 'lodash', 'core/request', 'core/promise', 'core/tokenHandler',
                         'X-CSRF-Token': 'token2'
                     },
                     response: function(settings) {
-                        var response = _.cloneDeep(responses[settings.url][0]);
-                        var content;
-                        if (response) {
-                            content = response.data || {};
-                            if (caseData.headers) {
-                                content.requestHeaders = settings.headers;
-                            }
-                            if (response.success === false) {
-                                this.responseText = JSON.stringify(response);
-                            } else {
-                                this.responseText = JSON.stringify({
-                                    success: true,
-                                    content: content
-                                });
-                            }
-                        }
+                        return standardMockResponse(settings, caseData, this);
                     }
                 }
             ]);
@@ -608,22 +565,14 @@ define(['jquery', 'lodash', 'core/request', 'core/promise', 'core/tokenHandler',
                     status: 403,
                     statusText: 'Authentication Error',
                     response: function(settings) {
-                        var response = _.cloneDeep(responses[settings.url][0]);
-                        var content;
-                        if (response) {
-                            content = response.data || {};
-                            if (caseData.headers) {
-                                content.requestHeaders = settings.headers;
-                            }
-                            if (response.success === false) {
-                                this.responseText = JSON.stringify(response);
-                            } else {
-                                this.responseText = JSON.stringify({
-                                    success: true,
-                                    content: content
-                                });
-                            }
-                        }
+                        return standardMockResponse(settings, caseData, this);
+                    }
+                },
+                {
+                    url: '//202',
+                    status: 202,
+                    response: function(settings) {
+                        return standardMockResponse(settings, caseData, this);
                     }
                 }
             ]);

--- a/test/core/request/test.js
+++ b/test/core/request/test.js
@@ -88,7 +88,9 @@ define(['jquery', 'lodash', 'core/request', 'core/promise', 'core/tokenHandler',
 
         '//403': [
             {
-                success: false
+                success: false,
+                errorCode: 403,
+                errorMsg: 'Authentication Error'
             },
             'Error',
             {
@@ -98,7 +100,9 @@ define(['jquery', 'lodash', 'core/request', 'core/promise', 'core/tokenHandler',
 
         '//500': [
             {
-                success: false
+                success: false,
+                errorCode: 500,
+                errorMsg: 'Internal Server Error'
             },
             'Error',
             {
@@ -531,6 +535,12 @@ define(['jquery', 'lodash', 'core/request', 'core/promise', 'core/tokenHandler',
             sent: true,
             source: 'network',
             message: '403 : Authentication Error'
+        },
+        '//500': {
+            code: 500,
+            sent: true,
+            source: 'request',
+            message: '500 : Internal Server Error'
         }
     };
 


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8657

In ACT's environment, test runner polling (via the "heartbeat" feature) when offline, causes all the FE tokens to be wasted.

The proposed solution is to re-use the current FE token (by re-enqueueing it in the tokenHandler) when such a request fails (if the HTTP response code === 0).

I also took the opportunity to cover some uncovered lines of code with new tests.

Dev TODOs:
- [x] ES6ify `core/request`

Post-merge:
- [ ] github release & npm publish?
- [ ] companion PR in `tao-core` to guarantee deployment?

**How to test:**
- [x] checkout https://github.com/oat-sa/act-deploy/tree/release/sprint-v0.105-alpha
- [x] `composer install`
- [x] link or copy this branch of `tao-core-sdk-fe` into `/tao/views/node_modules/@oat-sa/`
- [x] install your TAO instance
- [x] in `config/taoQtiTest/testRunner.conf.php`, I recommend to set a lower value of `plugins.heartbeat.frequency`
- [x] you may also set a lower value of `bootstrap.communication.params.interval`
- [x] in `config/tao/client_lib_config_registry.conf.php`, you can change the `core/logger` settings from `warn` to `debug` -> then you may see output in the browser console
- [x] create and launch a delivery. Play with going offline and online.
- [x] precaching (browse 3 items ahead while offline) should work without errors or warnings
- [x] there should be an offline message after this point, with ability to resume test when connection is back
- [x] after 6 or more failed "messages" requests in network tab, the test should still be usable
- [x] lastly, please `npm run test` :)
