### PR TITLE
Feature/tr 652 credential support for jwttokenhandler

### DIFF
--- a/src/core/jwt/jwtTokenHandler.js
+++ b/src/core/jwt/jwtTokenHandler.js
@@ -32,6 +32,7 @@ import promiseQueue from 'core/promiseQueue';
  * @param {Object} options Options of JWT token handler
  * @param {String} options.serviceName Name of the service what JWT token belongs to
  * @param {String} options.refreshTokenUrl Url where handler could refresh JWT token
+ * @param {Number} [options.accessTokenTTL] Set accessToken TTL in ms for token store
  * @param {Boolean} [options.useCredentials] refreshToken stored in cookie instead of store
  * @returns {Object} JWT Token handler instance
  */

--- a/src/core/jwt/jwtTokenHandler.js
+++ b/src/core/jwt/jwtTokenHandler.js
@@ -38,10 +38,12 @@ import promiseQueue from 'core/promiseQueue';
 const jwtTokenHandlerFactory = function jwtTokenHandlerFactory({
     serviceName = 'tao',
     refreshTokenUrl,
+    accessTokenTTL,
     useCredentials = false
 } = {}) {
     const tokenStorage = jwtTokenStoreFactory({
-        namespace: serviceName
+        namespace: serviceName,
+        accessTokenTTL
     });
 
     /**
@@ -156,6 +158,14 @@ const jwtTokenHandlerFactory = function jwtTokenHandlerFactory({
          */
         refreshToken() {
             return actionQueue.serie(() => unQueuedRefreshToken());
+        },
+
+        /**
+         * Set accessToken TTL
+         * @param {Number} accessTokenTTL - accessToken TTL in ms
+         */
+        setAccessTokenTTL(accessTokenTTL) {
+            tokenStorage.setAccessTokenTTL(accessTokenTTL);
         }
     };
 };

