### PR TITLE
Fix TBD-48 initialize token pool with configuration values on first access

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "displayName": "TAO Core SDK",
   "description": "Core libraries of TAO",
   "homepage": "https://github.com/oat-sa/tao-core-sdk-fe#readme",

--- a/src/core/tokenHandler.js
+++ b/src/core/tokenHandler.js
@@ -85,21 +85,25 @@ export default function tokenHandlerFactory(options) {
             // Some async checks before we go for the token:
             return tokenStore
                 .expireOldTokens()
-                .then(() => tokenStore.getSize())
-                .then(queueSize => {
-                    if (queueSize > 0) {
-                        // Token available, use it
-                        return getFirstTokenValue();
-                    } else if (!validateTokensOpt) {
+                .then(() => {
+                    if (!validateTokensOpt) {
                         return this.getClientConfigTokens()
                             .then(getFirstTokenValue);
-                    }else if (!clientConfigFetched) {
+                    } else if (!clientConfigFetched) {
                         // Client Config allowed! (first and only time)
                         return this.getClientConfigTokens()
                             .then(getFirstTokenValue);
                     } else {
-                        // No more token options, refresh needed
-                        return Promise.reject(new Error('No tokens available. Please refresh the page.'));
+                        return tokenStore.getSize()
+                            .then(queueSize => {
+                                if (queueSize > 0) {
+                                    // Token available, use it
+                                    return getFirstTokenValue();
+                                } else {
+                                    // No more token options, refresh needed
+                                    return Promise.reject(new Error('No tokens available. Please refresh the page.'));
+                                }
+                            });
                     }
                 });
         },

--- a/src/core/tokenHandler.js
+++ b/src/core/tokenHandler.js
@@ -86,10 +86,7 @@ export default function tokenHandlerFactory(options) {
             return tokenStore
                 .expireOldTokens()
                 .then(() => {
-                    if (!validateTokensOpt) {
-                        return this.getClientConfigTokens()
-                            .then(getFirstTokenValue);
-                    } else if (!clientConfigFetched) {
+                    if (!clientConfigFetched) {
                         // Client Config allowed! (first and only time)
                         return this.getClientConfigTokens()
                             .then(getFirstTokenValue);
@@ -99,6 +96,9 @@ export default function tokenHandlerFactory(options) {
                                 if (queueSize > 0) {
                                     // Token available, use it
                                     return getFirstTokenValue();
+                                } else if (!validateTokensOpt) {
+                                    return this.getClientConfigTokens()
+                                        .then(getFirstTokenValue);
                                 } else {
                                     // No more token options, refresh needed
                                     return Promise.reject(new Error('No tokens available. Please refresh the page.'));


### PR DESCRIPTION
- [TBD-48](https://oat-sa.atlassian.net/browse/TBD-48) feat: initialize token pool store with configuration values upon first access in order to use a fresh set after a page has been reloaded
- [TBD-48](https://oat-sa.atlassian.net/browse/TBD-48) chore(version): bump a fix one

ℹ️ Will be incorporated by `tao-core` [2633](https://github.com/oat-sa/tao-core/pull/2633).