### PR TITLE
Fix [CON-203] - Color of arrowheads does not match with color of lines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2402,10 +2402,9 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
-    "eve-raphael": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/eve-raphael/-/eve-raphael-0.5.0.tgz",
-      "integrity": "sha1-F8dUt5K+7z+maE15z1pHxjxM2jA=",
+    "eve": {
+      "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
+      "from": "git://github.com/adobe-webplatform/eve.git#eef80ed",
       "dev": true
     },
     "extract-zip": {
@@ -3961,12 +3960,12 @@
       "dev": true
     },
     "raphael": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.3.0.tgz",
-      "integrity": "sha512-w2yIenZAQnp257XUWGni4bLMVxpUpcIl7qgxEgDIXtmSypYtlNxfXWpOBxs7LBTps5sDwhRnrToJrMUrivqNTQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.2.0.tgz",
+      "integrity": "sha1-qdhPJj7I/obS4WzCz36pq8IA1ho=",
       "dev": true,
       "requires": {
-        "eve-raphael": "0.5.0"
+        "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
       }
     },
     "raw-body": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1123,9 +1123,9 @@
       "dev": true
     },
     "@oat-sa/tao-core-libs": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-libs/-/tao-core-libs-0.2.0.tgz",
-      "integrity": "sha512-oEKv7JJ5UIYD/kqvj32b/QQQ/17GPNIizT/KRwxmvPMpDxQcx6RtyQ8dumnn4aT8EVCgMccpQI9rhayiT6R7jw==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-libs/-/tao-core-libs-0.4.3.tgz",
+      "integrity": "sha512-6H4B5ETIWK011gJIPNxOMP2xIdWLNcTpDRsQvLuHO/716KbGG5PCAFCgQwdhmyIBAx9ApUeTF2ee0Xn6Ds0FAA==",
       "dev": true
     },
     "@oat-sa/tao-qunit-testrunner": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2402,9 +2402,10 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
-    "eve": {
-      "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
-      "from": "git://github.com/adobe-webplatform/eve.git#eef80ed",
+    "eve-raphael": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/eve-raphael/-/eve-raphael-0.5.0.tgz",
+      "integrity": "sha1-F8dUt5K+7z+maE15z1pHxjxM2jA=",
       "dev": true
     },
     "extract-zip": {
@@ -3960,12 +3961,12 @@
       "dev": true
     },
     "raphael": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.1.4.tgz",
-      "integrity": "sha1-sJymZK0Ei4FLsv9dTR51g4yrnJc=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.3.0.tgz",
+      "integrity": "sha512-w2yIenZAQnp257XUWGni4bLMVxpUpcIl7qgxEgDIXtmSypYtlNxfXWpOBxs7LBTps5sDwhRnrToJrMUrivqNTQ==",
       "dev": true,
       "requires": {
-        "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
+        "eve-raphael": "0.5.0"
       }
     },
     "raw-body": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@oat-sa/eslint-config-tao": "^0.1.1",
     "@oat-sa/expr-eval": "^1.3.0",
     "@oat-sa/prettier-config": "^0.1.1",
-    "@oat-sa/tao-core-libs": "^0.2.0",
+    "@oat-sa/tao-core-libs": "^0.4.3",
     "@oat-sa/tao-qunit-testrunner": "^0.1.3",
     "async": "^0.2.10",
     "decimal.js": "10.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "displayName": "TAO Core SDK",
   "description": "Core libraries of TAO",
   "homepage": "https://github.com/oat-sa/tao-core-sdk-fe#readme",
@@ -72,7 +72,7 @@
     "prettier": "^2.1.2",
     "promise-limit": "^2.7.0",
     "qunit": "^2.9.2",
-    "raphael": "2.1.4",
+    "raphael": "^2.2.2",
     "require-css": "^0.1.10",
     "requirejs-plugins": "^1.0.2",
     "rollup": "^1.16.7",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "prettier": "^2.1.2",
     "promise-limit": "^2.7.0",
     "qunit": "^2.9.2",
-    "raphael": "^2.2.2",
+    "raphael": "2.2.0",
     "require-css": "^0.1.10",
     "requirejs-plugins": "^1.0.2",
     "rollup": "^1.16.7",


### PR DESCRIPTION
**Issue**

https://oat-sa.atlassian.net/browse/CON-203

**Related work**

https://github.com/oat-sa/extension-tao-itemqti/issues/1577

**Description**

The color of all arrowheads (including axis arrowheads) changes, when we change the current line or add new. So, it will always inherit the color from the last path created with the arrow-end/ arrow-start attribute set.
 
![imagen](https://user-images.githubusercontent.com/34692207/104584984-aed6dd00-5663-11eb-9173-732e4fc5c82c.png)

The full description of [issue](https://github.com/oat-sa/extension-tao-itemqti)/issues/1577

Also, it looks like the PCI settings are broken on the construct side. When trying to open Lines options an error pops up in the console.

![imagen](https://user-images.githubusercontent.com/34692207/104585059-ca41e800-5663-11eb-939c-19309c432365.png)

**AC**

- [x] Fix arrow head color
- [ ] Fix error in console of PCI settings