--- a/src/core/jwt/jwtTokenHandler.js
+++ b/src/core/jwt/jwtTokenHandler.js
@@ -68,22 +68,24 @@ const jwtTokenHandlerFactory = function jwtTokenHandlerFactory({
             flow = Promise.resolve();
         } else {
             flow = tokenStorage.getRefreshToken().then(refreshToken => {
-                if (!refreshToken) {
+                if (refreshToken) {
                     throw new Error('Refresh token is not available');
-                } else {
-                    body = JSON.stringify({ refreshToken });
                 }
+                body = JSON.stringify({ refreshToken });
             });
         }
 
-        return flow.then(() => fetch(refreshTokenUrl, {
-                method: 'POST',
-                credentials,
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body
-        }))
+        return flow
+            .then(() =>
+                fetch(refreshTokenUrl, {
+                    method: 'POST',
+                    credentials,
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body
+                })
+            )
             .then(response => {
                 if (response.status === 200) {
                     return response.json();

--- a/src/core/jwt/jwtTokenHandler.js
+++ b/src/core/jwt/jwtTokenHandler.js
@@ -68,7 +68,7 @@ const jwtTokenHandlerFactory = function jwtTokenHandlerFactory({
             flow = Promise.resolve();
         } else {
             flow = tokenStorage.getRefreshToken().then(refreshToken => {
-                if (refreshToken) {
+                if (!refreshToken) {
                     throw new Error('Refresh token is not available');
                 }
                 body = JSON.stringify({ refreshToken });

--- a/test/core/jwt/jwtTokenHandler/test.html
+++ b/test/core/jwt/jwtTokenHandler/test.html
@@ -5,18 +5,24 @@
         <title>Test - JWT Token Handler</title>
         <script type="text/javascript" src="/environment/require.js"></script>
         <script type="text/javascript">
-            require(['/environment/config.js'], function() {
-                require(['qunitEnv'], function() {
+            require(['/environment/config.js'], function () {
+                require(['qunitEnv'], function () {
                     // mock jwt token store
-                    define('core/jwt/jwtTokenStore', () => () => {
+                    define('core/jwt/jwtTokenStore', () => ({ accessTokenTTL: accessTokenTTLParam }) => {
                         let accessToken = null;
                         let refreshToken = null;
+                        let accessTokenTTL = accessTokenTTLParam;
+                        let accessTokenStoredAt = 0;
                         return {
                             setAccessToken(newAccessToken) {
                                 accessToken = newAccessToken;
+                                accessTokenStoredAt = Date.now();
                                 return Promise.resolve(true);
                             },
                             getAccessToken() {
+                                if (accessTokenTTL && accessTokenStoredAt + accessTokenTTL < Date.now()) {
+                                    return Promise.resolve(null);
+                                }
                                 return Promise.resolve(accessToken);
                             },
                             setRefreshToken(newRefreshToken) {
@@ -29,10 +35,13 @@
                             clear() {
                                 accessToken = refreshToken = null;
                                 return Promise.resolve(true);
+                            },
+                            setAccessTokenTTL(newAccessTokenTTL) {
+                                accessTokenTTL = newAccessTokenTTL;
                             }
                         };
                     });
-                    require(['test/core/jwt/jwtTokenHandler/test'], function() {
+                    require(['test/core/jwt/jwtTokenHandler/test'], function () {
                         QUnit.start();
                     });
                 });

--- a/test/core/jwt/jwtTokenHandler/test.js
+++ b/test/core/jwt/jwtTokenHandler/test.js
@@ -41,27 +41,27 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock'], ($, jwtTokenHandler
     });
 
     QUnit.module('API', {
-        beforeEach: function() {
+        beforeEach: function () {
             this.handler = jwtTokenHandlerFactory({ refreshTokenUrl: '/refreshUrl' });
         },
-        afterEach: function(assert) {
+        afterEach: function (assert) {
             const done = assert.async();
             fetchMock.restore();
             this.handler.clearStore().then(done);
         }
     });
 
-    QUnit.test('get service name', function(assert) {
+    QUnit.test('get service name', function (assert) {
         assert.expect(2);
 
         // default
         assert.strictEqual(this.handler.serviceName, 'tao', 'default service name is tao');
 
-        const handler = jwtTokenHandlerFactory({serviceName: 'foo'});
+        const handler = jwtTokenHandlerFactory({ serviceName: 'foo' });
         assert.strictEqual(handler.serviceName, 'foo', 'return with the provided service name');
     });
 
-    QUnit.test('get access token', function(assert) {
+    QUnit.test('get access token', function (assert) {
         assert.expect(2);
 
         const done = assert.async();
@@ -78,7 +78,7 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock'], ($, jwtTokenHandler
         });
     });
 
-    QUnit.test('clear', function(assert) {
+    QUnit.test('clear', function (assert) {
         assert.expect(4);
 
         const done = assert.async();
@@ -101,7 +101,7 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock'], ($, jwtTokenHandler
         });
     });
 
-    QUnit.test('refresh token on empty store', function(assert) {
+    QUnit.test('refresh token on empty store', function (assert) {
         assert.expect(1);
 
         assert.rejects(
@@ -111,7 +111,7 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock'], ($, jwtTokenHandler
         );
     });
 
-    QUnit.test('refresh token', function(assert) {
+    QUnit.test('refresh token', function (assert) {
         assert.expect(4);
 
         const done = assert.async();
@@ -119,7 +119,7 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock'], ($, jwtTokenHandler
         const accessToken = 'some access token';
         const refreshToken = 'some refresh token';
 
-        fetchMock.mock('/refreshUrl', function(url, opts) {
+        fetchMock.mock('/refreshUrl', function (url, opts) {
             const data = JSON.parse(opts.body);
             assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
             return JSON.stringify({ accessToken });
@@ -138,7 +138,7 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock'], ($, jwtTokenHandler
         });
     });
 
-    QUnit.test('unsuccessful refresh token', function(assert) {
+    QUnit.test('unsuccessful refresh token', function (assert) {
         assert.expect(5);
 
         const done = assert.async();
@@ -146,28 +146,29 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock'], ($, jwtTokenHandler
         const error = 'some backend error';
         const refreshToken = 'some refresh token';
 
-        fetchMock.mock('/refreshUrl', function(url, opts) {
+        fetchMock.mock('/refreshUrl', function (url, opts) {
             const data = JSON.parse(opts.body);
             assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
-            return new Response(JSON.stringify({error}), { status: 401 });
+            return new Response(JSON.stringify({ error }), { status: 401 });
         });
 
         this.handler.storeRefreshToken(refreshToken).then(setTokenResult => {
             assert.equal(setTokenResult, true, 'refresh token is set');
-            this.handler.refreshToken()
-            .catch(e => {
-                assert.equal(e instanceof Error, true, 'rejects with error');
-                assert.equal(e.response instanceof Response, true, 'passes response');
-                return e.response.json();
-            })
-            .then(errorResponse => {
-                assert.equal(errorResponse.error, error, 'should get back api error message');
-                done();
-            });
+            this.handler
+                .refreshToken()
+                .catch(e => {
+                    assert.equal(e instanceof Error, true, 'rejects with error');
+                    assert.equal(e.response instanceof Response, true, 'passes response');
+                    return e.response.json();
+                })
+                .then(errorResponse => {
+                    assert.equal(errorResponse.error, error, 'should get back api error message');
+                    done();
+                });
         });
     });
 
-    QUnit.test('unsuccessful get token if refresh fails', function(assert) {
+    QUnit.test('unsuccessful get token if refresh fails', function (assert) {
         assert.expect(5);
 
         const done = assert.async();
@@ -175,39 +176,40 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock'], ($, jwtTokenHandler
         const error = 'some backend error';
         const refreshToken = 'some refresh token';
 
-        fetchMock.mock('/refreshUrl', function(url, opts) {
+        fetchMock.mock('/refreshUrl', function (url, opts) {
             const data = JSON.parse(opts.body);
             assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
-            return new Response(JSON.stringify({error}), { status: 401 });
+            return new Response(JSON.stringify({ error }), { status: 401 });
         });
 
         this.handler.storeRefreshToken(refreshToken).then(setTokenResult => {
             assert.equal(setTokenResult, true, 'refresh token is set');
-            this.handler.getToken()
-            .catch(e => {
-                assert.equal(e instanceof Error, true, 'rejects with error');
-                assert.equal(e.response instanceof Response, true, 'passes response');
-                return e.response.json();
-            })
-            .then(errorResponse => {
-                assert.equal(errorResponse.error, error, 'should get back api error message');
-                done();
-            });
+            this.handler
+                .getToken()
+                .catch(e => {
+                    assert.equal(e instanceof Error, true, 'rejects with error');
+                    assert.equal(e.response instanceof Response, true, 'passes response');
+                    return e.response.json();
+                })
+                .then(errorResponse => {
+                    assert.equal(errorResponse.error, error, 'should get back api error message');
+                    done();
+                });
         });
     });
 
     QUnit.module('Concurrency', {
-        beforeEach: function() {
+        beforeEach: function () {
             this.handler = jwtTokenHandlerFactory({ refreshTokenUrl: '/refreshUrl' });
         },
-        afterEach: function(assert) {
+        afterEach: function (assert) {
             const done = assert.async();
             fetchMock.restore();
             this.handler.clearStore().then(done);
         }
     });
 
-    QUnit.test('queue get token if other get is in progress', function(assert) {
+    QUnit.test('queue get token if other get is in progress', function (assert) {
         assert.expect(4);
 
         const done = assert.async();
@@ -215,10 +217,10 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock'], ($, jwtTokenHandler
         const accessToken = 'some access token';
         const refreshToken = 'some refresh token';
 
-        fetchMock.mock('/refreshUrl', function(url, opts) {
+        fetchMock.mock('/refreshUrl', function (url, opts) {
             const data = JSON.parse(opts.body);
             assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
-            return JSON.stringify({accessToken});
+            return JSON.stringify({ accessToken });
         });
 
         this.handler.storeRefreshToken(refreshToken).then(setTokenResult => {
@@ -236,7 +238,7 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock'], ($, jwtTokenHandler
         });
     });
 
-    QUnit.test('queue get token if refresh token is in progress', function(assert) {
+    QUnit.test('queue get token if refresh token is in progress', function (assert) {
         assert.expect(4);
 
         const done = assert.async();
@@ -244,10 +246,10 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock'], ($, jwtTokenHandler
         const accessToken = 'some access token';
         const refreshToken = 'some refresh token';
 
-        fetchMock.mock('/refreshUrl', function(url, opts) {
+        fetchMock.mock('/refreshUrl', function (url, opts) {
             const data = JSON.parse(opts.body);
             assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
-            return JSON.stringify({accessToken});
+            return JSON.stringify({ accessToken });
         });
 
         this.handler.storeRefreshToken(refreshToken).then(setTokenResult => {
@@ -265,7 +267,7 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock'], ($, jwtTokenHandler
         });
     });
 
-    QUnit.test('queue refresh token if another refresh token is in progress', function(assert) {
+    QUnit.test('queue refresh token if another refresh token is in progress', function (assert) {
         assert.expect(5);
 
         const done = assert.async();
@@ -276,18 +278,18 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock'], ($, jwtTokenHandler
 
         const setupSecondRequest = () => {
             fetchMock.restore();
-            fetchMock.mock('/refreshUrl', function(url, opts) {
+            fetchMock.mock('/refreshUrl', function (url, opts) {
                 const data = JSON.parse(opts.body);
                 assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
-                return JSON.stringify({accessToken: accessToken2});
+                return JSON.stringify({ accessToken: accessToken2 });
             });
         };
 
-        fetchMock.mock('/refreshUrl', function(url, opts) {
+        fetchMock.mock('/refreshUrl', function (url, opts) {
             const data = JSON.parse(opts.body);
             assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
             setupSecondRequest();
-            return JSON.stringify({accessToken: accessToken1});
+            return JSON.stringify({ accessToken: accessToken1 });
         });
 
         this.handler.storeRefreshToken(refreshToken).then(setTokenResult => {
@@ -306,24 +308,24 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock'], ($, jwtTokenHandler
     });
 
     QUnit.module('useCredential', {
-        beforeEach: function() {
+        beforeEach: function () {
             this.handler = jwtTokenHandlerFactory({ refreshTokenUrl: '/refreshUrl', useCredentials: true });
         },
-        afterEach: function(assert) {
+        afterEach: function (assert) {
             const done = assert.async();
             fetchMock.restore();
             this.handler.clearStore().then(done);
         }
     });
 
-    QUnit.test('refresh token', function(assert) {
+    QUnit.test('refresh token', function (assert) {
         assert.expect(4);
 
         const done = assert.async();
 
         const accessToken = 'some access token';
 
-        fetchMock.mock('/refreshUrl', function(url, opts) {
+        fetchMock.mock('/refreshUrl', function (url, opts) {
             assert.equal(opts.credentials, 'include', 'credentials are sent to the api');
             assert.equal(typeof opts.body, 'undefined', 'body is undefined');
             return JSON.stringify({ accessToken });
@@ -339,7 +341,7 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock'], ($, jwtTokenHandler
         });
     });
 
-    QUnit.test('cannot set refresh token', function(assert) {
+    QUnit.test('cannot set refresh token', function (assert) {
         assert.expect(1);
 
         const done = assert.async();
@@ -348,5 +350,83 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock'], ($, jwtTokenHandler
             assert.equal(setTokenResult, false, 'refresh token is not set');
             done();
         });
+    });
+
+    QUnit.module('TTL', {
+        beforeEach: function () {
+            this.handler = jwtTokenHandlerFactory({ refreshTokenUrl: '/refreshUrl', accessTokenTTL: 500 });
+        },
+        afterEach: function (assert) {
+            const done = assert.async();
+            fetchMock.restore();
+            this.handler.clearStore().then(done);
+        }
+    });
+
+    QUnit.test('get accessToken with TTL', function (assert) {
+        assert.expect(4);
+
+        const done = assert.async();
+
+        const accessToken = 'some access token';
+        const refreshToken = 'some refresh token';
+        const refreshedAccessToken = 'some new access token';
+
+        fetchMock.mock('/refreshUrl', function (url, opts) {
+            const data = JSON.parse(opts.body);
+            assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
+            return JSON.stringify({ accessToken: refreshedAccessToken });
+        });
+
+        Promise.all([this.handler.storeRefreshToken(refreshToken), this.handler.storeAccessToken(accessToken)]).then(
+            setTokenResults => {
+                assert.deepEqual(setTokenResults, [true, true], 'tokens are set');
+                this.handler
+                    .getToken()
+                    .then(storedAccessToken => {
+                        assert.equal(storedAccessToken, accessToken, 'get same accessToken before TTL');
+                        return new Promise(resolve => setTimeout(resolve, 500));
+                    })
+                    .then(this.handler.getToken)
+                    .then(storedAccessToken => {
+                        assert.equal(storedAccessToken, refreshedAccessToken, 'token will be refreshed after ttl');
+                        done();
+                    });
+            }
+        );
+    });
+
+    QUnit.test('set accessTokenTTL after initialization of store', function (assert) {
+        assert.expect(4);
+
+        const done = assert.async();
+
+        const accessToken = 'some access token';
+        const refreshToken = 'some refresh token';
+        const refreshedAccessToken = 'some new access token';
+
+        fetchMock.mock('/refreshUrl', function (url, opts) {
+            const data = JSON.parse(opts.body);
+            assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
+            return JSON.stringify({ accessToken: refreshedAccessToken });
+        });
+
+        Promise.all([this.handler.storeRefreshToken(refreshToken), this.handler.storeAccessToken(accessToken)]).then(
+            setTokenResults => {
+                assert.deepEqual(setTokenResults, [true, true], 'tokens are set');
+                this.handler
+                    .getToken()
+                    .then(storedAccessToken => {
+                        assert.equal(storedAccessToken, accessToken, 'get same accessToken before TTL');
+                        this.handler.setAccessTokenTTL(100);
+                        return new Promise(resolve => setTimeout(resolve, 100));
+                    })
+                    .then(this.handler.getToken)
+                    .then(storedAccessToken => {
+                        assert.equal(storedAccessToken, refreshedAccessToken, 'token will be refreshed after ttl');
+                        done();
+                    });
+            }
+        );
     });
 });

--- a/test/core/jwt/jwtTokenHandler/test.js
+++ b/test/core/jwt/jwtTokenHandler/test.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2019-2021 (original work) Open Assessment Technologies SA ;
  */
 
 /**

--- a/test/core/jwt/jwtTokenStore/test.js
+++ b/test/core/jwt/jwtTokenStore/test.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2019-2021 (original work) Open Assessment Technologies SA ;
  */
 
 /**

--- a/test/core/jwt/jwtTokenStore/test.js
+++ b/test/core/jwt/jwtTokenStore/test.js
@@ -41,10 +41,10 @@ define(['core/jwt/jwtTokenStore'], jwtTokenStoreFactory => {
     });
 
     QUnit.module('API', {
-        beforeEach: function() {
+        beforeEach: function () {
             this.storage = jwtTokenStoreFactory();
         },
-        afterEach: function(assert) {
+        afterEach: function (assert) {
             const done = assert.async();
             this.storage.clear().then(done);
         }
@@ -52,7 +52,7 @@ define(['core/jwt/jwtTokenStore'], jwtTokenStoreFactory => {
 
     const exampleTokens = ['foo', 'bar', 'baz'];
 
-    QUnit.cases.init(exampleTokens).test('set access token', function(token, assert) {
+    QUnit.cases.init(exampleTokens).test('set access token', function (token, assert) {
         assert.expect(2);
         const done = assert.async();
 
@@ -65,7 +65,7 @@ define(['core/jwt/jwtTokenStore'], jwtTokenStoreFactory => {
         });
     });
 
-    QUnit.cases.init(exampleTokens).test('set refresh token', function(token, assert) {
+    QUnit.cases.init(exampleTokens).test('set refresh token', function (token, assert) {
         assert.expect(2);
         const done = assert.async();
 
@@ -78,7 +78,7 @@ define(['core/jwt/jwtTokenStore'], jwtTokenStoreFactory => {
         });
     });
 
-    QUnit.test('set tokens', function(assert) {
+    QUnit.test('set tokens', function (assert) {
         assert.expect(3);
         const done = assert.async();
 
@@ -97,7 +97,7 @@ define(['core/jwt/jwtTokenStore'], jwtTokenStoreFactory => {
         });
     });
 
-    QUnit.test('clear access token', function(assert) {
+    QUnit.test('clear access token', function (assert) {
         assert.expect(3);
         const done = assert.async();
 
@@ -113,7 +113,7 @@ define(['core/jwt/jwtTokenStore'], jwtTokenStoreFactory => {
         });
     });
 
-    QUnit.test('clear refresh token', function(assert) {
+    QUnit.test('clear refresh token', function (assert) {
         assert.expect(3);
         const done = assert.async();
 
@@ -129,7 +129,7 @@ define(['core/jwt/jwtTokenStore'], jwtTokenStoreFactory => {
         });
     });
 
-    QUnit.test('clear tokens', function(assert) {
+    QUnit.test('clear tokens', function (assert) {
         assert.expect(4);
         const done = assert.async();
 
@@ -148,18 +148,73 @@ define(['core/jwt/jwtTokenStore'], jwtTokenStoreFactory => {
         });
     });
 
+    QUnit.test('accessTokenTTL in constructor', function (assert) {
+        const done = assert.async();
+        assert.expect(3);
+
+        const accessToken = 'foo';
+
+        const storage = jwtTokenStoreFactory({
+            accessTokenTTL: 500
+        });
+
+        storage
+            .setAccessToken(accessToken)
+            .then(storeResult => {
+                assert.ok(storeResult, 'accessToken is stored');
+                return storage.getAccessToken();
+            })
+            .then(storedAccessToken => {
+                assert.equal(storedAccessToken, accessToken, 'accessToken can be received before ttl');
+                return new Promise(resolve => setTimeout(resolve, 500));
+            })
+            .then(storage.getAccessToken)
+            .then(storedAccessToken => {
+                assert.equal(storedAccessToken, null, 'accessToken cannot be received after ttl');
+                done();
+            });
+    });
+
+    QUnit.test('setAccessTokenTTL', function (assert) {
+        const done = assert.async();
+        assert.expect(3);
+
+        const accessToken = 'foo';
+
+        const storage = jwtTokenStoreFactory({
+            accessTokenTTL: 1000
+        });
+
+        storage
+            .setAccessToken(accessToken)
+            .then(storeResult => {
+                assert.ok(storeResult, 'accessToken is stored');
+                return storage.getAccessToken();
+            })
+            .then(storedAccessToken => {
+                assert.equal(storedAccessToken, accessToken, 'accessToken can be received before ttl');
+                storage.setAccessTokenTTL(100);
+                return new Promise(resolve => setTimeout(resolve, 100));
+            })
+            .then(storage.getAccessToken)
+            .then(storedAccessToken => {
+                assert.equal(storedAccessToken, null, 'accessToken cannot be received after ttl');
+                done();
+            });
+    });
+
     QUnit.module('Same namespace', {
-        beforeEach: function() {
+        beforeEach: function () {
             this.storage1 = jwtTokenStoreFactory({ namespace: 'namespace' });
             this.storage2 = jwtTokenStoreFactory({ namespace: 'namespace' });
         },
-        afterEach: function(assert) {
+        afterEach: function (assert) {
             const done = assert.async();
             Promise.all([this.storage1.clear(), this.storage2.clear()]).then(done);
         }
     });
 
-    QUnit.test('stores could access to same tokens', function(assert) {
+    QUnit.test('stores could access to same tokens', function (assert) {
         assert.expect(3);
         const done = assert.async();
 
@@ -178,7 +233,7 @@ define(['core/jwt/jwtTokenStore'], jwtTokenStoreFactory => {
         });
     });
 
-    QUnit.test('store will be empty if other store will be cleared', function(assert) {
+    QUnit.test('store will be empty if other store will be cleared', function (assert) {
         assert.expect(4);
         const done = assert.async();
 
@@ -201,17 +256,17 @@ define(['core/jwt/jwtTokenStore'], jwtTokenStoreFactory => {
     });
 
     QUnit.module('Different namespace', {
-        beforeEach: function() {
+        beforeEach: function () {
             this.storage1 = jwtTokenStoreFactory({ namespace: 'namespace1' });
             this.storage2 = jwtTokenStoreFactory({ namespace: 'namespace2' });
         },
-        afterEach: function(assert) {
+        afterEach: function (assert) {
             const done = assert.async();
             Promise.all([this.storage1.clear(), this.storage2.clear()]).then(done);
         }
     });
 
-    QUnit.test('stores could not access to same tokens', function(assert) {
+    QUnit.test('stores could not access to same tokens', function (assert) {
         assert.expect(6);
         const done = assert.async();
 
@@ -242,7 +297,7 @@ define(['core/jwt/jwtTokenStore'], jwtTokenStoreFactory => {
         });
     });
 
-    QUnit.test('store content will be kept if other store will be cleared', function(assert) {
+    QUnit.test('store content will be kept if other store will be cleared', function (assert) {
         assert.expect(4);
         const done = assert.async();
 


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-652

- Add `useCredentials` option to `jwtTokenHandler`
- Write tests for new `refreshToken` method.

Test:
- `npm run test`