### PR TITLE
Fix/VFV-4/remove fastestsmallesttextencoderdecoder from tao core

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -70,7 +70,11 @@ export default inputs.map(input => {
         ],
         plugins: [
             resolve({ mainFields: ['main'] }),
-            commonJS(),
+            commonJS({
+                namedExports: {
+                    fastestsmallesttextencoderdecoder: ['TextEncoder']
+                }
+            }),
             alias({
                 resolve: ['.js', '.json'],
                 core: path.resolve(srcDir, 'core'),

--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -66,11 +66,10 @@ export default inputs.map(input => {
             'lib/uuid',
             'lodash',
             'module',
-            'moment',
-            'fastestsmallesttextencoderdecoder'
+            'moment'
         ],
         plugins: [
-            resolve(),
+            resolve({ mainFields: ['main'] }),
             commonJS(),
             alias({
                 resolve: ['.js', '.json'],

--- a/environment/config.js
+++ b/environment/config.js
@@ -36,9 +36,7 @@ define(['/node_modules/@oat-sa/tao-core-libs/dist/pathdefinition.js'], function(
 
                 'jquery.mockjax': '/node_modules/jquery-mockjax/dist/jquery.mockjax',
                 'webcrypto-shim': '/node_modules/webcrypto-shim/webcrypto-shim',
-                'idb-wrapper': '/node_modules/idb-wrapper/idbstore',
-                fastestsmallesttextencoderdecoder:
-                    '/node_modules/fastestsmallesttextencoderdecoder/NodeJS/EncoderAndDecoderNodeJS.min'
+                'idb-wrapper': '/node_modules/idb-wrapper/idbstore'
             },
             libPathDefinition
         ),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "displayName": "TAO Core SDK",
   "description": "Core libraries of TAO",
   "homepage": "https://github.com/oat-sa/tao-core-sdk-fe#readme",

--- a/src/core/digest.js
+++ b/src/core/digest.js
@@ -26,9 +26,7 @@
  */
 import _ from 'lodash';
 import 'webcrypto-shim';
-import TextEncoderPolyfill from 'fastestsmallesttextencoderdecoder';
-
-const { TextEncoder } = TextEncoderPolyfill;
+import { TextEncoder } from 'fastestsmallesttextencoderdecoder';
 
 //get the native implementation of the CryptoSubtle
 var subtle = window.crypto.subtle || window.crypto.webkitSubtle;

--- a/src/core/digest.js
+++ b/src/core/digest.js
@@ -26,7 +26,9 @@
  */
 import _ from 'lodash';
 import 'webcrypto-shim';
-import { TextEncoder } from 'fastestsmallesttextencoderdecoder';
+import TextEncoderPolyfill from 'fastestsmallesttextencoderdecoder';
+
+const { TextEncoder } = TextEncoderPolyfill;
 
 //get the native implementation of the CryptoSubtle
 var subtle = window.crypto.subtle || window.crypto.webkitSubtle;


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/VFV-4
**Description:** Remove from `fastestsmallesttextencoderdecoder` as dependency from `tao-core`. 
Add `fastestsmallesttextencoderdecoder` module to the production build instead of required it from external `tao-core` node modules
**Unit tests cli:** `npm run test`