### PR TITLE
Feature/trn 348/jwt embedded ttl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ typings/
 .next
 
 dist
+
+# IDE
+.vscode

--- a/src/core/jwt/jwtToken.js
+++ b/src/core/jwt/jwtToken.js
@@ -18,13 +18,15 @@
 
 /**
  * JWT token helper collection
+ * This is only a minimal set of tools for the parts we currently need
+ * @see https://tools.ietf.org/html/rfc7519
  * @module core/jwtToken
  */
 
 /**
  * Decodes the payload (middle section) of a JWT token
- * @param {String} token - JWT token, xxxxx.yyyyy.zzzzz format
- * @returns {Object}
+ * @param {String} token - JWT token, 'xxxxx.yyyyy.zzzzz' format
+ * @returns {Object} JWT payload
  */
 export function parseJwtPayload(token) {
     try {
@@ -37,18 +39,13 @@ export function parseJwtPayload(token) {
 /**
  * Calculates TTL of a token based on its claims
  * @param {Object} payload - parsed JWT object
- * @param {Number} payload.iat - "issued at time" timestamp
- * @param {Number} payload.exp - "expiration" timestamp
- * @param {Number} defaultTTL - fallback TTL from configuration, in ms
- * @param {Number} latency - desired network latency to account for, in ms
- * @returns {Number} TTL, in ms
+ * @param {Number} payload.iat - "issued at time", as timestamp
+ * @param {Number} payload.exp - "expiration", as timestamp
+ * @returns {Number|null} TTL, in ms
  */
-export function getJwtTTL(payload, defaultTTL = 500000, latency = 10000) {
-    let ttl = 0;
+export function getJwtTTL(payload) {
     if (payload && payload.exp && payload.iat) {
-        ttl = (payload.exp - payload.iat) * 1000;
-    } else {
-        ttl = defaultTTL;
+        return (payload.exp - payload.iat) * 1000;
     }
-    return ttl - latency;
+    return null;
 }

--- a/src/core/jwt/jwtToken.js
+++ b/src/core/jwt/jwtToken.js
@@ -1,0 +1,54 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+
+/**
+ * JWT token helper collection
+ * @module core/jwtToken
+ */
+
+/**
+ * Decodes the payload (middle section) of a JWT token
+ * @param {String} token - JWT token, xxxxx.yyyyy.zzzzz format
+ * @returns {Object}
+ */
+export function parseJwtPayload(token) {
+    try {
+        return JSON.parse(atob(token.split('.')[1]));
+    } catch (e) {
+        return null;
+    }
+}
+
+/**
+ * Calculates TTL of a token based on its claims
+ * @param {Object} payload - parsed JWT object
+ * @param {Number} payload.iat - "issued at time" timestamp
+ * @param {Number} payload.exp - "expiration" timestamp
+ * @param {Number} defaultTTL - fallback TTL from configuration, in ms
+ * @param {Number} latency - desired network latency to account for, in ms
+ * @returns {Number} TTL, in ms
+ */
+export function getJwtTTL(payload, defaultTTL = 500000, latency = 10000) {
+    let ttl = 0;
+    if (payload && payload.exp && payload.iat) {
+        ttl = (payload.exp - payload.iat) * 1000;
+    } else {
+        ttl = defaultTTL;
+    }
+    return ttl - latency;
+}

--- a/src/core/jwt/jwtTokenHandler.js
+++ b/src/core/jwt/jwtTokenHandler.js
@@ -33,6 +33,7 @@ import promiseQueue from 'core/promiseQueue';
  * @param {String} options.serviceName Name of the service what JWT token belongs to
  * @param {String} options.refreshTokenUrl Url where handler could refresh JWT token
  * @param {Number} [options.accessTokenTTL] Set accessToken TTL in ms for token store
+ * @param {Boolean} [options.usePerTokenTTL] if true, accessToken TTL should be extractable from JWT payload, and accessTokenTTL will be used as fallback
  * @param {Boolean} [options.useCredentials] refreshToken stored in cookie instead of store
  * @param {Object} [options.refreshTokenParameters] Parameters that should be send in refreshToken call
  * @returns {Object} JWT Token handler instance
@@ -41,12 +42,14 @@ const jwtTokenHandlerFactory = function jwtTokenHandlerFactory({
     serviceName = 'tao',
     refreshTokenUrl,
     accessTokenTTL,
+    usePerTokenTTL = false,
     refreshTokenParameters,
     useCredentials = false
 } = {}) {
     const tokenStorage = jwtTokenStoreFactory({
         namespace: serviceName,
-        accessTokenTTL
+        accessTokenTTL,
+        usePerTokenTTL
     });
 
     /**
@@ -174,10 +177,10 @@ const jwtTokenHandlerFactory = function jwtTokenHandlerFactory({
 
         /**
          * Set accessToken TTL
-         * @param {Number} accessTokenTTL - accessToken TTL in ms
+         * @param {Number} newAccessTokenTTL - accessToken TTL in ms
          */
-        setAccessTokenTTL(accessTokenTTL) {
-            tokenStorage.setAccessTokenTTL(accessTokenTTL);
+        setAccessTokenTTL(newAccessTokenTTL) {
+            tokenStorage.setAccessTokenTTL(newAccessTokenTTL);
         }
     };
 };

--- a/src/core/jwt/jwtTokenStore.js
+++ b/src/core/jwt/jwtTokenStore.js
@@ -61,8 +61,7 @@ const jwtTokenStoreFactory = function jwtTokenStoreFactory({
         setAccessToken(token) {
             if (usePerTokenTTL) {
                 const tokenPayload = parseJwtPayload(token);
-                const buffer = 10000;
-                currentAccessTokenTTL = (getJwtTTL(tokenPayload) || defaultAccessTokenTTL) - buffer;
+                currentAccessTokenTTL = getJwtTTL(tokenPayload) || defaultAccessTokenTTL;
             }
             accessTokenStoredAt = Date.now();
             return getAccessTokenStore().then(storage => storage.setItem(accessTokenName, token));

--- a/src/core/jwt/jwtTokenStore.js
+++ b/src/core/jwt/jwtTokenStore.js
@@ -140,11 +140,11 @@ const jwtTokenStoreFactory = function jwtTokenStoreFactory({
 
         /**
          * Set a new TTL value for accessToken
-         * @param {Number} accessTokenTTL - accessToken TTL in ms
+         * @param {Number} newAccessTokenTTL - accessToken TTL in ms
          * @returns {void}
          */
-        setAccessTokenTTL(accessTokenTTL) {
-            defaultAccessTokenTTL = accessTokenTTL;
+        setAccessTokenTTL(newAccessTokenTTL) {
+            defaultAccessTokenTTL = newAccessTokenTTL;
         }
     };
 };

--- a/test/core/jwt/jwtToken/test.html
+++ b/test/core/jwt/jwtToken/test.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Test - JWT Token</title>
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    require(['test/core/jwt/jwtToken/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/test/core/jwt/jwtToken/test.js
+++ b/test/core/jwt/jwtToken/test.js
@@ -46,21 +46,17 @@ define(['core/jwt/jwtToken'], jwtToken => {
 
     const time1 = 1620651921250;
     const time2 = 1620651922000;
-    const jwtPayload1 = { iat: time1, exp: time2 };
-    const jwtPayload2 = { exp: time2 };
+    const jwtPayload1 = { iat: time1, exp: time2 }; // 750 seconds apart
+    const jwtPayload2 = { iat: time1 };
+    const jwtPayload3 = { exp: time2 };
 
     QUnit.cases.init([
-        { payload: jwtPayload1, defaultTTL: void 0, latency: void 0, expectedTTL: 740000 },
-        { payload: jwtPayload1, defaultTTL: void 0, latency: 10000, expectedTTL: 740000 },
-        { payload: jwtPayload1, defaultTTL: void 0, latency: 20000, expectedTTL: 730000 },
-        { payload: jwtPayload2, defaultTTL: void 0, latency: void 0, expectedTTL: 490000 },
-        { payload: jwtPayload2, defaultTTL: void 0, latency: 10000, expectedTTL: 490000 },
-        { payload: jwtPayload2, defaultTTL: void 0, latency: 20000, expectedTTL: 480000 },
-        { payload: jwtPayload2, defaultTTL: 300000, latency: void 0, expectedTTL: 290000 },
-        { payload: jwtPayload2, defaultTTL: 300000, latency: 100000, expectedTTL: 200000 },
-        { payload: null, defaultTTL: 300000, latency: void 0, expectedTTL: 290000 },
+        { payload: jwtPayload1, expectedTTL: 750000 },
+        { payload: jwtPayload2, expectedTTL: null },
+        { payload: jwtPayload3, expectedTTL: null },
+        { payload: void 0, expectedTTL: null },
     ]).test('returns correct TTL', function(data, assert) {
         assert.expect(1);
-        assert.equal(getJwtTTL(data.payload, data.defaultTTL, data.latency), data.expectedTTL, JSON.stringify(data));
+        assert.equal(getJwtTTL(data.payload, data.defaultTTL), data.expectedTTL, JSON.stringify(data));
     });
 });

--- a/test/core/jwt/jwtToken/test.js
+++ b/test/core/jwt/jwtToken/test.js
@@ -1,0 +1,66 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+
+define(['core/jwt/jwtToken'], jwtToken => {
+    'use strict';
+
+    const { parseJwtPayload, getJwtTTL } = jwtToken;
+
+    QUnit.module('factory');
+
+    QUnit.test('module', assert => {
+        assert.expect(2);
+        assert.ok(typeof parseJwtPayload === 'function', 'the module exposes a parseJwtPayload function');
+        assert.ok(typeof getJwtTTL === 'function', 'the module exposes a getJwtTTL function');
+    });
+
+    QUnit.module('parseJwtPayload');
+
+    QUnit.test('parses payload object from full token', assert => {
+        assert.expect(4);
+        const token = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjA2NTM1NDgsImV4cCI6MTYyMDY1NDc2MiwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoiIn0.3j-2RN4OVgDYUVxP9VIaOnpkno8I4LDDzouSzgAdUsw';
+        const result = parseJwtPayload(token);
+        assert.ok(typeof result === 'object');
+        assert.equal(result.iat, 1620653548);
+        assert.equal(result.exp, 1620654762);
+        assert.equal(result.aud, 'www.example.com', 'audience correctly parsed');
+    });
+
+
+    QUnit.module('getJwtTTL');
+
+    const time1 = 1620651921250;
+    const time2 = 1620651922000;
+    const jwtPayload1 = { iat: time1, exp: time2 };
+    const jwtPayload2 = { exp: time2 };
+
+    QUnit.cases.init([
+        { payload: jwtPayload1, defaultTTL: void 0, latency: void 0, expectedTTL: 740000 },
+        { payload: jwtPayload1, defaultTTL: void 0, latency: 10000, expectedTTL: 740000 },
+        { payload: jwtPayload1, defaultTTL: void 0, latency: 20000, expectedTTL: 730000 },
+        { payload: jwtPayload2, defaultTTL: void 0, latency: void 0, expectedTTL: 490000 },
+        { payload: jwtPayload2, defaultTTL: void 0, latency: 10000, expectedTTL: 490000 },
+        { payload: jwtPayload2, defaultTTL: void 0, latency: 20000, expectedTTL: 480000 },
+        { payload: jwtPayload2, defaultTTL: 300000, latency: void 0, expectedTTL: 290000 },
+        { payload: jwtPayload2, defaultTTL: 300000, latency: 100000, expectedTTL: 200000 },
+        { payload: null, defaultTTL: 300000, latency: void 0, expectedTTL: 290000 },
+    ]).test('returns correct TTL', function(data, assert) {
+        assert.expect(1);
+        assert.equal(getJwtTTL(data.payload, data.defaultTTL, data.latency), data.expectedTTL, JSON.stringify(data));
+    });
+});

--- a/test/core/jwt/jwtToken/test.js
+++ b/test/core/jwt/jwtToken/test.js
@@ -41,6 +41,12 @@ define(['core/jwt/jwtToken'], jwtToken => {
         assert.equal(result.aud, 'www.example.com', 'audience correctly parsed');
     });
 
+    QUnit.test('returns null for bad or missing token', assert => {
+        assert.expect(2);
+        const badtoken = 'xxxxx.yyyyy.zzzzz';
+        assert.equal(parseJwtPayload(badtoken), null);
+        assert.equal(parseJwtPayload(), null);
+    });
 
     QUnit.module('getJwtTTL');
 

--- a/test/core/jwt/jwtToken/test.js
+++ b/test/core/jwt/jwtToken/test.js
@@ -35,17 +35,17 @@ define(['core/jwt/jwtToken'], jwtToken => {
         assert.expect(4);
         const token = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjA2NTM1NDgsImV4cCI6MTYyMDY1NDc2MiwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoiIn0.3j-2RN4OVgDYUVxP9VIaOnpkno8I4LDDzouSzgAdUsw';
         const result = parseJwtPayload(token);
-        assert.ok(typeof result === 'object');
-        assert.equal(result.iat, 1620653548);
-        assert.equal(result.exp, 1620654762);
-        assert.equal(result.aud, 'www.example.com', 'audience correctly parsed');
+        assert.ok(typeof result === 'object', 'parsed payload is an object');
+        assert.equal(result.iat, 1620653548, 'iat correctly parsed');
+        assert.equal(result.exp, 1620654762, 'exp correctly parsed');
+        assert.equal(result.aud, 'www.example.com', 'aud correctly parsed');
     });
 
     QUnit.test('returns null for bad or missing token', assert => {
         assert.expect(2);
         const badtoken = 'xxxxx.yyyyy.zzzzz';
-        assert.equal(parseJwtPayload(badtoken), null);
-        assert.equal(parseJwtPayload(), null);
+        assert.equal(parseJwtPayload(badtoken), null, 'invalid token returns null');
+        assert.equal(parseJwtPayload(), null, 'missing token returns null');
     });
 
     QUnit.module('getJwtTTL');

--- a/test/core/jwt/jwtTokenStore/test.js
+++ b/test/core/jwt/jwtTokenStore/test.js
@@ -203,6 +203,35 @@ define(['core/jwt/jwtTokenStore'], jwtTokenStoreFactory => {
             });
     });
 
+    QUnit.test('usePerTokenTTL', function (assert) {
+        const done = assert.async();
+        assert.expect(3);
+
+        // exp - iat = 11 seconds
+        // TTL will be 1 second
+        const accessToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjA2NTUzNzksImV4cCI6MTYyMDY1NTM5MCwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoiIn0.WTLwqVo9ZEkUM-zLGG1MTjF7zgQaLTfCcHxyAV2xgCo';
+
+        const storage = jwtTokenStoreFactory({
+            usePerTokenTTL: true
+        });
+
+        storage
+            .setAccessToken(accessToken)
+            .then(storeResult => {
+                assert.ok(storeResult, 'accessToken is stored');
+                return storage.getAccessToken();
+            })
+            .then(storedAccessToken => {
+                assert.equal(storedAccessToken, accessToken, 'accessToken can be received before its embedded ttl');
+                return new Promise(resolve => setTimeout(resolve, 1000));
+            })
+            .then(storage.getAccessToken)
+            .then(storedAccessToken => {
+                assert.equal(storedAccessToken, null, 'accessToken cannot be received after its embedded ttl');
+                done();
+            });
+    });
+
     QUnit.module('Same namespace', {
         beforeEach: function () {
             this.storage1 = jwtTokenStoreFactory({ namespace: 'namespace' });

--- a/test/core/jwt/jwtTokenStore/test.js
+++ b/test/core/jwt/jwtTokenStore/test.js
@@ -207,9 +207,8 @@ define(['core/jwt/jwtTokenStore'], jwtTokenStoreFactory => {
         const done = assert.async();
         assert.expect(3);
 
-        // exp - iat = 11 seconds
-        // TTL will be 1 second
-        const accessToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjA2NTUzNzksImV4cCI6MTYyMDY1NTM5MCwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoiIn0.WTLwqVo9ZEkUM-zLGG1MTjF7zgQaLTfCcHxyAV2xgCo';
+        // exp - iat = 1 second
+        const accessToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjA2NTUzNzksImV4cCI6MTYyMDY1NTM4MCwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoiIiwicXdlcnR5dWlvcGFzZGZnaGprbHp4Y3Zibm0xMjM0NTYiOiJKb2hubnkiLCJTdXJuYW1lIjoiUm9ja2V0IiwiRW1haWwiOiJqcm9ja2V0QGV4YW1wbGUuY29tIiwiUm9sZSI6WyJNYW5hZ2VyIiwiUHJvamVjdCBBZG1pbmlzdHJhdG9yIl19.fJ4JrEBtbGaldUsk-460QXyfIbuG1udE4giLDbNSjBI';
 
         const storage = jwtTokenStoreFactory({
             usePerTokenTTL: true

--- a/test/core/jwt/jwtTokenStore/test.js
+++ b/test/core/jwt/jwtTokenStore/test.js
@@ -223,7 +223,7 @@ define(['core/jwt/jwtTokenStore'], jwtTokenStoreFactory => {
             })
             .then(storedAccessToken => {
                 assert.equal(storedAccessToken, accessToken, 'accessToken can be received before its embedded ttl');
-                return new Promise(resolve => setTimeout(resolve, 1000));
+                return new Promise(resolve => setTimeout(resolve, 1020));
             })
             .then(storage.getAccessToken)
             .then(storedAccessToken => {


### PR DESCRIPTION
Task: https://oat-sa.atlassian.net/browse/TRN-348

This PR replaces my previous attempts at JWT latency buffer [[1](https://github.com/oat-sa/tao-core-sdk-fe/pull/99)] and TTL configuration change [[2](https://github.com/oat-sa/tao-deliver-testrunner-nui-fe/pull/201)].

I added to the `jwtTokenStore` a way to use a TTL defined in the JWT itself (the payload's `exp` minus `iat` timestamps). To avoid breaking change, this option is turned on by adding `usePerTokenTTL: true`.
- With this on, the configured `accessTokenTTL` is used only as a fallback when the payload values can't be read.
- When this feature is *not* used, the `accessTokenTTL` works like before, as a universal JWT TTL.

There is also a latency buffer of 10s hard coded, although I considered removing it for simplicity.

**To test**:
`npm run test`
real test via related PR https://github.com/oat-sa/tao-deliver-testrunner-nui-fe/pull/202
