### PR TITLE
Feature/nsup 27/disable validation tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "displayName": "TAO Core SDK",
   "description": "Core libraries of TAO",
   "homepage": "https://github.com/oat-sa/tao-core-sdk-fe#readme",

--- a/src/core/tokenHandler.js
+++ b/src/core/tokenHandler.js
@@ -24,6 +24,7 @@ import module from 'module';
 import tokenStoreFactory from 'core/tokenStore';
 import promiseQueue from 'core/promiseQueue';
 
+let validateTokensOpt = true;
 let clientConfigFetched = false;
 
 const defaults = {
@@ -89,7 +90,10 @@ export default function tokenHandlerFactory(options) {
                     if (queueSize > 0) {
                         // Token available, use it
                         return getFirstTokenValue();
-                    } else if (!clientConfigFetched) {
+                    } else if (!validateTokensOpt) {
+                        return this.getClientConfigTokens()
+                            .then(getFirstTokenValue);
+                    }else if (!clientConfigFetched) {
                         // Client Config allowed! (first and only time)
                         return this.getClientConfigTokens()
                             .then(getFirstTokenValue);
@@ -115,15 +119,16 @@ export default function tokenHandlerFactory(options) {
          * @returns {Promise<Boolean>} - resolves true when completed
          */
         getClientConfigTokens() {
-            const {tokens} = module.config();
+            const {tokens, validateTokens} = module.config();
             const clientTokens = (tokens || []).map(serverToken => ({
                 value: serverToken,
                 receivedAt: Date.now()
             }));
+            // set validateToken options from the config
+            validateTokensOpt = validateTokens;
 
             // Record that this function ran:
             clientConfigFetched = true;
-
             return Promise.resolve(clientTokens)
                 .then(newTokens => {
                     // Add the fetched tokens to the store

--- a/test/core/tokenHandler/test.html
+++ b/test/core/tokenHandler/test.html
@@ -11,7 +11,8 @@
                     requirejs.config({
                         config: {
                             'core/tokenHandler': {
-                                tokens: ['token1', 'token2', 'token3', 'token4', 'token5']
+                                tokens: ['token1', 'token2', 'token3', 'token4', 'token5'],
+                                validateTokens: false
                             }
                         }
                     });

--- a/test/core/tokenHandler/test.js
+++ b/test/core/tokenHandler/test.js
@@ -42,7 +42,7 @@ define(['core/promise', 'core/tokenHandler', 'jquery.mockjax'], function(Promise
         {name: 'getClientConfigTokens'},
         {name: 'clearStore'},
         {name: 'getQueueLength'},
-        {name: 'setMaxSize'}
+        {name: 'setMaxSize'},
     ]).test('instance API ', function(data, assert) {
         var instance = tokenHandlerFactory();
         assert.expect(1);
@@ -254,6 +254,48 @@ define(['core/promise', 'core/tokenHandler', 'jquery.mockjax'], function(Promise
                 assert.equal(typeof token, 'string', 'A token string was fetched');
 
                 return tokenHandler.clearStore();
+            })
+            .then(function() {
+                ready();
+            })
+            .catch(function(err) {
+                assert.ok(false, err.message);
+                ready();
+            });
+    });
+
+    QUnit.test('validateTokens', function(assert) {
+        var ready = assert.async();
+        var tokenHandler = new tokenHandlerFactory({ maxSize: 5, validateTokens: false});
+
+        assert.expect(6);
+
+        Promise.all([])
+            .then(function() {
+                return tokenHandler.getToken();
+            })
+            .then(function($token) {
+                assert.equal($token, 'token1', 'The token1 is correct');
+                return tokenHandler.getToken();
+            })
+            .then(function($token) {
+                assert.equal($token, 'token2', 'The token2 is correct');
+                return tokenHandler.getToken();
+            })
+            .then(function($token) {
+                assert.equal($token, 'token3', 'The token3 is correct');
+                return tokenHandler.getToken();
+            })
+            .then(function($token) {
+                assert.equal($token, 'token4', 'The token4 is correct');
+                return tokenHandler.getToken();
+            })
+            .then(function($token) {
+                assert.equal($token, 'token5', 'The token5 is correct');
+                return tokenHandler.getToken();
+            })
+            .then(function($token) {
+                assert.equal($token, 'token1', 'The token1 is correct');
             })
             .then(function() {
                 ready();

--- a/test/core/tokenHandler/test.js
+++ b/test/core/tokenHandler/test.js
@@ -270,10 +270,7 @@ define(['core/promise', 'core/tokenHandler', 'jquery.mockjax'], function(Promise
 
         assert.expect(6);
 
-        Promise.all([])
-            .then(function() {
-                return tokenHandler.getToken();
-            })
+        tokenHandler.getToken()
             .then(function($token) {
                 assert.equal($token, 'token1', 'The token1 is correct');
                 return tokenHandler.getToken();


### PR DESCRIPTION
NSUP-28 and NSUP-27

Depends on https://github.com/oat-sa/tao-core/pull/2627

For one of the our clients, we need to disable xsrf tokens. By default, we can disable only validation on the server-side, but on FE side we will still try to get a token from the queue.
Because of that we added a new option which allows to reuse tokens from the queue again and send it to the server. 

How to reproduce that issue:
1. `config/taoQtiTest/testRunner.conf.php` set: `'csrf-token' => false`
2. `config/tao/security-xsrf-token.conf.php` set `poolSize' => 5`
3. Run a test with more than 5 items
4.  While in passing the test you will see the next error: `No tokens available. Please refresh the page.`

How to check the fix:
1. Update tao-core with tao-core-sdk-fe.
2. `config/taoQtiTest/testRunner.conf.php` set: `'csrf-token' => false`
3. `config/tao/security-xsrf-token.conf.php` set `poolSize' => 5` and `validateTokens => false`
4. Run a test with more than 5 items
5. You will finish the test without any issues