### PR TITLE
Feature/nex 831 implement fetch based request

### DIFF
--- a/environment/config.js
+++ b/environment/config.js
@@ -36,7 +36,8 @@ define(['/node_modules/@oat-sa/tao-core-libs/dist/pathdefinition.js'], function(
 
                 'jquery.mockjax': '/node_modules/jquery-mockjax/dist/jquery.mockjax',
                 'webcrypto-shim': '/node_modules/webcrypto-shim/webcrypto-shim',
-                'idb-wrapper': '/node_modules/idb-wrapper/idbstore'
+                'idb-wrapper': '/node_modules/idb-wrapper/idbstore',
+                'fetch-mock': '/node_modules/fetch-mock/es5/client-bundle'
             },
             libPathDefinition
         ),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "2.0.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2087,6 +2087,31 @@
         "pend": "~1.2.0"
       }
     },
+    "fetch-mock": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.4.0.tgz",
+      "integrity": "sha512-tqnFmcjYheW5Z9zOPRVY+ZXjB/QWCYtPiOrYGEsPgKfpGHco97eaaj7Rv9MjK7PVWG4rWfv6t2IgQAzDQizBZA==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^3.0.0",
+        "debug": "^4.1.1",
+        "glob-to-regexp": "^0.4.0",
+        "is-subset": "^0.1.1",
+        "lodash.isequal": "^4.5.0",
+        "path-to-regexp": "^2.2.1",
+        "querystring": "^0.2.0",
+        "whatwg-url": "^6.5.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+          "dev": true
+        }
+      }
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -2286,6 +2311,12 @@
       "requires": {
         "@types/glob": "*"
       }
+    },
+    "glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true
     },
     "globals": {
       "version": "11.12.0",
@@ -2598,6 +2629,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
       "dev": true
     },
     "is-symbol": {
@@ -2932,6 +2969,18 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
     "loose-envify": {
@@ -3532,6 +3581,12 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+      "dev": true
+    },
     "path-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -3642,6 +3697,12 @@
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+      "dev": true
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
     },
     "quick-lru": {
@@ -4486,6 +4547,15 @@
         "popper.js": "^1.0.2"
       }
     },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "trim-newlines": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
@@ -4640,6 +4710,23 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/webcrypto-shim/-/webcrypto-shim-0.1.4.tgz",
       "integrity": "sha512-I2lnL+K2oPNE9ryVHwo42oDnt8XQ9E1KKMGCmcT7OXaAKPmUeCi/G0nUgLR6M6Ztj05ZCxLMGf5bXNaSo+wURg=="
+    },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "2.0.0",
+  "version": "1.4.0",
   "displayName": "TAO Core SDK",
   "description": "Core libraries of TAO",
   "homepage": "https://github.com/oat-sa/tao-core-sdk-fe#readme",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint": "^5.16.0",
     "eslint-plugin-es": "^1.4.0",
     "eslint-plugin-jsdoc": "^4.8.3",
+    "fetch-mock": "^9.4.0",
     "gamp": "0.2.1",
     "glob": "^7.1.3",
     "handlebars": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "displayName": "TAO Core SDK",
   "description": "Core libraries of TAO",
   "homepage": "https://github.com/oat-sa/tao-core-sdk-fe#readme",

--- a/src/core/fetchRequest.js
+++ b/src/core/fetchRequest.js
@@ -18,14 +18,16 @@
 
 /**
  * !!! IE11 requires polyfill https://www.npmjs.com/package/whatwg-fetch
+ * Creates an HTTP request to the url based on the provided parameters
  * Request is based on fetch, so behaviour and parameters are the same, except
- * every response where response code is not 2xx will be rejected and
- * every response will be parsed as json.
- * It is extended with the following parameters:
- *  - timeout         : request will be rejected, when the timout will be reached  (default: 5000)
- *  - jwtTokenHandler : core/jwt/jwtTokenHandler instance, that should be used for the request
+ *   - every response where response code is not 2xx will be rejected and
+ *   - every response will be parsed as json.
+ * @param {string} url - url that should be requested
+ * @param {object} options - fetch request options that implements RequestInit (https://fetch.spec.whatwg.org/#requestinit)
+ * @param {integer} [options.timeout] - (default: 5000) if timeout reached, the request will be rejected
+ * @param {object} [options.jwtTokenHandler] - core/jwt/jwtTokenHandler instance that should be used during request
+ * @returns {Promise<Response>} resolves with http Response object
  */
