### PR TITLE
feat: TR-1524. Redirect on token expiration.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2772,8 +2772,8 @@
       "dev": true
     },
     "eve": {
-      "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
-      "from": "git://github.com/adobe-webplatform/eve.git#eef80ed",
+      "version": "https://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
+      "from": "https://github.com/adobe-webplatform/eve.git#eef80ed",
       "dev": true
     },
     "extract-zip": {
@@ -4897,7 +4897,7 @@
       "integrity": "sha1-qdhPJj7I/obS4WzCz36pq8IA1ho=",
       "dev": true,
       "requires": {
-        "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
+        "eve": "https://github.com/adobe-webplatform/eve.git#eef80ed"
       }
     },
     "raw-body": {

--- a/src/core/error/TokenError.js
+++ b/src/core/error/TokenError.js
@@ -1,0 +1,44 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA ;
+ */
+
+import errorTypes from 'core/error/types';
+import NetworkError from 'core/error/NetworkError';
+
+/**
+ * Token expiration error
+ */
+//eslint-disable-next-line
+export default class TokenError extends NetworkError {
+    /**
+     * Instantiate an error
+     * @param {string} message - the error message
+     * @param {Object} [response] - the full response object if any
+     * @param {boolean} [recoverable=true] - can the user recover after having such error ?
+     * @param {...} params - additional error parameters (line, etc.)
+     */
+    constructor(message, response, recoverable = true, ...params) {
+        super(message, 401, response, recoverable, ...params);
+
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, TokenError);
+        }
+
+        this.name = 'TokenError';
+        this.type = errorTypes.token;
+    }
+}

--- a/src/core/error/TokenError.js
+++ b/src/core/error/TokenError.js
@@ -40,5 +40,6 @@ export default class TokenError extends NetworkError {
 
         this.name = 'TokenError';
         this.type = errorTypes.token;
+        this.recoverable = false;
     }
 }

