### PR TITLE
Feature/tr 780 send parameters in refresh token call

### DIFF
--- a/src/core/jwt/jwtTokenHandler.js
+++ b/src/core/jwt/jwtTokenHandler.js
@@ -66,7 +66,7 @@ const jwtTokenHandlerFactory = function jwtTokenHandlerFactory({
         let flow;
 
         if (refreshTokenParameters) {
-            body = { ...refreshTokenParameters };
+            body = Object.assign({}, refreshTokenParameters);
         }
 
         if (useCredentials) {
@@ -77,7 +77,7 @@ const jwtTokenHandlerFactory = function jwtTokenHandlerFactory({
                 if (!refreshToken) {
                     throw new Error('Refresh token is not available');
                 }
-                body = { ...body, refreshToken };
+                body = Object.assign({}, body, { refreshToken });
             });
         }
 
@@ -117,22 +117,24 @@ const jwtTokenHandlerFactory = function jwtTokenHandlerFactory({
          * @returns {Promise<String|null>} Promise of access token
          */
         getToken() {
-            return actionQueue.serie(() => tokenStorage.getAccessToken().then(accessToken => {
-                if (accessToken) {
-                    return accessToken;
-                }
-
-                if (useCredentials) {
-                    return unQueuedRefreshToken();
-                }
-                return tokenStorage.getRefreshToken().then(refreshToken => {
-                    if (refreshToken) {
-                        return unQueuedRefreshToken();
-                    } else {
-                        throw new Error('Token not available and cannot be refreshed');
+            return actionQueue.serie(() =>
+                tokenStorage.getAccessToken().then(accessToken => {
+                    if (accessToken) {
+                        return accessToken;
                     }
-                });
-            }));
+
+                    if (useCredentials) {
+                        return unQueuedRefreshToken();
+                    }
+                    return tokenStorage.getRefreshToken().then(refreshToken => {
+                        if (refreshToken) {
+                            return unQueuedRefreshToken();
+                        } else {
+                            throw new Error('Token not available and cannot be refreshed');
+                        }
+                    });
+                })
+            );
         },
 
         /**

--- a/src/core/jwt/jwtTokenHandler.js
+++ b/src/core/jwt/jwtTokenHandler.js
@@ -117,24 +117,22 @@ const jwtTokenHandlerFactory = function jwtTokenHandlerFactory({
          * @returns {Promise<String|null>} Promise of access token
          */
         getToken() {
-            return actionQueue.serie(() =>
-                tokenStorage.getAccessToken().then(accessToken => {
-                    if (accessToken) {
-                        return accessToken;
-                    }
+            return actionQueue.serie(() => tokenStorage.getAccessToken().then(accessToken => {
+                if (accessToken) {
+                    return accessToken;
+                }
 
-                    if (useCredentials) {
+                if (useCredentials) {
+                    return unQueuedRefreshToken();
+                }
+                return tokenStorage.getRefreshToken().then(refreshToken => {
+                    if (refreshToken) {
                         return unQueuedRefreshToken();
+                    } else {
+                        throw new Error('Token not available and cannot be refreshed');
                     }
-                    return tokenStorage.getRefreshToken().then(refreshToken => {
-                        if (refreshToken) {
-                            return unQueuedRefreshToken();
-                        } else {
-                            throw new Error('Token not available and cannot be refreshed');
-                        }
-                    });
-                })
-            );
+                });
+            }));
         },
 
         /**


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-780

- Add support of optional `refreshTokenParameters`
- Extend tests with refresh token parameters

Test: `npm run test`