### PR TITLE
Feature/trn 28/improve network errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "displayName": "TAO Core SDK",
   "description": "Core libraries of TAO",
   "homepage": "https://github.com/oat-sa/tao-core-sdk-fe#readme",

--- a/src/core/error/ApiError.js
+++ b/src/core/error/ApiError.js
@@ -27,7 +27,7 @@ export default class ApiError extends Error {
     /**
      * Instantiate an error
      * @param {string} message - the error message
-     * @param {number} errorCode - the HTTP status or custom error code
+     * @param {number} errorCode - the API error code
      * @param {Object} response - the full response object
      * @param {boolean} [recoverable=true] - can the user recover after having such error ?
      * @param {...} params - additional error parameters (line, etc.)

--- a/src/core/error/ApiError.js
+++ b/src/core/error/ApiError.js
@@ -23,12 +23,13 @@ import errorTypes from 'core/error/types';
  */
 //eslint-disable-next-line
 export default class ApiError extends Error {
+
     /**
      * Instantiate an error
-     * @param {string} message- the error message
+     * @param {string} message - the error message
      * @param {number} errorCode - the HTTP status or custom error code
      * @param {Object} response - the full response object
-     * @param {boolean} [recoverable] - can the user recover after having such error ?
+     * @param {boolean} [recoverable=true] - can the user recover after having such error ?
      * @param {...} params - additional error parameters (line, etc.)
      */
     constructor(message, errorCode, response, recoverable = true, ...params) {

--- a/src/core/error/ApiError.js
+++ b/src/core/error/ApiError.js
@@ -1,0 +1,48 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+
+import errorTypes from 'core/error/types';
+
+/**
+ * Errors sent by HTTP API / backend
+ */
+//eslint-disable-next-line
+export default class ApiError extends Error {
+    /**
+     * Instantiate an error
+     * @param {string} message- the error message
+     * @param {number} errorCode - the HTTP status or custom error code
+     * @param {Object} response - the full response object
+     * @param {boolean} [recoverable] - can the user recover after having such error ?
+     * @param {...} params - additional error parameters (line, etc.)
+     */
+    constructor(message, errorCode, response, recoverable = true, ...params) {
+        super(message, ...params);
+
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, ApiError);
+        }
+
+        this.name = 'ApiError';
+        this.message = message;
+        this.errorCode = errorCode;
+        this.response = response;
+        this.recoverable = !!recoverable;
+        this.type = errorTypes.api;
+    }
+}

--- a/src/core/error/AuthError.js
+++ b/src/core/error/AuthError.js
@@ -23,9 +23,10 @@ import errorTypes from 'core/error/types';
  */
 //eslint-disable-next-line
 export default class AuthError extends Error {
+
     /**
      * Instantiate an error
-     * @param {string} message]- the error message
+     * @param {string} [message] - the error message
      * @param {Boolean} [recoverable] - can the user recover after having such error ?
      * @param {...} params - additional error parameters (line, etc.)
      */

--- a/src/core/error/AuthError.js
+++ b/src/core/error/AuthError.js
@@ -26,8 +26,8 @@ export default class AuthError extends Error {
 
     /**
      * Instantiate an error
-     * @param {string} [message] - the error message
-     * @param {Boolean} [recoverable] - can the user recover after having such error ?
+     * @param {string} message - the error message
+     * @param {Boolean} [recoverable=true] - can the user recover after having such error ?
      * @param {...} params - additional error parameters (line, etc.)
      */
     constructor(message, recoverable = true, ...params) {

--- a/src/core/error/AuthError.js
+++ b/src/core/error/AuthError.js
@@ -1,0 +1,44 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+
+import errorTypes from 'core/error/types';
+
+/**
+ * Error due to client side authentication mechanisms
+ */
+//eslint-disable-next-line
+export default class AuthError extends Error {
+    /**
+     * Instantiate an error
+     * @param {string} message]- the error message
+     * @param {Boolean} [recoverable] - can the user recover after having such error ?
+     * @param {...} params - additional error parameters (line, etc.)
+     */
+    constructor(message, recoverable = true, ...params) {
+        super(message, ...params);
+
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, AuthError);
+        }
+
+        this.name = 'AuthError';
+        this.message = message;
+        this.recoverable = !!recoverable;
+        this.type = errorTypes.auth;
+    }
+}

--- a/src/core/error/NetworkError.js
+++ b/src/core/error/NetworkError.js
@@ -23,12 +23,13 @@ import errorTypes from 'core/error/types';
  */
 //eslint-disable-next-line
 export default class NetworkError extends Error {
+
     /**
      * Instantiate an error
-     * @param {string} message- the error message
+     * @param {string} message - the error message
      * @param {number} [errorCode] - the HTTP status if any
      * @param {Object} [response] - the full response object if any
-     * @param {boolean} [recoverable] - can the user recover after having such error ?
+     * @param {boolean} [recoverable=true] - can the user recover after having such error ?
      * @param {...} params - additional error parameters (line, etc.)
      */
     constructor(message, errorCode, response, recoverable = true, ...params) {

--- a/src/core/error/NetworkError.js
+++ b/src/core/error/NetworkError.js
@@ -1,0 +1,48 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+
+import errorTypes from 'core/error/types';
+
+/**
+ * Network errors
+ */
+//eslint-disable-next-line
+export default class NetworkError extends Error {
+    /**
+     * Instantiate an error
+     * @param {string} message- the error message
+     * @param {number} [errorCode] - the HTTP status if any
+     * @param {Object} [response] - the full response object if any
+     * @param {boolean} [recoverable] - can the user recover after having such error ?
+     * @param {...} params - additional error parameters (line, etc.)
+     */
+    constructor(message, errorCode, response, recoverable = true, ...params) {
+        super(message, ...params);
+
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, NetworkError);
+        }
+
+        this.name = 'NetworkError';
+        this.message = message;
+        this.errorCode = errorCode;
+        this.response = response;
+        this.recoverable = !!recoverable;
+        this.type = errorTypes.network;
+    }
+}

--- a/src/core/error/RenderingError.js
+++ b/src/core/error/RenderingError.js
@@ -26,8 +26,8 @@ export default class RenderingError extends Error {
 
     /**
      * Instantiate an error
-     * @param {string} message]- the error message
-     * @param {Boolean} [recoverable] - can the user recover after having such error ?
+     * @param {string} message - the error message
+     * @param {Boolean} [recoverable=true] - can the user recover after having such error ?
      * @param {...} params - additional error parameters (line, etc.)
      */
     constructor(message, recoverable = true, ...params) {

--- a/src/core/error/RenderingError.js
+++ b/src/core/error/RenderingError.js
@@ -1,0 +1,45 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+
+import errorTypes from 'core/error/types';
+
+/**
+ * Error in rendering
+ */
+//eslint-disable-next-line
+export default class RenderingError extends Error {
+
+    /**
+     * Instantiate an error
+     * @param {string} message]- the error message
+     * @param {Boolean} [recoverable] - can the user recover after having such error ?
+     * @param {...} params - additional error parameters (line, etc.)
+     */
+    constructor(message, recoverable = true, ...params) {
+        super(message, ...params);
+
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, RenderingError);
+        }
+
+        this.name = 'RenderingError';
+        this.message = message;
+        this.recoverable = !!recoverable;
+        this.type = errorTypes.rendering;
+    }
+}

--- a/src/core/error/TimeoutError.js
+++ b/src/core/error/TimeoutError.js
@@ -23,11 +23,12 @@ import errorTypes from 'core/error/types';
  */
 //eslint-disable-next-line
 export default class TimeoutError extends Error {
+
     /**
      * Instantiate an error
-     * @param {string} message]- the error message
+     * @param {string} message - the error message
      * @param {number} timeout - the timeout value
-     * @param {boolean} [recoverable] - can the user recover after having such error ?
+     * @param {boolean} [recoverable=true] - can the user recover after having such error ?
      * @param {...} params - additional error parameters (line, etc.)
      */
     constructor(message, timeout, recoverable = true, ...params) {

--- a/src/core/error/TimeoutError.js
+++ b/src/core/error/TimeoutError.js
@@ -1,0 +1,46 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+
+import errorTypes from 'core/error/types';
+
+/**
+ * Error when an action times out
+ */
+//eslint-disable-next-line
+export default class TimeoutError extends Error {
+    /**
+     * Instantiate an error
+     * @param {string} message]- the error message
+     * @param {number} timeout - the timeout value
+     * @param {boolean} [recoverable] - can the user recover after having such error ?
+     * @param {...} params - additional error parameters (line, etc.)
+     */
+    constructor(message, timeout, recoverable = true, ...params) {
+        super(message, ...params);
+
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, TimeoutError);
+        }
+
+        this.name = 'TimeoutError';
+        this.message = message;
+        this.timeout = timeout;
+        this.recoverable = !!recoverable;
+        this.type = errorTypes.timeout;
+    }
+}

--- a/src/core/error/UserError.js
+++ b/src/core/error/UserError.js
@@ -23,10 +23,11 @@ import errorTypes from 'core/error/types';
  */
 //eslint-disable-next-line
 export default class UserError extends Error {
+
     /**
      * Instantiate an error
-     * @param {string} message]- the error message
-     * @param {boolean} [recoverable] - can the user recover after having such error ?
+     * @param {string} message - the error message
+     * @param {boolean} [recoverable=true] - can the user recover after having such error ?
      * @param {...} params - additional error parameters (line, etc.)
      */
     constructor(message, recoverable = true, ...params) {

--- a/src/core/error/UserError.js
+++ b/src/core/error/UserError.js
@@ -1,0 +1,44 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+
+import errorTypes from 'core/error/types';
+
+/**
+ * Error due to wrong user input
+ */
+//eslint-disable-next-line
+export default class UserError extends Error {
+    /**
+     * Instantiate an error
+     * @param {string} message]- the error message
+     * @param {boolean} [recoverable] - can the user recover after having such error ?
+     * @param {...} params - additional error parameters (line, etc.)
+     */
+    constructor(message, recoverable = true, ...params) {
+        super(message, ...params);
+
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, UserError);
+        }
+
+        this.name = 'UserError';
+        this.message = message;
+        this.recoverable = !!recoverable;
+        this.type = errorTypes.user;
+    }
+}

--- a/src/core/error/types.js
+++ b/src/core/error/types.js
@@ -1,0 +1,37 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+
+export default Object.freeze({
+    // the server API is not successful: 500, 412, 403, etc.
+    api: 'api',
+
+    // any network error: CORS, offline, etc.
+    network: 'network',
+
+    // timeout error: an action cannot be performed in the given time
+    timeout: 'timeout',
+
+    // authentication: internal error about authentication (token pool issue, etc.)
+    auth: 'auth',
+
+    // errors due to user's input: wrong data range, etc.
+    user: 'user',
+
+    // rendering error: an interface, a component fails to render
+    rendering: 'rendering'
+});

--- a/src/core/fetchRequest.js
+++ b/src/core/fetchRequest.js
@@ -123,8 +123,11 @@ const requestFactory = (url, options) => {
             throw err;
         })
         .catch(err => {
-            //offline, CORS, etc.
-            throw new NetworkError(err.message, 0);
+            if(!err.type){
+                //offline, CORS, etc.
+                return Promise.reject(new NetworkError(err.message, 0));
+            }
+            return Promise.reject(err);
         });
 
     return flow;

--- a/src/core/fetchRequest.js
+++ b/src/core/fetchRequest.js
@@ -121,6 +121,10 @@ const requestFactory = (url, options) => {
                 );
             }
             throw err;
