### PR TITLE
Fix/CGA-151/call controller destroy on page navigation

### DIFF
--- a/src/core/historyRouter.js
+++ b/src/core/historyRouter.js
@@ -151,6 +151,10 @@ function historyRouterFactory() {
         })
     );
 
+    router.on('destroy', () => {
+        historyRouter.trigger('destroy');
+    })
+
     // ensure the current route is in the history
     window.history.replaceState({ url: location }, '', location);
 

--- a/src/core/router.js
+++ b/src/core/router.js
@@ -38,7 +38,7 @@ import eventifier from 'core/eventifier';
 
 const logger = loggerFactory('router');
 
-let currentControllerDependency = null;
+let currentControllerDependency = [];
 
 /**
  * The router helps you to execute a controller when an URL maps a defined route.
@@ -69,6 +69,8 @@ const router = eventifier({
         if (!_.isArray(urls)) {
             urls = [urls];
         }
+
+        this.destroyCurrentRoute();
 
         return Promise.all(
             urls.map(function (url) {
@@ -239,13 +241,13 @@ const router = eventifier({
                         window.require(
                             dependencies,
                             function () {
-                                self.destroyCurrentRoute();
-
-                                currentControllerDependency = arguments;
-                                
                                 _.forEach(arguments, function (dependency) {
                                     if (dependency && _.isFunction(dependency.start)) {
                                         dependency.start();
+                                    }
+
+                                    if (dependency && _.isFunction(dependency.destroy)){
+                                        currentControllerDependency.push(dependency);
                                     }
                                 });
 
@@ -270,7 +272,8 @@ const router = eventifier({
             }
         });
 
-        self.trigger('destroy');
+        currentControllerDependency = [];
+        this.trigger('destroy');
     }
 });
 

--- a/src/core/router.js
+++ b/src/core/router.js
@@ -34,6 +34,7 @@ import context from 'context';
 import UrlParser from 'util/urlParser';
 import loggerFactory from 'core/logger';
 import Promise from 'core/promise';
+import eventifier from 'core/eventifier';
 
 var logger = loggerFactory('router');
 
@@ -46,7 +47,8 @@ var logger = loggerFactory('router');
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  * @exports router
  */
-var router = {
+var router = eventifier({
+    activeController: null,
     /**
      * Routing dispatching: execute the controller for the given URL.
      * If more than one URL is provided, we try to dispatch until a valid routing if found
@@ -231,9 +233,16 @@ var router = {
                         window.require(
                             dependencies,
                             function() {
+                                if(_.has(self.activeController, 'destroy')){
+                                    self.activeController.destroy();
+                                }
+
+                                self.trigger('destroy');
+
                                 _.forEach(arguments, function(dependency) {
                                     if (dependency && _.isFunction(dependency.start)) {
                                         dependency.start();
+                                        self.activeController = dependency;
                                     }
                                 });
 
@@ -246,6 +255,6 @@ var router = {
                 }
             });
     }
-};
+});
 
 export default router;


### PR DESCRIPTION
**Related to task:**   https://oat-sa.atlassian.net/browse/CGA-151
**Description:** Wrap router into `eventifer` to have possibility subscribe to the events. Call `destroy` method on the active controller 
**Requires:** 
- [ ] https://github.com/oat-sa/extension-tao-mpart/pull/814