-
 const requestFactory = (url, options) => {
     options = Object.assign(
         {
@@ -70,7 +72,13 @@ const requestFactory = (url, options) => {
         });
     }
 
+    /**
+     * Stores the original response
+     */
     let originalResponse;
+    /**
+     * Stores the response code
+     */
     let responseCode;
 
     flow = flow.then(response => {

--- a/src/core/fetchRequest.js
+++ b/src/core/fetchRequest.js
@@ -17,12 +17,13 @@
  */
 
 /**
+ * !!! IE11 requires polyfill https://www.npmjs.com/package/whatwg-fetch
  * Request is based on fetch, so behaviour and parameters are the same, except
  * every response where response code is not 2xx will be rejected and
  * every response will be parsed as json.
  * It is extended with the following parameters:
  *  - timeout         : request will be rejected, when the timout will be reached  (default: 5000)
- *  - jwtTokenHandler : jwt token handler, that should be used for the request
+ *  - jwtTokenHandler : core/jwt/jwtTokenHandler instance, that should be used for the request
  */
 
 const requestFactory = (url, options) => {
@@ -59,11 +60,10 @@ const requestFactory = (url, options) => {
                 return options.jwtTokenHandler
                     .refreshToken()
                     .then(options.jwtTokenHandler.getToken)
-                    .then(token => ({
-                        Authorization: `Bearer ${token}`
-                    }))
-                    .then(headers => Object.assign({}, options, { headers }))
-                    .then(newOptions => fetch(url, newOptions));
+                    .then(token => {
+                        options.headers.Authorization = `Bearer ${token}`;
+                        return fetch(url, options);
+                    });
             }
 
             return Promise.resolve(response);

--- a/src/core/fetchRequest.js
+++ b/src/core/fetchRequest.js
@@ -1,0 +1,84 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+/**
+ * Request is based on fetch, so behaviour and parameters are the same, except
+ * every response where response code is not 2xx will be rejected and
+ * every response will be parsed as json.
+ * It is extended with the following parameters:
+ *  - timeout         : request will be rejected, when the timout will be reached  (default: 5000)
+ *  - jwtTokenHandel  : jwt token handler, that should be used for the request
+ */
+
+const requestFactory = (url, options) => {
+    options = Object.assign(
+        {
+            timeout: 5000
+        },
+        options
+    );
+
+    let flow = Promise.resolve();
+
+    if (options.jwtTokenHandler) {
+        flow = flow
+            .then(options.jwtTokenHandler.getToken)
+            .then(token => ({
+                Authorization: `Bearer ${token}`
+            }))
+            .then(headers => {
+                options.headers = Object.assign({}, options.headers, headers);
+            });
+    }
+
+    flow = flow.then(() => Promise.race([
+        fetch(url, options),
+        new Promise((resolve, reject) => {
+            setTimeout(() => reject(new Error('Timeout')), options.timeout);
+        })
+    ]));
+
+    if (options.jwtTokenHandler) {
+        flow = flow.then(response => {
+            if (response.status === 401) {
+                return options.jwtTokenHandler
+                    .refreshToken()
+                    .then(options.jwtTokenHandler.getToken)
+                    .then(token => ({
+                        Authorization: `Bearer ${token}`
+                    }))
+                    .then(headers => Object.assign({}, options, { headers }))
+                    .then(newOptions => fetch(url, newOptions));
+            }
+
+            return Promise.resolve(response);
+        });
+    }
+
+    flow = flow.then(response => {
+        if (response.status < 300) {
+            return response.json();
+        }
+
+        return Promise.reject(response);
+    });
+
+    return flow;
+};
+
+export default requestFactory;

--- a/src/core/jwt/jwtTokenHandler.js
+++ b/src/core/jwt/jwtTokenHandler.js
@@ -66,7 +66,9 @@ const jwtTokenHandlerFactory = function jwtTokenHandlerFactory({serviceName = 't
                     if (response.status === 200) {
                         return response.json();
                     }
-                    return Promise.reject(response);
+                    const error = new Error('Unsuccessful token refresh');
+                    error.response = response;
+                    return Promise.reject(error);
                 })
                 .then(({ accessToken }) => tokenStorage.setAccessToken(accessToken).then(() => accessToken));
 

--- a/src/core/jwt/jwtTokenHandler.js
+++ b/src/core/jwt/jwtTokenHandler.js
@@ -62,12 +62,9 @@ const jwtTokenHandlerFactory = function jwtTokenHandlerFactory({serviceName = 't
                 },
                 body: JSON.stringify({ refreshToken })
             })
-                .then(response => {
-                    if (response.status < 300) {
-                        return response.json();
-                    }
-                    return Promise.reject(response);
-                })
+                .then(response => response.json().catch(() => {
+                    throw response;
+                }))
                 .then(({ accessToken }) => tokenStorage.setAccessToken(accessToken).then(() => accessToken));
 
         }

--- a/src/core/jwt/jwtTokenHandler.js
+++ b/src/core/jwt/jwtTokenHandler.js
@@ -62,9 +62,12 @@ const jwtTokenHandlerFactory = function jwtTokenHandlerFactory({serviceName = 't
                 },
                 body: JSON.stringify({ refreshToken })
             })
-                .then(response => response.json().catch(() => {
-                    throw response;
-                }))
+                .then(response => {
+                    if (response.status === 200) {
+                        return response.json();
+                    }
+                    return Promise.reject(response);
+                })
                 .then(({ accessToken }) => tokenStorage.setAccessToken(accessToken).then(() => accessToken));
 
         }

--- a/src/core/jwt/jwtTokenHandler.js
+++ b/src/core/jwt/jwtTokenHandler.js
@@ -23,7 +23,6 @@
  */
 
 import jwtTokenStoreFactory from 'core/jwt/jwtTokenStore';
