### PR TITLE
fix: add falback for missed locales, simplified loop

### DIFF
--- a/src/util/locale.js
+++ b/src/util/locale.js
@@ -131,9 +131,14 @@ export default {
      * @return boolean
      */
     isLanguageRTL: function(lang) {
-        return (this.getConfig().rtl || [])
-            .map(lng => String(lng).toLowerCase())
-            .indexOf(lang.toLowerCase()) >= 0;
+        if (!(this.getConfig() && this.getConfig().rtl) || !lang) {
+            return false;
+        }
+
+        return this.getConfig().rtl
+            .some(function (lng) {
+                return String(lng).toLowerCase() === lang.toLowerCase();
+            });
     },
 
     /**

--- a/test/util/locale/test.js
+++ b/test/util/locale/test.js
@@ -133,11 +133,19 @@ define([
         lang: 'ar-ARB',
         direction: 'rtl'
     }, {
-        // check upper/lowercase
-        title: 'RTL language letter case',
+        title: 'RTL language upper/lowercase ignoring',
         config: ['ar-ARB'],
         lang: 'ar-arb',
         direction: 'rtl'
+    }, {
+        title: 'RTL with missed "lang" fallback to LTR',
+        config: ['ar-ARB'],
+        direction: 'ltr'
+    }, {
+        title: 'Empty config fallback to LTR',
+        config: [],
+        lang: 'ar-arb',
+        direction: 'ltr'
     }]).test('getLanguageDirection', (data, assert) => {
         assert.expect(1);
         locale.setConfig({


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-892

this is fix adding fallback for interactions with missed locales

- [ ]  wait for BE template modifications, maybe we will not need all of this*
* better to have it till https://oat-sa.atlassian.net/browse/TR-1768