+        })
+        .catch(err => {
+            //offline, CORS, etc.
+            throw new NetworkError(err.message, 0);
         });
 
     return flow;

--- a/src/core/fetchRequest.js
+++ b/src/core/fetchRequest.js
@@ -16,6 +16,9 @@
  * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
  */
 
+import errorTypes from 'core/error/types';
+import TimeoutError from 'core/error/TimeoutError';
+
 /**
  * !!! IE11 requires polyfill https://www.npmjs.com/package/whatwg-fetch
  * Creates an HTTP request to the url based on the provided parameters
@@ -105,10 +108,16 @@ const requestFactory = (url, options) => {
                 err = new Error(
                     `${response.errorCode} : ${response.errorMsg || response.errorMessage || response.error}`
                 );
+                err.type = errorTypes.api;
             } else {
                 err = new Error(`${responseCode} : Request error`);
+                err.type = errorTypes.network;
             }
             err.response = originalResponse;
+            throw err;
+        })
+        .catch( err => {
+            err.type = errorTypes.network;
             throw err;
         });
 

--- a/test/core/error/api/test.html
+++ b/test/core/error/api/test.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    require(['test/core/error/api/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/test/core/error/api/test.js
+++ b/test/core/error/api/test.js
@@ -1,0 +1,49 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA
+ *
+ */
+
+define(['core/error/types', 'core/error/ApiError'], function (errorTypes, ApiError) {
+    'use strict';
+
+    QUnit.module('ApiError');
+
+    QUnit.test('construct', assert => {
+        assert.expect(6);
+
+        const response = { success: false, errorCode: 500 };
+        const err = new ApiError('Server error', 500, response, true);
+        assert.equal(err.name, 'ApiError');
+        assert.equal(err.type, errorTypes.api);
+        assert.equal(err.message, 'Server error');
+        assert.equal(err.errorCode, 500);
+        assert.deepEqual(err.response, response);
+        assert.equal(err.recoverable, true);
+    });
+
+    QUnit.test('throw', assert => {
+        assert.expect(1);
+
+        assert.throws(
+            () => {
+                throw new ApiError('Invalid request', 412, { success: false, errorCode: 500 }, true, 'foo.js', 123);
+            },
+            ApiError,
+            'Thrown error type is matching'
+        );
+    });
+});

