### PR TITLE
Feature/TR-1207/Add locale format for DateTime in UTC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1129,25 +1129,25 @@
       "dev": true
     },
     "@oat-sa/tao-qunit-testrunner": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-qunit-testrunner/-/tao-qunit-testrunner-0.1.3.tgz",
-      "integrity": "sha512-BgSzuFTyqAJRKoDdpNcWjWW37dwchfCllPRRqNaYEwyk40vsHQjIxlNMMvDesi/uBSzSDw6F+M2HB6t/uWdtKg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-qunit-testrunner/-/tao-qunit-testrunner-1.0.3.tgz",
+      "integrity": "sha512-1Zo+GxzEL777eaeJekIIY1lw30I9Zm2tb1pRT7j/IfFV1yR8tW05ni+O545MQm1mrxdOuP/HKB4+DuiaYB9GHg==",
       "dev": true,
       "requires": {
         "body-parser": "^1.19.0",
         "chalk": "^2.4.2",
         "connect": "^3.7.0",
-        "fs-extra": "^8.0.1",
+        "fs-extra": "^8.1.0",
         "get-port": "^5.0.0",
-        "glob": "^7.1.4",
+        "glob": "^7.1.6",
         "glob-promise": "^3.4.0",
         "istanbul-lib-instrument": "^3.3.0",
         "minimatch": "^3.0.4",
-        "node-qunit-puppeteer": "^1.0.13",
+        "node-qunit-puppeteer": "^1.0.16",
         "promise-limit": "^2.7.0",
         "serve-index": "^1.9.1",
         "serve-static": "^1.14.1",
-        "yargs": "^13.2.4"
+        "yargs": "^13.3.0"
       }
     },
     "@types/estree": {
@@ -1167,9 +1167,9 @@
       }
     },
     "@types/minimatch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==",
       "dev": true
     },
     "@types/node": {
@@ -3439,18 +3439,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "version": "2.1.30",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
+      "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
       "dev": true,
       "requires": {
-        "mime-db": "1.44.0"
+        "mime-db": "1.47.0"
       }
     },
     "minimatch": {
@@ -4996,7 +4996,8 @@
     "y18n": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true
     },
     "yallist": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@oat-sa/expr-eval": "^1.3.0",
     "@oat-sa/prettier-config": "^0.1.1",
     "@oat-sa/tao-core-libs": "^0.4.3",
-    "@oat-sa/tao-qunit-testrunner": "^0.1.3",
+    "@oat-sa/tao-qunit-testrunner": "1.0.3",
     "async": "^0.2.10",
     "decimal.js": "10.1.1",
     "dompurify": "1.0.11",

--- a/src/util/locale.js
+++ b/src/util/locale.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016-2019 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2016-2021 (original work) Open Assessment Technologies SA;
  *
  */
 
@@ -115,11 +115,13 @@ export default {
 
     /**
      * Parse unix timestamp
-     * Note that user's (browser's) timezone will be used.
-     * @param {Number} timestamp
+     * Note that user's (browser's) timezone will be used by default, unless the utc parameter is set to true.
+     * @param {Number} timestamp - The timestamp to format. It is considered as in the target timezone.
+     * @param {Boolean} [utc=false] - For the UTC timezone. By default the user's timezone will be used.
      * @return string
      */
-    formatDateTime: function(timestamp) {
-        return moment(timestamp, 'X').format(this.getDateTimeFormat());
+    formatDateTime(timestamp, utc = false) {
+        const datetime = utc ? moment.utc(timestamp, 'X') : moment(timestamp, 'X');
+        return datetime.format(this.getDateTimeFormat());
     }
 };

--- a/test/util/locale/momentMock.js
+++ b/test/util/locale/momentMock.js
@@ -1,0 +1,54 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'core/eventifier'
+], function (eventifier) {
+    'use strict';
+
+    const mockValues = {};
+
+    const momentMock = eventifier(function (...args) {
+        momentMock.trigger('moment', ...args);
+        return momentMockFactory(...args);
+    });
+
+    function momentMockFactory(...factoryArgs) {
+        momentMock.trigger('factory', ...factoryArgs);
+
+        return {
+            format(...args) {
+                momentMock.trigger('format', ...args);
+                return mockValues.format;
+            }
+        };
+    }
+
+    return Object.assign(momentMock, {
+        utc(...args) {
+            momentMock.trigger('utc', ...args);
+            return momentMockFactory(...args);
+        },
+
+        mockFormat(value) {
+            mockValues.format = value;
+        }
+    });
+});

