### PR TITLE
Feature/fun 509 oauth2 token handler

### DIFF
--- a/test/core/jwt/jwtTokenHandler/test.html
+++ b/test/core/jwt/jwtTokenHandler/test.html
@@ -38,6 +38,12 @@
                             },
                             setAccessTokenTTL(newAccessTokenTTL) {
                                 accessTokenTTL = newAccessTokenTTL;
+                            },
+                            setTokens(newAccessToken, newRefreshToken) {
+                                accessToken = newAccessToken;
+                                refreshToken = newRefreshToken;
+                                accessTokenStoredAt = Date.now();
+                                return Promise.resolve(true);
                             }
                         };
                     });


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/FUN-509

Goal is to implement https://oauth2.thephpleague.com/authorization-server/refresh-token-grant/
The different between the required oauth2 request and the original OAT JWT token request is:
**Request:**
- refresh token is called `refresh_token` in the request
- request format is FormData instead of json
- `client_id` and `grant_type` should be sent, but this is handled with the existing `refreshTokenParameters`

**Response:**
- access token is called `access_token` in the response
- refresh token is sent in the response and it is called `refresh_token`
- `expires_in` is sent in the response and this is the TTL of the access token in seconds

These differences could be handled with some conditions, so I made the decision to do not create a new token handler, but modify the existing one.

### Test:
- run tests and check them, because they covers everything

(I tested it with @peetya on his local environment, where this modification will be necessary)

Now, it is not possible to test in a working environment, because it is just a small part of big refactoring.