--- a/test/core/error/auth/test.html
+++ b/test/core/error/auth/test.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    require(['test/core/error/auth/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/test/core/error/auth/test.js
+++ b/test/core/error/auth/test.js
@@ -1,0 +1,46 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA
+ *
+ */
+
+define(['core/error/types', 'core/error/AuthError'], function (errorTypes, AuthError) {
+    'use strict';
+
+    QUnit.module('AuthError');
+
+    QUnit.test('construct', assert => {
+        assert.expect(4);
+
+        const err = new AuthError('Token pool reading error', false);
+        assert.equal(err.name, 'AuthError');
+        assert.equal(err.type, errorTypes.auth);
+        assert.equal(err.message, 'Token pool reading error');
+        assert.equal(err.recoverable, false);
+    });
+
+    QUnit.test('throw', assert => {
+        assert.expect(1);
+
+        assert.throws(
+            () => {
+                throw new AuthError('Wrong key');
+            },
+            AuthError,
+            'Thrown error type is matching'
+        );
+    });
+});

--- a/test/core/error/network/test.html
+++ b/test/core/error/network/test.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    require(['test/core/error/network/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/test/core/error/network/test.js
+++ b/test/core/error/network/test.js
@@ -1,0 +1,48 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA
+ *
+ */
+
+define(['core/error/types', 'core/error/NetworkError'], function (errorTypes, NetworkError) {
+    'use strict';
+
+    QUnit.module('NetworkError');
+
+    QUnit.test('construct', assert => {
+        assert.expect(6);
+
+        const err = new NetworkError('No connection', 0, null, true);
+        assert.equal(err.name, 'NetworkError');
+        assert.equal(err.type, errorTypes.network);
+        assert.equal(err.message, 'No connection');
+        assert.equal(err.errorCode, 0);
+        assert.equal(err.response, null);
+        assert.equal(err.recoverable, true);
+    });
+
+    QUnit.test('throw', assert => {
+        assert.expect(1);
+
+        assert.throws(
+            () => {
+                throw new NetworkError('Port closed during the connection');
+            },
+            NetworkError,
+            'Thrown error type is matching'
+        );
+    });
+});

--- a/test/core/error/rendering/test.html
+++ b/test/core/error/rendering/test.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    require(['test/core/error/rendering/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/test/core/error/rendering/test.js
+++ b/test/core/error/rendering/test.js
@@ -1,0 +1,46 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA
+ *
+ */
+
+define(['core/error/types', 'core/error/RenderingError'], function (errorTypes, RenderingError) {
+    'use strict';
+
+    QUnit.module('RenderingError');
+
+    QUnit.test('construct', assert => {
+        assert.expect(4);
+
+        const err = new RenderingError('Fail to render an item due to inconsitent model.', true);
+        assert.equal(err.name, 'RenderingError');
+        assert.equal(err.type, errorTypes.rendering);
+        assert.equal(err.message, 'Fail to render an item due to inconsitent model.');
+        assert.equal(err.recoverable, true);
+    });
+
+    QUnit.test('throw', assert => {
+        assert.expect(1);
+
+        assert.throws(
+            () => {
+                throw new RenderingError('No mount point');
+            },
+            RenderingError,
+            'Thrown error type is matching'
+        );
+    });
+});

--- a/test/core/error/timeout/test.html
+++ b/test/core/error/timeout/test.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    require(['test/core/error/timeout/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/test/core/error/timeout/test.js
+++ b/test/core/error/timeout/test.js
@@ -1,0 +1,48 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA
+ *
+ */
+
+define(['core/error/types', 'core/error/TimeoutError'], function (errorTypes, TimeoutError) {
+    'use strict';
+
+    QUnit.module('TimeoutError');
+
+    QUnit.test('construct', assert => {
+        assert.expect(5);
+
+        const err = new TimeoutError('Submition timeout', 30, true);
+
+        assert.equal(err.name, 'TimeoutError');
+        assert.equal(err.type, errorTypes.timeout);
+        assert.equal(err.message, 'Submition timeout');
+        assert.equal(err.timeout, 30);
+        assert.equal(err.recoverable, true);
+    });
+
+    QUnit.test('throw', assert => {
+        assert.expect(1);
+
+        assert.throws(
+            () => {
+                throw new TimeoutError('Unable to import');
+            },
+            TimeoutError,
+            'Thrown error type is matching'
+        );
+    });
+});

--- a/test/core/error/user/test.html
+++ b/test/core/error/user/test.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    require(['test/core/error/user/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/test/core/error/user/test.js
+++ b/test/core/error/user/test.js
@@ -1,0 +1,49 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA
+ *
+ */
+
+/**
+ * Test the error types
+ */
+define(['core/error/types', 'core/error/UserError'], function (errorTypes, UserError) {
+    'use strict';
+
+    QUnit.module('UserError');
+
+    QUnit.test('construct', assert => {
+        assert.expect(4);
+
+        const err = new UserError('This value is not a date', true);
+        assert.equal(err.name, 'UserError');
+        assert.equal(err.type, errorTypes.user);
+        assert.equal(err.message, 'This value is not a date');
+        assert.equal(err.recoverable, true);
+    });
+
+    QUnit.test('throw', assert => {
+        assert.expect(1);
+
+        assert.throws(
+            () => {
+                throw new UserError('The text is too long');
+            },
+            UserError,
+            'Thrown error type is matching'
+        );
+    });
+});


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TRN-28

 - introduce new error types (extended using classes to extend native types according to the [coding guide](https://hub.taotesting.com/articles/frontend/architecture/tao-frontend-coding-guide))
 - use the error types `TimeoutError`, `ApiError` and `NetworkError` in `core/fetchRequest` 

How to test: 
 - run unit tests
 - use this branch inside https://github.com/oat-sa/tao-deliver-testrunner-nui-fe/pull/102