### PR TITLE
Fix/si 453/update sev level for token errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-core-sdk",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "displayName": "TAO Core SDK",
   "description": "Core libraries of TAO",
   "homepage": "https://github.com/oat-sa/tao-core-sdk-fe#readme",

--- a/src/core/tokenHandler.js
+++ b/src/core/tokenHandler.js
@@ -101,7 +101,7 @@ export default function tokenHandlerFactory(options) {
                                         .then(getFirstTokenValue);
                                 } else {
                                     // No more token options, refresh needed
-                                    return Promise.reject(new Error('No tokens available. Please refresh the page.'));
+                                    return Promise.reject({"level": "warn", "message": "No tokens available. Please refresh the page."});
                                 }
                             });
                     }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/SI-453

On all our prod environments we have enabled frontend logs that pushes all logs from the FE to CloudWatch.

`{"severity":"ERROR","tag":"tao","message":"{\"level\":\"error\",\"v\":0,\"time\":\"2019-10-31T20:56:41.845Z\",\"msg\":\"No tokens available. Please refresh the page.\",\"err\":{\"source\":\"network\",\"purpose\":\"communicator\"},\"runnerOptions\":{...},\"name\":\"controller\\/runner\",\"pid\":1,\"hostname\":\"Mozilla\\/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit\\/537.36 (KHTML, like Gecko) Chrome\\/77.0.3865.120 Safari\\/537.36\",\"displayMessage\":\"No tokens available. Please refresh the page.\"}","code_file":"undefined","code_line":"0","instance_id":"i-09b448f40f43a8da1","stack":"usact03dep","host_type":"taocloud/ws/delivery"}
`

Depending on configuration on prod environments we can have different counts and TTL for our tokens.
It can generate cases when we have a huge amount of logs that interfere with the investigation and do not make any sense.

Based on this we should do not reject the Promise with the Error type, but with Wrn