### PR TITLE
allow supporting HEAD request

### DIFF
--- a/src/core/fetchRequest.js
+++ b/src/core/fetchRequest.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2020-21 (original work) Open Assessment Technologies SA ;
  */
 
 import ApiError from 'core/error/ApiError';
@@ -30,6 +30,7 @@ import TimeoutError from 'core/error/TimeoutError';
  * @param {object} options - fetch request options that implements RequestInit (https://fetch.spec.whatwg.org/#requestinit)
  * @param {integer} [options.timeout] - (default: 5000) if timeout reached, the request will be rejected
  * @param {object} [options.jwtTokenHandler] - core/jwt/jwtTokenHandler instance that should be used during request
+ * @param {boolean} [options.returnOriginalResponse] - the full original response should be returned instead of parsing internally (useful for HEAD requests or other empty-response-body requests)
  * @returns {Promise<Response>} resolves with http Response object
  */
 const requestFactory = (url, options) => {
@@ -93,6 +94,10 @@ const requestFactory = (url, options) => {
         .then(response => {
             originalResponse = response.clone();
             responseCode = response.status;
+
+            if (options.returnOriginalResponse) {
+                return originalResponse;
+            }
             return response.json().catch(() => ({}));
         })
         .then(response => {
@@ -102,12 +107,6 @@ const requestFactory = (url, options) => {
 
             // successful request
             if ((responseCode >= 200 && responseCode < 300) || (response && response.success === true)) {
-                if (options.method === 'HEAD') {
-                    const headers = {};
-                    [...originalResponse.headers].forEach(([key, value]) => (headers[key] = value));
-                    return Object.assign(response, { headers });
-                }
-
                 return response;
             }
 

--- a/src/core/fetchRequest.js
+++ b/src/core/fetchRequest.js
@@ -119,7 +119,11 @@ const requestFactory = (url, options) => {
                     originalResponse
                 );
             } else {
-                err = new NetworkError(`${responseCode} : Request error`, responseCode || 0, originalResponse);
+                err = new NetworkError(
+                    `${responseCode} : Request error`,
+                    responseCode || 0,
+                    originalResponse
+                );
             }
             throw err;
         })

--- a/src/core/fetchRequest.js
+++ b/src/core/fetchRequest.js
@@ -103,7 +103,8 @@ const requestFactory = (url, options) => {
             // successful request
             if ((responseCode >= 200 && responseCode < 300) || (response && response.success === true)) {
                 if (options.method === 'HEAD') {
-                    const { headers } = originalResponse;
+                    const headers = {};
+                    [...originalResponse.headers].forEach(([key, value]) => (headers[key] = value));
                     return Object.assign(response, { headers });
                 }
 

--- a/src/core/fetchRequest.js
+++ b/src/core/fetchRequest.js
@@ -102,6 +102,14 @@ const requestFactory = (url, options) => {
 
             // successful request
             if ((responseCode >= 200 && responseCode < 300) || (response && response.success === true)) {
+                if(options.method === "HEAD"){
+                    const headers = {};
+                    for (const [key, value] of originalResponse.headers.entries()) {
+                        headers[key] = value;
+                    }
+                    return Object.assign(response, {headers});
+                }
+
                 return response;
             }
 

--- a/src/core/fetchRequest.js
+++ b/src/core/fetchRequest.js
@@ -53,7 +53,7 @@ const requestFactory = (url, options) => {
             });
     }
 
-    flow = flow.then(() => (
+    flow = flow.then(() =>
         Promise.race([
             fetch(url, options),
             new Promise((resolve, reject) => {
@@ -62,7 +62,7 @@ const requestFactory = (url, options) => {
                 }, options.timeout);
             })
         ])
-    ));
+    );
 
     if (options.jwtTokenHandler) {
         flow = flow.then(response => {
@@ -102,12 +102,9 @@ const requestFactory = (url, options) => {
 
             // successful request
             if ((responseCode >= 200 && responseCode < 300) || (response && response.success === true)) {
-                if(options.method === "HEAD"){
-                    const headers = {};
-                    for (const [key, value] of originalResponse.headers.entries()) {
-                        headers[key] = value;
-                    }
-                    return Object.assign(response, {headers});
+                if (options.method === 'HEAD') {
+                    const { headers } = originalResponse;
+                    return Object.assign(response, { headers });
                 }
 
                 return response;
@@ -122,16 +119,12 @@ const requestFactory = (url, options) => {
                     originalResponse
                 );
             } else {
-                err = new NetworkError(
-                    `${responseCode} : Request error`,
-                    responseCode || 0,
-                    originalResponse
-                );
+                err = new NetworkError(`${responseCode} : Request error`, responseCode || 0, originalResponse);
             }
             throw err;
         })
         .catch(err => {
-            if(!err.type){
+            if (!err.type) {
                 //offline, CORS, etc.
                 return Promise.reject(new NetworkError(err.message, 0));
             }

--- a/test/core/fetchRequest/test.js
+++ b/test/core/fetchRequest/test.js
@@ -100,7 +100,7 @@ define([
         });
     });
 
-    QUnit.test('request returns with headers if status code is 2XX and method HEAD', assert => {
+    QUnit.test('request returns headers if status code is 2XX and method HEAD', assert => {
         assert.expect(1);
         const done = assert.async();
 
@@ -270,7 +270,7 @@ define([
     });
 
     QUnit.test('request returns with the correct error response if there are no tokens', function (assert) {
-        // assert.expect(1);
+        assert.expect(1);
         assert.rejects(
             request('/foo', { jwtTokenHandler: this.jwtTokenHandler }),
             /Token not available and cannot be refreshed/

--- a/test/core/fetchRequest/test.js
+++ b/test/core/fetchRequest/test.js
@@ -16,14 +16,14 @@
  * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
  */
 
-define(['core/fetchRequest', 'core/jwt/jwtTokenHandler', 'fetch-mock', 'core/error/ApiError','core/error/NetworkError',  'core/error/TimeoutError'], (
-    request,
-    jwtTokenHandlerFactory,
-    fetchMock,
-    ApiError,
-    NetworkError,
-    TimeoutError
-) => {
+define([
+    'core/fetchRequest',
+    'core/jwt/jwtTokenHandler',
+    'fetch-mock',
+    'core/error/ApiError',
+    'core/error/NetworkError',
+    'core/error/TimeoutError'
+], (request, jwtTokenHandlerFactory, fetchMock, ApiError, NetworkError, TimeoutError) => {
     'use strict';
 
     // can mocked url redefined
@@ -96,6 +96,27 @@ define(['core/fetchRequest', 'core/jwt/jwtTokenHandler', 'fetch-mock', 'core/err
 
         request('/foo').then(response => {
             assert.deepEqual(response, {});
+            done();
+        });
+    });
+
+    QUnit.test('request returns with headers if status code is 2XX and method HEAD', assert => {
+        assert.expect(1);
+        const done = assert.async();
+
+        let payload = {};
+        let headers = new Headers({ Accept: 'application/json' });
+
+        fetchMock.head('/foo', { body: payload, headers });
+
+        request('/foo', { method: 'HEAD' }).then(response => {
+            assert.deepEqual(response, {
+                headers: {
+                    accept: 'application/json',
+                    'content-length': '2',
+                    'content-type': 'application/json'
+                }
+            });
             done();
         });
     });
@@ -249,7 +270,7 @@ define(['core/fetchRequest', 'core/jwt/jwtTokenHandler', 'fetch-mock', 'core/err
     });
 
     QUnit.test('request returns with the correct error response if there are no tokens', function (assert) {
-        assert.expect(1);
+        // assert.expect(1);
         assert.rejects(
             request('/foo', { jwtTokenHandler: this.jwtTokenHandler }),
             /Token not available and cannot be refreshed/


### PR DESCRIPTION
For head requests headers are added to returning response

**Main problem**: headers from fetch return [Headers object](https://developer.mozilla.org/en-US/docs/Web/API/Headers) which is iterator. It has plenty of methods for iterate, but all of them do not supported by IE.

**What's next**: iterator by itself has various possibilities for handling values, but non of them supported by IE. However i found in repository two methods which pretty widely used and can be used also for handling iterator:
1. `[...iterator]`
2. `new Map(iterator)`

I used first variant in current approach

**Doubts**: I not 100% sure that files where i found spread syntax is used by CG, so may be "IE constraint" is still actual for my approach