--- a/test/util/locale/test.html
+++ b/test/util/locale/test.html
@@ -7,6 +7,12 @@
         <script type="text/javascript">
             require(['/environment/config.js'], function() {
                 require(['qunitEnv'], function() {
+                    //some mocks
+                    requirejs.config({
+                        paths: {
+                            'moment': 'test/util/locale/momentMock'
+                        }
+                    });
                     require(['test/util/locale/test'], function() {
                         QUnit.start();
                     });

--- a/test/util/locale/test.js
+++ b/test/util/locale/test.js
@@ -13,15 +13,19 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2016-2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  * @author Ivan Klimchuk <klimchuk@1pt.com>
  */
-define(['module', 'util/locale'], function(module, locale) {
+define([
+    'module',
+    'moment',
+    'util/locale'
+], function(module, moment, locale) {
     // All tests are grouped in one module because global state is changed during them
     QUnit.module('API');
 
-    QUnit.test('util api, different locales', function(assert) {
+    QUnit.test('util api, different locales', assert => {
         // American style
         locale.setConfig({
             decimalSeparator: '.',
@@ -91,5 +95,88 @@ define(['module', 'util/locale'], function(module, locale) {
             6,
             'the valid integer value with dot as decimal separator and comma as thousands separator'
         );
+    });
+
+    QUnit.test('util/formatDateTime', assert => {
+        const ready = assert.async();
+        const expectedTimestamp = 1621641600;
+        const expectedOptions = 'X';
+
+        Promise.resolve()
+            .then(() => {
+                const expectedOutput = '05/21/2021';
+
+                moment.off('.test');
+
+                const promises = [
+                    new Promise(resolve => {
+                        moment.on('moment.test', (ts, options) => {
+                            assert.ok(true, 'Local timezone applied!');
+                            assert.equal(ts, expectedTimestamp, 'The expected timestamp has been supplied');
+                            assert.equal(options, expectedOptions, 'The expected options have been supplied');
+                            resolve();
+                        });
+
+                        moment.on('utc.test', (ts, options) => {
+                            assert.ok(false, 'UTC timezone should not be applied!');
+                            assert.equal(ts, expectedTimestamp, 'The expected timestamp has been supplied');
+                            assert.equal(options, expectedOptions, 'The expected options have been supplied');
+                            resolve();
+                        });
+                    }),
+                    new Promise(resolve => {
+                        moment.on('format.test', () => {
+                            assert.ok(true, 'Local format applied');
+                            resolve();
+                        });
+                    })
+                ];
+
+                moment.mockFormat(expectedOutput);
+                assert.equal(locale.formatDateTime(expectedTimestamp), expectedOutput, 'Format date/time to locale using user timezone');
+
+                return promises;
+            })
+            .then(() => {
+                const expectedOutput = '05/22/2021';
+
+                moment.off('.test');
+
+                const promises = [
+                    new Promise(resolve => {
+                        moment.on('moment.test', (ts, options) => {
+                            assert.ok(false, 'Local timezone should not be applied!');
+                            assert.equal(ts, expectedTimestamp, 'The expected timestamp has been supplied');
+                            assert.equal(options, expectedOptions, 'The expected options have been supplied');
+                            resolve();
+                        });
+
+                        moment.on('utc.test', (ts, options) => {
+                            assert.ok(true, 'UTC timezone applied!');
+                            assert.equal(ts, expectedTimestamp, 'The expected timestamp has been supplied');
+                            assert.equal(options, expectedOptions, 'The expected options have been supplied');
+                            resolve();
+                        });
+                    }),
+                    new Promise(resolve => {
+                        moment.on('format.test', () => {
+                            assert.ok(true, 'Local format applied');
+                            resolve();
+                        });
+                    })
+                ];
+
+                moment.mockFormat(expectedOutput);
+                assert.equal(locale.formatDateTime(expectedTimestamp, true), expectedOutput, 'Format date/time to locale using UTC timezone');
+
+                return promises;
+            })
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
     });
 });

--- a/test/util/locale/test.js
+++ b/test/util/locale/test.js
@@ -21,7 +21,7 @@ define([
     'module',
     'moment',
     'util/locale'
-], function(module, moment, locale) {
+], function (module, moment, locale) {
     // All tests are grouped in one module because global state is changed during them
     QUnit.module('API');
 
@@ -101,6 +101,8 @@ define([
         const ready = assert.async();
         const expectedTimestamp = 1621641600;
         const expectedOptions = 'X';
+
+        assert.expect(10);
 
         Promise.resolve()
             .then(() => {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-1207

Add a variant for the helper `formatDateTime()` to also support timestamp in UTC.

By default, the helper will continue assuming the supplied timestamp is in the user's timezone. However, the second parameter of the helper allows qualifying the timestamp as being in UTC instead.

How to test:
- run the unit tests
- check the companion PR for complete testing