--- a/src/core/error/TokenError.js
+++ b/src/core/error/TokenError.js
@@ -28,11 +28,10 @@ export default class TokenError extends NetworkError {
      * Instantiate an error
      * @param {string} message - the error message
      * @param {Object} [response] - the full response object if any
-     * @param {boolean} [recoverable=true] - can the user recover after having such error ?
      * @param {...} params - additional error parameters (line, etc.)
      */
-    constructor(message, response, recoverable = true, ...params) {
-        super(message, 401, response, recoverable, ...params);
+    constructor(message, response, ...params) {
+        super(message, 401, response, false, ...params);
 
         if (Error.captureStackTrace) {
             Error.captureStackTrace(this, TokenError);
@@ -40,6 +39,5 @@ export default class TokenError extends NetworkError {
 
         this.name = 'TokenError';
         this.type = errorTypes.token;
-        this.recoverable = false;
     }
 }

--- a/src/core/error/types.js
+++ b/src/core/error/types.js
@@ -33,5 +33,8 @@ export default Object.freeze({
     user: 'user',
 
     // rendering error: an interface, a component fails to render
-    rendering: 'rendering'
+    rendering: 'rendering',
+
+    // token expiration error: 401
+    token: 'token'
 });

--- a/src/core/jwt/jwtTokenHandler.js
+++ b/src/core/jwt/jwtTokenHandler.js
@@ -103,7 +103,13 @@ const jwtTokenHandlerFactory = function jwtTokenHandlerFactory({
                 if (response.status === 200) {
                     return response.json();
                 }
-                const error = new TokenError('Refresh-token expired', response);
+                if(response.status === 401){
+                    const error = new TokenError('Refresh-token expired', response);
+                    return Promise.reject(error);
+                }
+
+                let error = new Error('Unsuccessful token refresh');
+                error.response = response;
                 return Promise.reject(error);
             })
             .then(({ accessToken }) => tokenStorage.setAccessToken(accessToken).then(() => accessToken));

--- a/src/core/jwt/jwtTokenHandler.js
+++ b/src/core/jwt/jwtTokenHandler.js
@@ -103,7 +103,7 @@ const jwtTokenHandlerFactory = function jwtTokenHandlerFactory({
                 if (response.status === 200) {
                     return response.json();
                 }
-                const error = new TokenError('Unsuccessful token refresh', response);
+                const error = new TokenError('Refresh-token expired', response);
                 return Promise.reject(error);
             })
             .then(({ accessToken }) => tokenStorage.setAccessToken(accessToken).then(() => accessToken));

--- a/src/core/jwt/jwtTokenHandler.js
+++ b/src/core/jwt/jwtTokenHandler.js
@@ -26,6 +26,7 @@
 
 import jwtTokenStoreFactory from 'core/jwt/jwtTokenStore';
 import promiseQueue from 'core/promiseQueue';
+import TokenError from 'core/error/TokenError';
 
 /**
  * JWT token handler factory
@@ -102,8 +103,7 @@ const jwtTokenHandlerFactory = function jwtTokenHandlerFactory({
                 if (response.status === 200) {
                     return response.json();
                 }
-                const error = new Error('Unsuccessful token refresh');
-                error.response = response;
+                const error = new TokenError('Unsuccessful token refresh', response);
                 return Promise.reject(error);
             })
             .then(({ accessToken }) => tokenStorage.setAccessToken(accessToken).then(() => accessToken));

--- a/src/core/jwt/jwtTokenHandler.js
+++ b/src/core/jwt/jwtTokenHandler.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019-2021 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2019-2022 (original work) Open Assessment Technologies SA ;
  */
 
 /**

--- a/test/core/error/token/test.html
+++ b/test/core/error/token/test.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    require(['test/core/error/token/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/test/core/error/token/test.js
+++ b/test/core/error/token/test.js
@@ -1,0 +1,48 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA
+ *
+ */
+
+define(['core/error/types', 'core/error/TokenError'], function (errorTypes, TokenError) {
+    'use strict';
+
+    QUnit.module('TokenError');
+
+    QUnit.test('construct', assert => {
+        assert.expect(6);
+
+        const err = new TokenError('Token expired', null);
+        assert.equal(err.name, 'TokenError');
+        assert.equal(err.type, errorTypes.token);
+        assert.equal(err.message, 'Token expired');
+        assert.equal(err.errorCode, 401);
+        assert.equal(err.response, null);
+        assert.equal(err.recoverable, false);
+    });
+
+    QUnit.test('throw', assert => {
+        assert.expect(1);
+
+        assert.throws(
+            () => {
+                throw new TokenError('Refresh token unsuccessful');
+            },
+            TokenError,
+            'Thrown error type is matching'
+        );
+    });
+});

--- a/test/core/error/token/test.js
+++ b/test/core/error/token/test.js
@@ -35,16 +35,17 @@ define(['core/error/types', 'core/error/TokenError'], function (errorTypes, Toke
     });
 
     QUnit.test('construct with passed params', assert => {
-        assert.expect(6);
+        assert.expect(7);
 
         const response = {};
-        const err = new TokenError('Unexpected error', response, true);
+        const err = new TokenError('Unexpected error', response, {cause: true});
         assert.equal(err.name, 'TokenError');
         assert.equal(err.type, errorTypes.token);
         assert.equal(err.message, 'Unexpected error');
         assert.equal(err.errorCode, 401);
         assert.equal(err.response, response);
         assert.equal(err.recoverable, false);
+        assert.equal(err.cause, true);
     });
 
     QUnit.test('throw', assert => {

--- a/test/core/error/token/test.js
+++ b/test/core/error/token/test.js
@@ -22,7 +22,7 @@ define(['core/error/types', 'core/error/TokenError'], function (errorTypes, Toke
 
     QUnit.module('TokenError');
 
-    QUnit.test('construct', assert => {
+    QUnit.test('construct with default params', assert => {
         assert.expect(6);
 
         const err = new TokenError('Token expired', null);
@@ -31,6 +31,19 @@ define(['core/error/types', 'core/error/TokenError'], function (errorTypes, Toke
         assert.equal(err.message, 'Token expired');
         assert.equal(err.errorCode, 401);
         assert.equal(err.response, null);
+        assert.equal(err.recoverable, false);
+    });
+
+    QUnit.test('construct with passed params', assert => {
+        assert.expect(6);
+
+        const response = {};
+        const err = new TokenError('Unexpected error', response, true);
+        assert.equal(err.name, 'TokenError');
+        assert.equal(err.type, errorTypes.token);
+        assert.equal(err.message, 'Unexpected error');
+        assert.equal(err.errorCode, 401);
+        assert.equal(err.response, response);
         assert.equal(err.recoverable, false);
     });
 

--- a/test/core/error/token/test.js
+++ b/test/core/error/token/test.js
@@ -22,10 +22,10 @@ define(['core/error/types', 'core/error/TokenError'], function (errorTypes, Toke
 
     QUnit.module('TokenError');
 
-    QUnit.test('construct with default params', assert => {
+    QUnit.test('construct with minimal params', assert => {
         assert.expect(6);
 
-        const err = new TokenError('Token expired', null);
+        const err = new TokenError('Token expired');
         assert.equal(err.name, 'TokenError');
         assert.equal(err.type, errorTypes.token);
         assert.equal(err.message, 'Token expired');
@@ -35,17 +35,16 @@ define(['core/error/types', 'core/error/TokenError'], function (errorTypes, Toke
     });
 
     QUnit.test('construct with passed params', assert => {
-        assert.expect(7);
+        assert.expect(6);
 
         const response = {};
-        const err = new TokenError('Unexpected error', response, {cause: true});
+        const err = new TokenError('Unexpected error', response);
         assert.equal(err.name, 'TokenError');
         assert.equal(err.type, errorTypes.token);
         assert.equal(err.message, 'Unexpected error');
         assert.equal(err.errorCode, 401);
         assert.equal(err.response, response);
         assert.equal(err.recoverable, false);
-        assert.equal(err.cause, true);
     });
 
     QUnit.test('throw', assert => {

--- a/test/core/jwt/jwtTokenHandler/test.js
+++ b/test/core/jwt/jwtTokenHandler/test.js
@@ -20,7 +20,7 @@
  * @author Tamas Besenyei <tamas@taotesting.com>
  */
 
-define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock'], ($, jwtTokenHandlerFactory, fetchMock) => {
+define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock', 'core/error/TokenError'], ($, jwtTokenHandlerFactory, fetchMock, TokenError) => {
     'use strict';
 
     QUnit.module('factory');
@@ -191,7 +191,7 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock'], ($, jwtTokenHandler
             this.handler
                 .refreshToken()
                 .catch(e => {
-                    assert.equal(e instanceof Error, true, 'rejects with error');
+                    assert.equal(e instanceof TokenError, true, 'rejects with error');
                     assert.equal(e.response instanceof Response, true, 'passes response');
                     return e.response.json();
                 })
@@ -221,7 +221,7 @@ define(['jquery', 'core/jwt/jwtTokenHandler', 'fetch-mock'], ($, jwtTokenHandler
             this.handler
                 .getToken()
                 .catch(e => {
-                    assert.equal(e instanceof Error, true, 'rejects with error');
+                    assert.equal(e instanceof TokenError, true, 'rejects with error');
                     assert.equal(e.response instanceof Response, true, 'passes response');
                     return e.response.json();
                 })

--- a/test/core/jwt/jwtTokenHandler/test.js
+++ b/test/core/jwt/jwtTokenHandler/test.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019-2021 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2019-2022 (original work) Open Assessment Technologies SA ;
  */
 
 /**


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-1524

Here i implemented new type of Network error. This allow handle error in deliver-app without extra conditions.

TODO: 
- [ ] validate message for `lti_errorlog`

How to test: test it in terms of https://github.com/oat-sa/tao-deliver-fe/pull/320