### PR TITLE
Feature/nex 394 implement request logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "displayName": "TAO Core SDK",
   "description": "Core libraries of TAO",
   "homepage": "https://github.com/oat-sa/tao-core-sdk-fe#readme",

--- a/src/core/request.js
+++ b/src/core/request.js
@@ -102,7 +102,7 @@ export default function request(options) {
 
     // Request logger
     const requestLogger = logger.child({ url: options.url });
-    const logLevel = {options};
+    const { logLevel } = options;
     if (logLevel) {
         requestLogger.level(logLevel);
     }

--- a/test/core/request/test.html
+++ b/test/core/request/test.html
@@ -7,14 +7,6 @@
         <script type="text/javascript">
             require(['/environment/config.js'], function() {
                 require(['qunitEnv'], function() {
-                    requirejs.config({
-                        config: {
-                            'core/logger': {
-                                level: 'trace'
-                            }
-                        }
-                    });
-
                     define('core/logger', () => {
                         const logger = {
                             child() {

--- a/test/core/request/test.html
+++ b/test/core/request/test.html
@@ -7,6 +7,32 @@
         <script type="text/javascript">
             require(['/environment/config.js'], function() {
                 require(['qunitEnv'], function() {
+                    requirejs.config({
+                        config: {
+                            'core/logger': {
+                                level: 'trace'
+                            }
+                        }
+                    });
+
+                    define('core/logger', () => {
+                        const logger = {
+                            child() {
+                                return logger;
+                            },
+                            level(level) {
+                                logger.loggerLevel = level;
+                            },
+                            trace() {},
+                            debug() {},
+                            info() {},
+                            error() {},
+                            fatal() {},
+                            warn() {}
+                        };
+                        return () => logger;
+                    });
+                        
                     require(['test/core/request/test'], function() {
                         QUnit.start();
                     });

--- a/test/core/request/test.js
+++ b/test/core/request/test.js
@@ -21,12 +21,13 @@
  *
  * @author Martin Nicholson <martin@taotesting.com>
  */
-define(['jquery', 'lodash', 'core/request', 'core/tokenHandler', 'core/jwt/jwtTokenHandler', 'jquery.mockjax'], function(
+define(['jquery', 'lodash', 'core/request', 'core/tokenHandler', 'core/jwt/jwtTokenHandler', 'core/logger', 'jquery.mockjax'], function(
     $,
     _,
     request,
     tokenHandlerFactory,
-    jwtTokenHandlerFactory
+    jwtTokenHandlerFactory,
+    loggerFactory
 ) {
     'use strict';
 
@@ -847,5 +848,29 @@ define(['jquery', 'lodash', 'core/request', 'core/tokenHandler', 'core/jwt/jwtTo
             /Token not available and cannot be refreshed/i,
             'request fails if token handler cannot provide access token'
         );
+    });
+
+    QUnit.module('request logger', {
+        afterEach: function() {
+            $.mockjax.clear();
+        }
+    });
+
+    QUnit.cases.init(['warn', 'error', 'fatal']).test('request logger min level is set based on config', (logLevel, assert) => {
+        const done = assert.async();
+        assert.expect(1);
+
+        $.mockjax([
+            {
+                url: '//endpoint',
+                status: 200,
+                responseText: JSON.stringify({})
+            }
+        ]);
+
+        request({ url: '//endpoint', noToken: true, logLevel }).then(() => {
+            assert.equal(loggerFactory().loggerLevel, logLevel, `loggel level should be ${logLevel} based on config`);
+            done();
+        });
     });
 });


### PR DESCRIPTION
Jira: https://oat-sa.atlassian.net/browse/NEX-394

Implement request logger, what will be a `logger.child` for every request, to be able to let request based log level for logger.

Test: `npm run test`

Related PR:
- [ ] https://github.com/oat-sa/tao-deliver-testrunner-fe/pull/38