### PR TITLE
Add a util to detect iOS browsers

### DIFF
--- a/src/util/browser.js
+++ b/src/util/browser.js
@@ -1,0 +1,33 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022  (original work) Open Assessment Technologies SA;
+ *
+ *
+ */
+export default {
+    /**
+     * Check if the current runtime is on iOS
+     * ! Please use this method as a last resort, always prefer feature detection
+     * @returns {boolean} true if the current runtime looks like iOS
+     */
+    isIOs() {
+        return (
+            (/iPad|iPhone|iPod/.test(window.navigator.platform) ||
+                (window.navigator.platform === 'MacIntel' && window.navigator.maxTouchPoints > 1)) &&
+            !window.MSStream
+        );
+    }
+};

--- a/test/util/browser/test.html
+++ b/test/util/browser/test.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Test - Browser Util</title>
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    require(['test/util/browser/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/test/util/browser/test.js
+++ b/test/util/browser/test.js
@@ -1,0 +1,98 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ *
+ */
+define(['jquery', 'util/browser'], function ($, browser) {
+    'use strict';
+
+    QUnit.module('API');
+
+    QUnit.test('eventifier', function (assert) {
+        assert.expect(1);
+
+        assert.ok(typeof browser.isIOs === 'function', 'the isIOs method is exposed');
+    });
+
+    let initialPlatform;
+    let initialMaxTouchPoints;
+    QUnit.module('Methods', {
+        beforeEach() {
+            initialPlatform = window.navigator.platform;
+            initialMaxTouchPoints = window.navigator.maxTouchPoints;
+        },
+        afterEach() {
+            Object.defineProperty(window.navigator, 'platform', {
+                get: () => initialPlatform,
+                configurable: true
+            });
+            Object.defineProperty(window.navigator, 'maxTouchPoints', {
+                get: () => initialMaxTouchPoints,
+                configurable: true
+            });
+            delete window.MSStream;
+        }
+    });
+
+    QUnit.cases
+        .init([
+            { title: 'test runtime', result: false },
+            {
+                title: 'iphone',
+                result: true,
+                platform: 'iPhone'
+            },
+            {
+                title: 'ipad',
+                result: true,
+                platform: 'MacIntel',
+                maxTouchPoints: 2
+            },
+            {
+                title: 'macOs',
+                result: false,
+                platform: 'MacIntel',
+                maxTouchPoints: 0
+            },
+            {
+                title: 'ie11 on gmail',
+                result: false,
+                msstream: true
+            }
+        ])
+        .test('isIOs', function (data, assert) {
+            if (typeof data.platform !== 'undefined') {
+                Object.defineProperty(window.navigator, 'platform', {
+                    get: () => data.platform,
+                    configurable: true
+                });
+            }
+            if (typeof data.maxTouchPoints !== 'undefined') {
+                Object.defineProperty(window.navigator, 'maxTouchPoints', {
+                    get: () => data.maxTouchPoints,
+                    configurable: true
+                });
+            }
+            if (typeof data.msstream !== 'undefined') {
+                window.MSStream = data.msstream;
+            }
+
+            assert.expect(1);
+
+            assert.equal(browser.isIOs(), data.result);
+        });
+});


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-3071

 - Since it's done in a lot of places and I needed it, I've created a small util to centralize the browser detection  - it's one of those situations where you can't rely feature detection :/ 

How to test:
 - run the unit tests
 - test along with the other PRs 