### PR TITLE
fix/cog-29/add-textencoder-to-support-IE11

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -51,7 +51,7 @@ export default inputs.map(input => {
             name
         },
         watch: {
-            clearScreen : false
+            clearScreen: false
         },
         external: [
             ...localExternals,
@@ -66,7 +66,8 @@ export default inputs.map(input => {
             'lib/uuid',
             'lodash',
             'module',
-            'moment'
+            'moment',
+            'fastestsmallesttextencoderdecoder'
         ],
         plugins: [
             resolve(),
@@ -81,11 +82,14 @@ export default inputs.map(input => {
             }),
             ...(process.env.COVERAGE ? [istanbul()] : []),
             babel({
-                presets: [[
-                    '@babel/env', {
-                        useBuiltIns: false
-                    }
-                ]]
+                presets: [
+                    [
+                        '@babel/env',
+                        {
+                            useBuiltIns: false
+                        }
+                    ]
+                ]
             })
         ]
     };

--- a/environment/config.js
+++ b/environment/config.js
@@ -19,23 +19,29 @@
 define(['/node_modules/@oat-sa/tao-core-libs/dist/pathdefinition.js'], function(libPathDefinition) {
     requirejs.config({
         baseUrl: '/',
-        paths: Object.assign({}, {
-            css: '/node_modules/require-css/css',
-            json: '/node_modules/requirejs-plugins/src/json',
-            text: '/node_modules/requirejs-plugins/lib/text',
+        paths: Object.assign(
+            {},
+            {
+                css: '/node_modules/require-css/css',
+                json: '/node_modules/requirejs-plugins/src/json',
+                text: '/node_modules/requirejs-plugins/lib/text',
 
-            'qunit-parameterize': '/environment/qunit2-parameterize',
-            'jquery.simulate': '/node_modules/jquery-simulate/jquery.simulate',
-            qunit: '/node_modules/qunit/qunit',
-            test: '/test',
+                'qunit-parameterize': '/environment/qunit2-parameterize',
+                'jquery.simulate': '/node_modules/jquery-simulate/jquery.simulate',
+                qunit: '/node_modules/qunit/qunit',
+                test: '/test',
 
-            core: '/dist/core',
-            util: '/dist/util',
+                core: '/dist/core',
+                util: '/dist/util',
 
-            'jquery.mockjax': '/node_modules/jquery-mockjax/dist/jquery.mockjax',
-            'webcrypto-shim': '/node_modules/webcrypto-shim/webcrypto-shim',
-            'idb-wrapper': '/node_modules/idb-wrapper/idbstore'
-        }, libPathDefinition),
+                'jquery.mockjax': '/node_modules/jquery-mockjax/dist/jquery.mockjax',
+                'webcrypto-shim': '/node_modules/webcrypto-shim/webcrypto-shim',
+                'idb-wrapper': '/node_modules/idb-wrapper/idbstore',
+                fastestsmallesttextencoderdecoder:
+                    '/node_modules/fastestsmallesttextencoderdecoder/NodeJS/EncoderAndDecoderNodeJS.min'
+            },
+            libPathDefinition
+        ),
         shim: {
             'jquery.simulate': {
                 deps: ['jquery']

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2079,6 +2079,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fastestsmallesttextencoderdecoder": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.14.tgz",
+      "integrity": "sha512-ov+uDh4DMZHpZvcGwlCb9tfntaHwRI7SK+/6XkdXhksZLJcMoTJ20FZx3GvujnsGjMvJVQ71LkduEUEPwX1BvQ=="
     },
     "fd-slicer": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "displayName": "TAO Core SDK",
   "description": "Core libraries of TAO",
   "homepage": "https://github.com/oat-sa/tao-core-sdk-fe#readme",
@@ -82,6 +82,7 @@
     "tooltip.js": "1.3.2"
   },
   "dependencies": {
+    "fastestsmallesttextencoderdecoder": "^1.0.14",
     "idb-wrapper": "1.7.0",
     "webcrypto-shim": "0.1.4"
   },

--- a/src/core/digest.js
+++ b/src/core/digest.js
@@ -26,6 +26,7 @@
  */
 import _ from 'lodash';
 import 'webcrypto-shim';
+import { TextEncoder } from 'fastestsmallesttextencoderdecoder';
 
 //get the native implementation of the CryptoSubtle
 var subtle = window.crypto.subtle || window.crypto.webkitSubtle;


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/COG-29
**Description:** `TextEncode` polyfill is added to support IE11 in the latest version of the core
**Unit tests cli:** `npm run test`