### PR TITLE
Feature/trn 348/jwt access token ttl buffer

### DIFF
--- a/src/core/jwt/jwtTokenHandler.js
+++ b/src/core/jwt/jwtTokenHandler.js
@@ -33,6 +33,7 @@ import promiseQueue from 'core/promiseQueue';
  * @param {String} options.serviceName Name of the service what JWT token belongs to
  * @param {String} options.refreshTokenUrl Url where handler could refresh JWT token
  * @param {Number} [options.accessTokenTTL] Set accessToken TTL in ms for token store
+ * @param {Number} [options.accessTokenTTLBuffer] Buffer value for accessToken TTL in ms for token store
  * @param {Boolean} [options.useCredentials] refreshToken stored in cookie instead of store
  * @param {Object} [options.refreshTokenParameters] Parameters that should be send in refreshToken call
  * @returns {Object} JWT Token handler instance
@@ -41,12 +42,14 @@ const jwtTokenHandlerFactory = function jwtTokenHandlerFactory({
     serviceName = 'tao',
     refreshTokenUrl,
     accessTokenTTL,
+    accessTokenTTLBuffer,
     refreshTokenParameters,
     useCredentials = false
 } = {}) {
     const tokenStorage = jwtTokenStoreFactory({
         namespace: serviceName,
-        accessTokenTTL
+        accessTokenTTL,
+        accessTokenTTLBuffer
     });
 
     /**
@@ -174,10 +177,11 @@ const jwtTokenHandlerFactory = function jwtTokenHandlerFactory({
 
         /**
          * Set accessToken TTL
-         * @param {Number} accessTokenTTL - accessToken TTL in ms
+         * @param {Number} newAccessTokenTTL - accessToken TTL in ms
+         * @param {Number} newAccessTokenTTLBuffer - accessToken TTL buffer value in ms
          */
-        setAccessTokenTTL(accessTokenTTL) {
-            tokenStorage.setAccessTokenTTL(accessTokenTTL);
+        setAccessTokenTTL(newAccessTokenTTL, newAccessTokenTTLBuffer) {
+            tokenStorage.setAccessTokenTTL(newAccessTokenTTL, newAccessTokenTTLBuffer);
         }
     };
 };


### PR DESCRIPTION
Related task: https://oat-sa.atlassian.net/browse/TRN-348

This may not be a full solution to the above ticket, but adds a property to `jwtTokenHandler`/`jwtTokenStore` to configure a buffer of time where a stored JWT token should no longer be used. The reason to configure it is to account for **network latency** between the BE's validity clock and the FE's validity clock.

For example, if we receive on the FE a new token, and the system is configured (BE+FE) with `accessTokenTTL`: 5 minutes and (FE)`accessTokenTTLBuffer`: 10 seconds, we should consider it invalid after 4 minutes 50 seconds.

This will prevent sending a valid token which may be expired by the time BE checks it, in such cases where the request is initiated in the final buffer period.

![accessTokenTTLBuffer](https://user-images.githubusercontent.com/43652944/117259302-31bbb780-ae4e-11eb-9984-dca5214698ce.png)

**To test:**
Configure your accessTokenTTL in `nextgen-stack` to a low value like 30 seconds:
- on BE side in tao-deliver-be/config/services.yaml -> `jwt_access_token_ttl: 30`
- on FE side in tao-deliver-testrunner-nui-fe/src/config.js -> `accessTokenTTL: 30000`

Now when you launch a test, each new token you receive is valid for 30 sec, but requests made after 20 sec will trigger a token refresh first. You should not have 401 errors at all, as your token will either be used (in first 20 sec) or refreshed (any time after that).