-import coreRequest from 'core/request';
 import promiseQueue from 'core/promiseQueue';
 
 /**
@@ -54,14 +53,20 @@ const jwtTokenHandlerFactory = function jwtTokenHandlerFactory({serviceName = 't
         if (!refreshToken) {
             throw new Error('Refresh token is not available');
         } else {
-            return coreRequest({
-                url: refreshTokenUrl,
+            return fetch(refreshTokenUrl, {
                 method: 'POST',
-                data: JSON.stringify({ refreshToken }),
-                dataType: 'json',
-                contentType: 'application/json',
-                noToken: true
-            }).then(({ accessToken }) => tokenStorage.setAccessToken(accessToken).then(() => accessToken));
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ refreshToken })
+            })
+                .then(response => {
+                    if (response.status < 300) {
+                        return response.json();
+                    }
+                    return Promise.reject(response);
+                })
+                .then(({ accessToken }) => tokenStorage.setAccessToken(accessToken).then(() => accessToken));
 
         }
     });

--- a/src/core/jwt/jwtTokenHandler.js
+++ b/src/core/jwt/jwtTokenHandler.js
@@ -18,6 +18,8 @@
 
 /**
  * Give and refresh JWT token
+ * !!! The module uses native fetch request to refresh token.
+ * !!! IE11 requires polyfill https://www.npmjs.com/package/whatwg-fetch
  * @module core/jwtTokenHandler
  * @author Tamas Besenyei <tamas@taotesting.com>
  */

