### PR TITLE
Feature TBD-48 configurable CSRF token pool store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "displayName": "TAO Core SDK",
   "description": "Core libraries of TAO",
   "homepage": "https://github.com/oat-sa/tao-core-sdk-fe#readme",

--- a/src/core/tokenStore.js
+++ b/src/core/tokenStore.js
@@ -31,12 +31,10 @@ import store from 'core/store';
  * @property {Number} receivedAt - Creation timestamp
  */
 
-/**
- * The default number of tokens to store
- */
 const defaultConfig = {
-    maxSize: 6,
-    tokenTimeLimit: 1000 * 60 * 24
+    maxSize: 6, // Default number of tokens to store
+    tokenTimeLimit: 1000 * 60 * 24, // Default token TTL (24 minutes)
+    store: 'memory' // In memory storage is preferred by default over the indexeddb or localStorage implementations
 };
 
 /**
@@ -49,9 +47,9 @@ const defaultConfig = {
 export default function tokenStoreFactory(options) {
     const config = _.defaults(options || {}, defaultConfig);
 
-    // In memory storage
-    // For security reasons, this is preferred over the indexeddb or localStorage implementations
-    const getStore = () => store('tokenStore.tokens', store.backends.memory);
+    const getStoreBackend = () => store.backends[config.store] || store.backends[defaultConfig.store];
+
+    const getStore = () => store('tokenStore.tokens', getStoreBackend());
 
     /**
      * @typedef tokenStore


### PR DESCRIPTION
- [TBD-48](https://oat-sa.atlassian.net/browse/TBD-48) feat: allow setting a CSRF-token-pool store via a `tokenStore`'s `store` configuration option
- [TBD-48](https://oat-sa.atlassian.net/browse/TBD-48) chore(version): bump a minor one

ℹ️ Will be incorporated by `tao-core` [2633](https://github.com/oat-sa/tao-core/pull/2633).