--- a/test/core/fetchRequest/test.html
+++ b/test/core/fetchRequest/test.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Core - Fetch Request</title>
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {    
+                    require(['test/core/fetchRequest/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/test/core/fetchRequest/test.js
+++ b/test/core/fetchRequest/test.js
@@ -109,18 +109,18 @@ define(['core/fetchRequest', 'core/jwt/jwtTokenHandler', 'fetch-mock'], (
         const done = assert.async();
 
         const mockResponse = { foo: 'bar' };
-        const authToken = 'someToken';
+        const accessToken = 'someToken';
         const url = '/bar';
 
         fetchMock.mock(url, (uri, opts) => {
             assert.deepEqual(opts.headers, {
-                Authorization: `Bearer ${authToken}`
+                Authorization: `Bearer ${accessToken}`
             });
             return mockResponse;
         });
 
         this.jwtTokenHandler
-            .storeAccessToken(authToken)
+            .storeAccessToken(accessToken)
             .then(() => request(url, { jwtTokenHandler: this.jwtTokenHandler }))
             .then(response => {
                 assert.deepEqual(response, mockResponse);
@@ -134,7 +134,7 @@ define(['core/fetchRequest', 'core/jwt/jwtTokenHandler', 'fetch-mock'], (
 
         const mockResponse = { response: 2 };
         const refreshToken = 'refreshToken';
-        const newAuthToken = 'newAuthToken';
+        const newAccessToken = 'newAccessToken';
         const url = '/api/request';
 
         fetchMock.mock('/refresh-token', (uri, opts) => {
@@ -142,11 +142,11 @@ define(['core/fetchRequest', 'core/jwt/jwtTokenHandler', 'fetch-mock'], (
             assert.equal(opts.headers['Content-Type'], 'application/json');
             assert.equal(opts.method, 'POST');
             assert.deepEqual(data, { refreshToken });
-            return JSON.stringify({ accessToken: newAuthToken });
+            return JSON.stringify({ accessToken: newAccessToken });
         });
 
         fetchMock.mock(url, (uri, opts) => {
-            assert.equal(opts.headers.Authorization, `Bearer ${newAuthToken}`);
+            assert.equal(opts.headers.Authorization, `Bearer ${newAccessToken}`);
             return JSON.stringify(mockResponse);
         });
 
@@ -166,12 +166,12 @@ define(['core/fetchRequest', 'core/jwt/jwtTokenHandler', 'fetch-mock'], (
         const mockResponse = { response: 2 };
         const refreshToken = 'refreshToken';
         const accessToken = 'invalidAccessToken';
-        const newAuthToken = 'newAuthToken';
+        const newAccessToken = 'newAccessToken';
         const url = '/api/request';
 
         const setupSecondRequest = () => {
             fetchMock.mock(url, function (uri, opts) {
-                assert.equal(opts.headers.Authorization, `Bearer ${newAuthToken}`);
+                assert.equal(opts.headers.Authorization, `Bearer ${newAccessToken}`);
                 return JSON.stringify(mockResponse);
             });
         };
@@ -187,7 +187,7 @@ define(['core/fetchRequest', 'core/jwt/jwtTokenHandler', 'fetch-mock'], (
             assert.equal(opts.method, 'POST');
             assert.equal(opts.headers['Content-Type'], 'application/json');
             assert.deepEqual(data, { refreshToken });
-            return JSON.stringify({ accessToken: newAuthToken });
+            return JSON.stringify({ accessToken: newAccessToken });
         });
 
         this.jwtTokenHandler
@@ -234,11 +234,11 @@ define(['core/fetchRequest', 'core/jwt/jwtTokenHandler', 'fetch-mock'], (
 
         const refreshToken = 'refreshToken';
         const accessToken = 'invalidAccessToken';
-        const newAuthToken = 'stillInvalidAccessToken';
+        const newAccessToken = 'stillInvalidAccessToken';
         const url = '/api/request';
 
         fetchMock.mock(url, 401);
-        fetchMock.mock('/refresh-token', JSON.stringify({ accessToken: newAuthToken }));
+        fetchMock.mock('/refresh-token', JSON.stringify({ accessToken: newAccessToken }));
 
         this.jwtTokenHandler
             .storeRefreshToken(refreshToken)

--- a/test/core/fetchRequest/test.js
+++ b/test/core/fetchRequest/test.js
@@ -1,0 +1,216 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+
+define(['core/fetchRequest', 'core/jwt/jwtTokenHandler', 'fetch-mock'], (
+    request,
+    jwtTokenHandlerFactory,
+    fetchMock
+) => {
+    'use strict';
+
+    // can mocked url redefined
+    fetchMock.config.overwriteRoutes = true;
+
+    QUnit.module('Request', {
+        beforeEach: function () {
+            this.jwtTokenHandler = jwtTokenHandlerFactory({ refreshTokenUrl: '/refresh-token' });
+        },
+        afterEach: function (done) {
+            fetchMock.restore();
+            this.jwtTokenHandler.clearStore().then(done);
+        }
+    });
+
+    QUnit.test('request returns with correct response', assert => {
+        assert.expect(1);
+        const done = assert.async();
+
+        const mockResponse = { ok: true };
+        fetchMock.mock('/foo', mockResponse);
+
+        request('/foo').then(response => {
+            assert.deepEqual(response, mockResponse);
+            done();
+        });
+    });
+
+    QUnit.test('request returns with a correct error response', assert => {
+        assert.expect(1);
+        const done = assert.async();
+
+        fetchMock.mock('/foo', 404);
+
+        request('/foo').catch(response => {
+            assert.equal(response.status, 404);
+            done();
+        });
+    });
+
+    QUnit.test('request sends an auth header', function (assert) {
+        assert.expect(2);
+        const done = assert.async();
+
+        const mockResponse = { foo: 'bar' };
+        const authToken = 'someToken';
+        const url = '/bar';
+
+        fetchMock.mock(url, (uri, opts) => {
+            assert.deepEqual(opts.headers, {
+                Authorization: `Bearer ${authToken}`
+            });
+            return mockResponse;
+        });
+
+        this.jwtTokenHandler
+            .storeAccessToken(authToken)
+            .then(() => request(url, { jwtTokenHandler: this.jwtTokenHandler }))
+            .then(response => {
+                assert.deepEqual(response, mockResponse);
+                done();
+            });
+    });
+
+    QUnit.test('request refreshes the token when it does not exist', function (assert) {
+        assert.expect(5);
+        const done = assert.async();
+
+        const mockResponse = { response: 2 };
+        const refreshToken = 'refreshToken';
+        const newAuthToken = 'newAuthToken';
+        const url = '/api/request';
+
+        fetchMock.mock('/refresh-token', (uri, opts) => {
+            const data = JSON.parse(opts.body);
+            assert.equal(opts.headers['Content-Type'], 'application/json');
+            assert.equal(opts.method, 'POST');
+            assert.deepEqual(data, { refreshToken });
+            return JSON.stringify({ accessToken: newAuthToken });
+        });
+
+        fetchMock.mock(url, (uri, opts) => {
+            assert.equal(opts.headers.Authorization, `Bearer ${newAuthToken}`);
+            return JSON.stringify(mockResponse);
+        });
+
+        this.jwtTokenHandler
+            .storeRefreshToken(refreshToken)
+            .then(() => request(url, { jwtTokenHandler: this.jwtTokenHandler }))
+            .then(response => {
+                assert.deepEqual(response, mockResponse);
+                done();
+            });
+    });
+
+    QUnit.test('request refreshes the token when it is not valid', function (assert) {
+        assert.expect(6);
+        const done = assert.async();
+
+        const mockResponse = { response: 2 };
+        const refreshToken = 'refreshToken';
+        const accessToken = 'invalidAccessToken';
+        const newAuthToken = 'newAuthToken';
+        const url = '/api/request';
+
+        const setupSecondRequest = () => {
+            fetchMock.mock(url, function (uri, opts) {
+                assert.equal(opts.headers.Authorization, `Bearer ${newAuthToken}`);
+                return JSON.stringify(mockResponse);
+            });
+        };
+
+        fetchMock.mock(url, function (uri, opts) {
+            assert.equal(opts.headers.Authorization, `Bearer ${accessToken}`);
+            setupSecondRequest();
+            return { status: 401 };
+        });
+
+        fetchMock.mock('/refresh-token', function (uri, opts) {
+            const data = JSON.parse(opts.body);
+            assert.equal(opts.method, 'POST');
+            assert.equal(opts.headers['Content-Type'], 'application/json');
+            assert.deepEqual(data, { refreshToken });
+            return JSON.stringify({ accessToken: newAuthToken });
+        });
+
+        this.jwtTokenHandler
+            .storeRefreshToken(refreshToken)
+            .then(() => this.jwtTokenHandler.storeAccessToken(accessToken))
+            .then(() => request(url, { jwtTokenHandler: this.jwtTokenHandler }))
+            .then(response => {
+                assert.deepEqual(response, mockResponse);
+                done();
+            });
+    });
+
+    QUnit.test('request returns with the correct error response if there are no tokens', function (assert) {
+        assert.expect(1);
+        assert.rejects(
+            request('/foo', { jwtTokenHandler: this.jwtTokenHandler }),
+            /Token not available and cannot be refreshed/
+        );
+    });
+
+    QUnit.test(
+        'request returns with the correct error response if token is not valid and cannot be refreshed',
+        function (assert) {
+            assert.expect(1);
+            const done = assert.async();
+
+            const accessToken = 'invalidAccessToken';
+
+            fetchMock.mock('/', 401);
+
+            this.jwtTokenHandler.storeAccessToken(accessToken).then(() => {
+                assert.rejects(
+                    request('/', { jwtTokenHandler: this.jwtTokenHandler }),
+                    /Refresh token is not available/
+                );
+                done();
+            });
+        }
+    );
+
+    QUnit.test('request fails if token is refreshed and is still not valid', function (assert) {
+        assert.expect(1);
+        const done = assert.async();
+
+        const refreshToken = 'refreshToken';
+        const accessToken = 'invalidAccessToken';
+        const newAuthToken = 'stillInvalidAccessToken';
+        const url = '/api/request';
+
+        fetchMock.mock(url, 401);
+        fetchMock.mock('/refresh-token', JSON.stringify({ accessToken: newAuthToken }));
+
+        this.jwtTokenHandler
+            .storeRefreshToken(refreshToken)
+            .then(() => this.jwtTokenHandler.storeAccessToken(accessToken))
+            .then(() => request(url, { jwtTokenHandler: this.jwtTokenHandler }))
+            .catch(response => {
+                assert.equal(response.status, 401);
+                done();
+            });
+    });
+
+    QUnit.test('request rejects if timeout reached', function (assert) {
+        assert.expect(1);
+        fetchMock.mock('/', new Promise(resolve => setTimeout(resolve, 2000)));
+
+        assert.rejects(request('/', { timeout: 1000 }), /Timeout/);
+    });
+});

--- a/test/core/fetchRequest/test.js
+++ b/test/core/fetchRequest/test.js
@@ -40,7 +40,7 @@ define(['core/fetchRequest', 'core/jwt/jwtTokenHandler', 'fetch-mock'], (
         assert.expect(1);
         const done = assert.async();
 
-        const mockResponse = { ok: true };
+        const mockResponse = { data: { ok: true } };
         fetchMock.mock('/foo', mockResponse);
 
         request('/foo').then(response => {
@@ -49,14 +49,57 @@ define(['core/fetchRequest', 'core/jwt/jwtTokenHandler', 'fetch-mock'], (
         });
     });
 
-    QUnit.test('request returns with a correct error response', assert => {
+    QUnit.test('request returns with correct response if success true', assert => {
         assert.expect(1);
+        const done = assert.async();
+
+        fetchMock.mock('/foo', new Response(JSON.stringify({ success: true, data: { ping: 123 } }), { status: 201 }));
+
+        request('/foo').then(response => {
+            assert.deepEqual(response.data, { ping: 123 });
+            done();
+        });
+    });
+
+    QUnit.test('request returns with correct response if 204 empty content', assert => {
+        assert.expect(1);
+        const done = assert.async();
+
+        fetchMock.mock('/foo', new Response(null, { status: 204 }));
+
+        request('/foo').then(response => {
+            assert.equal(response, null);
+            done();
+        });
+    });
+
+    QUnit.test('request returns with a correct error response', assert => {
+        assert.expect(2);
         const done = assert.async();
 
         fetchMock.mock('/foo', 404);
 
-        request('/foo').catch(response => {
-            assert.equal(response.status, 404);
+        request('/foo').catch(error => {
+            assert.equal(error.message, '404 : Request error');
+            assert.equal(error.response.status, 404);
+            done();
+        });
+    });
+
+    QUnit.test('request returns with a correct error response if success false', assert => {
+        assert.expect(2);
+        const done = assert.async();
+
+        fetchMock.mock(
+            '/foo',
+            new Response(JSON.stringify({ success: false, errorCode: 'ABC123', errorMessage: 'Cannot trigger ABC' }), {
+                status: 201
+            })
+        );
+
+        request('/foo').catch(error => {
+            assert.equal(error.message, 'ABC123 : Cannot trigger ABC');
+            assert.equal(error.response.status, 201);
             done();
         });
     });
@@ -186,7 +229,7 @@ define(['core/fetchRequest', 'core/jwt/jwtTokenHandler', 'fetch-mock'], (
     );
 
     QUnit.test('request fails if token is refreshed and is still not valid', function (assert) {
-        assert.expect(1);
+        assert.expect(2);
         const done = assert.async();
 
         const refreshToken = 'refreshToken';
@@ -201,8 +244,9 @@ define(['core/fetchRequest', 'core/jwt/jwtTokenHandler', 'fetch-mock'], (
             .storeRefreshToken(refreshToken)
             .then(() => this.jwtTokenHandler.storeAccessToken(accessToken))
             .then(() => request(url, { jwtTokenHandler: this.jwtTokenHandler }))
-            .catch(response => {
-                assert.equal(response.status, 401);
+            .catch(error => {
+                assert.equal(error.message, '401 : Request error');
+                assert.equal(error.response.status, 401);
                 done();
             });
     });

--- a/test/core/jwt/jwtTokenHandler/test.js
+++ b/test/core/jwt/jwtTokenHandler/test.js
@@ -139,7 +139,7 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock'], ($, jwtTokenHandler
     });
 
     QUnit.test('unsuccessful refresh token', function(assert) {
-        assert.expect(3);
+        assert.expect(5);
 
         const done = assert.async();
 
@@ -155,7 +155,11 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock'], ($, jwtTokenHandler
         this.handler.storeRefreshToken(refreshToken).then(setTokenResult => {
             assert.equal(setTokenResult, true, 'refresh token is set');
             this.handler.refreshToken()
-            .catch(errorResponse => errorResponse.json())
+            .catch(e => {
+                assert.equal(e instanceof Error, true, 'rejects with error');
+                assert.equal(e.response instanceof Response, true, 'passes response');
+                return e.response.json();
+            })
             .then(errorResponse => {
                 assert.equal(errorResponse.error, error, 'should get back api error message');
                 done();
@@ -164,7 +168,7 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock'], ($, jwtTokenHandler
     });
 
     QUnit.test('unsuccessful get token if refresh fails', function(assert) {
-        assert.expect(3);
+        assert.expect(5);
 
         const done = assert.async();
 
@@ -180,7 +184,11 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock'], ($, jwtTokenHandler
         this.handler.storeRefreshToken(refreshToken).then(setTokenResult => {
             assert.equal(setTokenResult, true, 'refresh token is set');
             this.handler.getToken()
-            .catch(errorResponse => errorResponse.json())
+            .catch(e => {
+                assert.equal(e instanceof Error, true, 'rejects with error');
+                assert.equal(e.response instanceof Response, true, 'passes response');
+                return e.response.json();
+            })
             .then(errorResponse => {
                 assert.equal(errorResponse.error, error, 'should get back api error message');
                 done();

--- a/test/core/jwt/jwtTokenHandler/test.js
+++ b/test/core/jwt/jwtTokenHandler/test.js
@@ -20,7 +20,7 @@
  * @author Tamas Besenyei <tamas@taotesting.com>
  */
 
-define(['jquery', 'core/jwt/jwtTokenHandler', 'jquery.mockjax'], ($, jwtTokenHandlerFactory) => {
+define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock'], ($, jwtTokenHandlerFactory, fetchMock) => {
     'use strict';
 
     QUnit.module('factory');
@@ -40,17 +40,13 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'jquery.mockjax'], ($, jwtTokenHan
         );
     });
 
-    // prevent the AJAX mocks to pollute the logs
-    $.mockjaxSettings.logger = null;
-    $.mockjaxSettings.responseTime = 1;
-
     QUnit.module('API', {
         beforeEach: function() {
-            this.handler = jwtTokenHandlerFactory({ refreshTokenUrl: '//refreshUrl' });
+            this.handler = jwtTokenHandlerFactory({ refreshTokenUrl: '/refreshUrl' });
         },
         afterEach: function(assert) {
             const done = assert.async();
-            $.mockjax.clear();
+            fetchMock.restore();
             this.handler.clearStore().then(done);
         }
     });
@@ -123,17 +119,11 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'jquery.mockjax'], ($, jwtTokenHan
         const accessToken = 'some access token';
         const refreshToken = 'some refresh token';
 
-        $.mockjax([
-            {
-                url: /^\/\/refreshUrl$/,
-                status: 200,
-                response: function(request) {
-                    const data = JSON.parse(request.data);
-                    assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
-                    this.responseText = JSON.stringify({ accessToken });
-                }
-            }
-        ]);
+        fetchMock.mock('/refreshUrl', function(url, opts) {
+            const data = JSON.parse(opts.body);
+            assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
+            return JSON.stringify({ accessToken });
+        });
 
         this.handler.storeRefreshToken(refreshToken).then(setTokenResult => {
             assert.equal(setTokenResult, true, 'refresh token is set');
@@ -156,22 +146,18 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'jquery.mockjax'], ($, jwtTokenHan
         const error = 'some backend error';
         const refreshToken = 'some refresh token';
 
-        $.mockjax([
-            {
-                url: /^\/\/refreshUrl$/,
-                status: 401,
-                response: function(request) {
-                    const data = JSON.parse(request.data);
-                    assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
-                    this.responseText = JSON.stringify({ error });
-                }
-            }
-        ]);
+        fetchMock.mock('/refreshUrl', function(url, opts) {
+            const data = JSON.parse(opts.body);
+            assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
+            return new Response(JSON.stringify({error}), { status: 401 });
+        });
 
         this.handler.storeRefreshToken(refreshToken).then(setTokenResult => {
             assert.equal(setTokenResult, true, 'refresh token is set');
-            this.handler.refreshToken().catch(errorResponse => {
-                assert.equal(errorResponse.response.error, error, 'should get back api error message');
+            this.handler.refreshToken()
+            .catch(errorResponse => errorResponse.json())
+            .then(errorResponse => {
+                assert.equal(errorResponse.error, error, 'should get back api error message');
                 done();
             });
         });
@@ -185,22 +171,18 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'jquery.mockjax'], ($, jwtTokenHan
         const error = 'some backend error';
         const refreshToken = 'some refresh token';
 
-        $.mockjax([
-            {
-                url: /^\/\/refreshUrl$/,
-                status: 401,
-                response: function(request) {
-                    const data = JSON.parse(request.data);
-                    assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
-                    this.responseText = JSON.stringify({ error });
-                }
-            }
-        ]);
+        fetchMock.mock('/refreshUrl', function(url, opts) {
+            const data = JSON.parse(opts.body);
+            assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
+            return new Response(JSON.stringify({error}), { status: 401 });
+        });
 
         this.handler.storeRefreshToken(refreshToken).then(setTokenResult => {
             assert.equal(setTokenResult, true, 'refresh token is set');
-            this.handler.getToken().catch(errorResponse => {
-                assert.equal(errorResponse.response.error, error, 'should get back api error message');
+            this.handler.getToken()
+            .catch(errorResponse => errorResponse.json())
+            .then(errorResponse => {
+                assert.equal(errorResponse.error, error, 'should get back api error message');
                 done();
             });
         });
@@ -208,11 +190,11 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'jquery.mockjax'], ($, jwtTokenHan
 
     QUnit.module('Concurrency', {
         beforeEach: function() {
-            this.handler = jwtTokenHandlerFactory({ refreshTokenUrl: '//refreshUrl' });
+            this.handler = jwtTokenHandlerFactory({ refreshTokenUrl: '/refreshUrl' });
         },
         afterEach: function(assert) {
             const done = assert.async();
-            $.mockjax.clear();
+            fetchMock.restore();
             this.handler.clearStore().then(done);
         }
     });
@@ -225,17 +207,11 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'jquery.mockjax'], ($, jwtTokenHan
         const accessToken = 'some access token';
         const refreshToken = 'some refresh token';
 
-        $.mockjax([
-            {
-                url: /^\/\/refreshUrl$/,
-                status: 200,
-                response: function(request) {
-                    const data = JSON.parse(request.data);
-                    assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
-                    this.responseText = JSON.stringify({ accessToken });
-                }
-            }
-        ]);
+        fetchMock.mock('/refreshUrl', function(url, opts) {
+            const data = JSON.parse(opts.body);
+            assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
+            return JSON.stringify({accessToken});
+        });
 
         this.handler.storeRefreshToken(refreshToken).then(setTokenResult => {
             assert.equal(setTokenResult, true, 'refresh token is set');
@@ -260,17 +236,11 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'jquery.mockjax'], ($, jwtTokenHan
         const accessToken = 'some access token';
         const refreshToken = 'some refresh token';
 
-        $.mockjax([
-            {
-                url: /^\/\/refreshUrl$/,
-                status: 200,
-                response: function(request) {
-                    const data = JSON.parse(request.data);
-                    assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
-                    this.responseText = JSON.stringify({ accessToken });
-                }
-            }
-        ]);
+        fetchMock.mock('/refreshUrl', function(url, opts) {
+            const data = JSON.parse(opts.body);
+            assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
+            return JSON.stringify({accessToken});
+        });
 
         this.handler.storeRefreshToken(refreshToken).then(setTokenResult => {
             assert.equal(setTokenResult, true, 'refresh token is set');
@@ -297,33 +267,20 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'jquery.mockjax'], ($, jwtTokenHan
         const refreshToken = 'some refresh token';
 
         const setupSecondRequest = () => {
-            $.mockjax.clear();
-            $.mockjax([
-                {
-                    url: /^\/\/refreshUrl$/,
-                    status: 200,
-                    response: function(request) {
-                        const data = JSON.parse(request.data);
-                        assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
-                        this.responseText = JSON.stringify({ accessToken: accessToken2 });
-                        setupSecondRequest();
-                    }
-                }
-            ]);
+            fetchMock.restore();
+            fetchMock.mock('/refreshUrl', function(url, opts) {
+                const data = JSON.parse(opts.body);
+                assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
+                return JSON.stringify({accessToken: accessToken2});
+            });
         };
 
-        $.mockjax([
-            {
-                url: /^\/\/refreshUrl$/,
-                status: 200,
-                response: function(request) {
-                    const data = JSON.parse(request.data);
-                    assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
-                    this.responseText = JSON.stringify({ accessToken: accessToken1 });
-                    setupSecondRequest();
-                }
-            }
-        ]);
+        fetchMock.mock('/refreshUrl', function(url, opts) {
+            const data = JSON.parse(opts.body);
+            assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
+            setupSecondRequest();
+            return JSON.stringify({accessToken: accessToken1});
+        });
 
         this.handler.storeRefreshToken(refreshToken).then(setTokenResult => {
             assert.equal(setTokenResult, true, 'refresh token is set');

--- a/test/core/request/test.js
+++ b/test/core/request/test.js
@@ -21,7 +21,7 @@
  *
  * @author Martin Nicholson <martin@taotesting.com>
  */
-define(['jquery', 'lodash', 'core/request', 'core/tokenHandler', 'core/jwt/jwtTokenHandler', 'core/logger', 'jquery.mockjax'], function(
+define(['jquery', 'lodash', 'core/request', 'core/tokenHandler', 'core/jwt/jwtTokenHandler', 'core/logger', 'fetch-mock', 'jquery.mockjax'], function(
     $,
     _,
     request,

--- a/test/core/request/test.js
+++ b/test/core/request/test.js
@@ -21,13 +21,14 @@
  *
  * @author Martin Nicholson <martin@taotesting.com>
  */
-define(['jquery', 'lodash', 'core/request', 'core/tokenHandler', 'core/jwt/jwtTokenHandler', 'core/logger', 'jquery.mockjax'], function(
+define(['jquery', 'lodash', 'core/request', 'core/tokenHandler', 'core/jwt/jwtTokenHandler', 'core/logger', 'fetch-mock', 'jquery.mockjax',], function(
     $,
     _,
     request,
     tokenHandlerFactory,
     jwtTokenHandlerFactory,
-    loggerFactory
+    loggerFactory,
+    fetchMock
 ) {
     'use strict';
 
@@ -616,11 +617,12 @@ define(['jquery', 'lodash', 'core/request', 'core/tokenHandler', 'core/jwt/jwtTo
 
     QUnit.module('JWT token', {
         beforeEach: function() {
-            this.handler = jwtTokenHandlerFactory({ refreshTokenUrl: '//refreshUrl' });
+            this.handler = jwtTokenHandlerFactory({ refreshTokenUrl: '/refreshUrl' });
         },
         afterEach: function() {
             this.handler.clearStore();
             $.mockjax.clear();
+            fetchMock.restore();
         }
     });
 
@@ -662,6 +664,12 @@ define(['jquery', 'lodash', 'core/request', 'core/tokenHandler', 'core/jwt/jwtTo
         const accessToken = 'some access token';
         const refreshToken = 'some refresh token';
 
+        fetchMock.mock('/refreshUrl', function(uri, opts) {
+            const data = JSON.parse(opts.body);
+            assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
+            return JSON.stringify({ accessToken });
+        });
+
         $.mockjax([
             {
                 url: /^\/\/200$/,
@@ -673,15 +681,6 @@ define(['jquery', 'lodash', 'core/request', 'core/tokenHandler', 'core/jwt/jwtTo
                         'Authorization token header is sent'
                     );
                     this.responseText = JSON.stringify({});
-                }
-            },
-            {
-                url: /^\/\/refreshUrl$/,
-                status: 200,
-                response: function(requestData) {
-                    const data = JSON.parse(requestData.data);
-                    assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
-                    this.responseText = JSON.stringify({ accessToken: accessToken });
                 }
             }
         ]);
@@ -703,6 +702,12 @@ define(['jquery', 'lodash', 'core/request', 'core/tokenHandler', 'core/jwt/jwtTo
         const validAccessToken = 'valid access token';
         const refreshToken = 'some refresh token';
 
+        fetchMock.mock('/refreshUrl', function(uri, opts) {
+            const data = JSON.parse(opts.body);
+            assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
+            return JSON.stringify({ accessToken: validAccessToken });
+        });
+
         $.mockjax([
             {
                 url: /^\/\/endpoint$/,
@@ -717,15 +722,6 @@ define(['jquery', 'lodash', 'core/request', 'core/tokenHandler', 'core/jwt/jwtTo
                         this.status = 200;
                         this.responseText = JSON.stringify({});
                     }
-                }
-            },
-            {
-                url: /^\/\/refreshUrl$/,
-                status: 200,
-                response: function(requestData) {
-                    const data = JSON.parse(requestData.data);
-                    assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
-                    this.responseText = JSON.stringify({ accessToken: validAccessToken });
                 }
             }
         ]);
@@ -754,6 +750,12 @@ define(['jquery', 'lodash', 'core/request', 'core/tokenHandler', 'core/jwt/jwtTo
             error: 'some error'
         };
 
+        fetchMock.mock('/refreshUrl', function(uri, opts) {
+            const data = JSON.parse(opts.body);
+            assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
+            return JSON.stringify({ accessToken: expiredAccessToken });
+        });
+        
         $.mockjax([
             {
                 url: /^\/\/endpoint$/,
@@ -765,15 +767,6 @@ define(['jquery', 'lodash', 'core/request', 'core/tokenHandler', 'core/jwt/jwtTo
                         'called with expired access token'
                     );
                     this.responseText = JSON.stringify(originalError);
-                }
-            },
-            {
-                url: /^\/\/refreshUrl$/,
-                status: 200,
-                response: function(requestData) {
-                    const data = JSON.parse(requestData.data);
-                    assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
-                    this.responseText = JSON.stringify({ accessToken: expiredAccessToken });
                 }
             }
         ]);
@@ -803,6 +796,12 @@ define(['jquery', 'lodash', 'core/request', 'core/tokenHandler', 'core/jwt/jwtTo
             error: 'some error'
         };
 
+        fetchMock.mock('/refreshUrl', function(uri, opts) {
+            const data = JSON.parse(opts.body);
+            assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
+            return new Response(JSON.stringify({ accessToken: expiredAccessToken }), { status: 401 });
+        });
+
         $.mockjax([
             {
                 url: /^\/\/endpoint$/,
@@ -814,14 +813,6 @@ define(['jquery', 'lodash', 'core/request', 'core/tokenHandler', 'core/jwt/jwtTo
                         'enpoint called with expired access token'
                     );
                     this.responseText = JSON.stringify(originalError);
-                }
-            },
-            {
-                url: /^\/\/refreshUrl$/,
-                status: 401,
-                response: function(requestData) {
-                    const data = JSON.parse(requestData.data);
-                    assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
                 }
             }
         ]);

--- a/test/core/request/test.js
+++ b/test/core/request/test.js
@@ -21,7 +21,7 @@
  *
  * @author Martin Nicholson <martin@taotesting.com>
  */
-define(['jquery', 'lodash', 'core/request', 'core/tokenHandler', 'core/jwt/jwtTokenHandler', 'core/logger', 'fetch-mock', 'jquery.mockjax',], function(
+define(['jquery', 'lodash', 'core/request', 'core/tokenHandler', 'core/jwt/jwtTokenHandler', 'core/logger', 'jquery.mockjax'], function(
     $,
     _,
     request,


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/NEX-1008

- Implement fetch based request
- Use native fetch in jwtTokenHandler to avoid external dependency

Test: `npm run test`