### PR TITLE
Fix/TR-3995/Max words restriction can be exceeded

### DIFF
--- a/src/util/strLimiter.js
+++ b/src/util/strLimiter.js
@@ -49,8 +49,8 @@ export default {
             if (!words) {
                 return '';
             }
-            const count = limit;
-            limit = Math.max(0, limit - words.length);
+            const count = Math.max(0, limit);
+            limit = Math.max(0, count - words.length);
             return words.slice(0, count).join('') + ((trailing && trailing[0]) || '');
         };
 

--- a/test/util/strLimiter/test.js
+++ b/test/util/strLimiter/test.js
@@ -13,54 +13,63 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2018 Open Assessment Technologies SA
- *
- *
+ * Copyright (c) 2018-2022 Open Assessment Technologies SA
  */
 define(['util/strLimiter'], function(strLimiter) {
     'use strict';
 
-    var txt = 'Lorem ipsum dolor sit amet'; // 5 words, 26 characters
+    QUnit.module('strLimiter');
 
-    var weirdWhiteSpace = 'Lorem    ipsum   dolor  sit   amet';
-
-    QUnit.module('API');
-
-    QUnit.test('Limit by Word Count', function(assert) {
-        assert.equal(
-            strLimiter.limitByWordCount(txt, 5),
-            'Lorem ipsum dolor sit amet',
-            'Word count, input already correct size'
-        );
-        assert.equal(strLimiter.limitByWordCount(txt, 10), 'Lorem ipsum dolor sit amet', 'Word count, input too short');
-        assert.equal(strLimiter.limitByWordCount(txt, 2), 'Lorem ipsum', 'Word count, input too long');
+    QUnit.cases.init([{
+        title: 'input already at the limit',
+        limit: 5,
+        input: 'Lorem ipsum dolor sit amet',
+        expected: 'Lorem ipsum dolor sit amet'
+    }, {
+        title: 'input below the limit',
+        limit: 10,
+        input: 'Lorem ipsum dolor sit amet',
+        expected: 'Lorem ipsum dolor sit amet'
+    }, {
+        title: 'input above the limit',
+        limit: 2,
+        input: 'Lorem ipsum dolor sit amet',
+        expected: 'Lorem ipsum'
+    }, {
+        title: 'input already at the limit - with long spaces',
+        limit: 5,
+        input: 'Lorem    ipsum   dolor  sit   amet',
+        expected: 'Lorem    ipsum   dolor  sit   amet'
+    }, {
+        title: 'input below the limit - with long spaces',
+        limit: 10,
+        input: 'Lorem    ipsum   dolor  sit   amet',
+        expected: 'Lorem    ipsum   dolor  sit   amet'
+    }, {
+        title: 'input above the limit - with long spaces',
+        limit: 2,
+        input: 'Lorem    ipsum   dolor  sit   amet',
+        expected: 'Lorem    ipsum'
+    }]).test('limitByWordCount ', (data, assert) => {
+        assert.equal(strLimiter.limitByWordCount(data.input, data.limit), data.expected, `Limit by ${data.limit} words`);
     });
 
-    QUnit.test('Limit by Word Count, weird whitespace', function(assert) {
-        assert.equal(
-            strLimiter.limitByWordCount(weirdWhiteSpace, 5),
-            'Lorem    ipsum   dolor  sit   amet',
-            'Word count, input already correct size'
-        );
-        assert.equal(
-            strLimiter.limitByWordCount(weirdWhiteSpace, 10),
-            'Lorem    ipsum   dolor  sit   amet',
-            'Word count, input too short'
-        );
-        assert.equal(strLimiter.limitByWordCount(weirdWhiteSpace, 2), 'Lorem    ipsum', 'Word count, input too long');
-    });
-
-    QUnit.test('Limit by Character count', function(assert) {
-        assert.equal(
-            strLimiter.limitByCharCount(txt, 26),
-            'Lorem ipsum dolor sit amet',
-            'Char count, input already correct size'
-        );
-        assert.equal(
-            strLimiter.limitByCharCount(txt, 100),
-            'Lorem ipsum dolor sit amet',
-            'Char count, input too short'
-        );
-        assert.equal(strLimiter.limitByCharCount(txt, 11), 'Lorem ipsum', 'Char count, input too long');
+    QUnit.cases.init([{
+        title: 'input already at the limit',
+        limit: 26,
+        input: 'Lorem ipsum dolor sit amet',
+        expected: 'Lorem ipsum dolor sit amet'
+    }, {
+        title: 'input below the limit',
+        limit: 100,
+        input: 'Lorem ipsum dolor sit amet',
+        expected: 'Lorem ipsum dolor sit amet'
+    }, {
+        title: 'input above the limit',
+        limit: 11,
+        input: 'Lorem ipsum dolor sit amet',
+        expected: 'Lorem ipsum'
+    }]).test('limitByCharCount ', (data, assert) => {
+        assert.equal(strLimiter.limitByCharCount(data.input, data.limit), data.expected, `Limit by ${data.limit} characters`);
     });
 });

--- a/test/util/strLimiter/test.js
+++ b/test/util/strLimiter/test.js
@@ -44,6 +44,8 @@ define(['util/strLimiter'], function(strLimiter) {
         assert.equal(strLimiter.limitByWordCount(data.input, 5), data.unlimited, 'Limited by 5 words');
         assert.equal(strLimiter.limitByWordCount(data.input, 10), data.unlimited, 'Limited by 10 words');
         assert.equal(strLimiter.limitByWordCount(data.input, 2), data.limited, 'Limited by 2 words');
+        assert.equal(strLimiter.limitByWordCount(data.input, 0), '', 'Limited by 0 words');
+        assert.equal(strLimiter.limitByWordCount(data.input, -2), '', 'Limited by negative value');
     });
 
     QUnit.cases.init([{
@@ -61,6 +63,51 @@ define(['util/strLimiter'], function(strLimiter) {
         limit: 11,
         input: 'Lorem ipsum dolor sit amet',
         expected: 'Lorem ipsum'
+    // }, {
+    //     title: 'input already at the limit - with long spaces',
+    //     limit: 34,
+    //     input: 'Lorem    ipsum   dolor  sit   amet',
+    //     expected: 'Lorem    ipsum   dolor  sit   amet'
+    // }, {
+    //     title: 'input below the limit - with long spaces',
+    //     limit: 100,
+    //     input: 'Lorem    ipsum   dolor  sit   amet',
+    //     expected: 'Lorem    ipsum   dolor  sit   amet'
+    // }, {
+    //     title: 'input above the limit - with long spaces',
+    //     limit: 14,
+    //     input: 'Lorem    ipsum   dolor  sit   amet',
+    //     expected: 'Lorem    ipsum'
+    // }, {
+    //     title: 'input already at the limit - with tags',
+    //     limit: 26,
+    //     input: '<p>Lorem</p><p>ipsum</p><p>dolor</p><p>sit</p><p>amet</p>',
+    //     expected: '<p>Lorem</p><p>ipsum</p><p>dolor</p><p>sit</p><p>amet</p>'
+    // }, {
+    //     title: 'input below the limit - with tags',
+    //     limit: 100,
+    //     input: '<p>Lorem</p><p>ipsum</p><p>dolor</p><p>sit</p><p>amet</p>',
+    //     expected: '<p>Lorem</p><p>ipsum</p><p>dolor</p><p>sit</p><p>amet</p>'
+    // }, {
+    //     title: 'input above the limit - with tags',
+    //     limit: 11,
+    //     input: '<p>Lorem</p><p>ipsum</p><p>dolor</p><p>sit</p><p>amet</p>',
+    //     expected: '<p>Lorem</p><p>ipsum</p>'
+    // }, {
+    //     title: 'input already at the limit - with entities',
+    //     limit: 26,
+    //     input: '<p>Lorem&nbsp;ipsum&nbsp;dolor&nbsp;sit&nbsp;amet</p>',
+    //     expected: '<p>Lorem&nbsp;ipsum&nbsp;dolor&nbsp;sit&nbsp;amet</p>'
+    // }, {
+    //     title: 'input below the limit - with entities',
+    //     limit: 100,
+    //     input: '<p>Lorem&nbsp;ipsum&nbsp;dolor&nbsp;sit&nbsp;amet</p>',
+    //     expected: '<p>Lorem&nbsp;ipsum&nbsp;dolor&nbsp;sit&nbsp;amet</p>'
+    // }, {
+    //     title: 'input above the limit - with entities',
+    //     limit: 11,
+    //     input: '<p>Lorem&nbsp;ipsum&nbsp;dolor&nbsp;sit&nbsp;amet</p>',
+    //     expected: '<p>Lorem&nbsp;ipsum</p>'
     }]).test('limitByCharCount ', (data, assert) => {
         assert.equal(strLimiter.limitByCharCount(data.input, data.limit), data.expected, `Limit by ${data.limit} characters`);
     });

--- a/test/util/strLimiter/test.js
+++ b/test/util/strLimiter/test.js
@@ -21,37 +21,29 @@ define(['util/strLimiter'], function(strLimiter) {
     QUnit.module('strLimiter');
 
     QUnit.cases.init([{
-        title: 'input already at the limit',
-        limit: 5,
+        title: 'plain text',
         input: 'Lorem ipsum dolor sit amet',
-        expected: 'Lorem ipsum dolor sit amet'
+        unlimited: 'Lorem ipsum dolor sit amet',
+        limited: 'Lorem ipsum'
     }, {
-        title: 'input below the limit',
-        limit: 10,
-        input: 'Lorem ipsum dolor sit amet',
-        expected: 'Lorem ipsum dolor sit amet'
+        title: 'plain text with long spaces',
+        input: '  Lorem    ipsum   dolor  sit   amet  ',
+        unlimited: '  Lorem    ipsum   dolor  sit   amet',
+        limited: '  Lorem    ipsum'
     }, {
-        title: 'input above the limit',
-        limit: 2,
-        input: 'Lorem ipsum dolor sit amet',
-        expected: 'Lorem ipsum'
+        title: 'simple HTML',
+        input: '<p>Lorem ipsum dolor sit amet</p>',
+        unlimited: '<p>Lorem ipsum dolor sit amet</p>',
+        limited: '<p>Lorem ipsum</p>'
     }, {
-        title: 'input already at the limit - with long spaces',
-        limit: 5,
-        input: 'Lorem    ipsum   dolor  sit   amet',
-        expected: 'Lorem    ipsum   dolor  sit   amet'
-    }, {
-        title: 'input below the limit - with long spaces',
-        limit: 10,
-        input: 'Lorem    ipsum   dolor  sit   amet',
-        expected: 'Lorem    ipsum   dolor  sit   amet'
-    }, {
-        title: 'input above the limit - with long spaces',
-        limit: 2,
-        input: 'Lorem    ipsum   dolor  sit   amet',
-        expected: 'Lorem    ipsum'
+        title: 'glued HTML',
+        input: '<p> Lorem </p><p> ipsum <br></p><p> dolor </p><p> sit </p><p> amet </p>',
+        unlimited: '<p> Lorem </p><p> ipsum <br></p><p> dolor </p><p> sit </p><p> amet </p>',
+        limited: '<p> Lorem </p><p> ipsum <br></p>'
     }]).test('limitByWordCount ', (data, assert) => {
-        assert.equal(strLimiter.limitByWordCount(data.input, data.limit), data.expected, `Limit by ${data.limit} words`);
+        assert.equal(strLimiter.limitByWordCount(data.input, 5), data.unlimited, 'Limited by 5 words');
+        assert.equal(strLimiter.limitByWordCount(data.input, 10), data.unlimited, 'Limited by 10 words');
+        assert.equal(strLimiter.limitByWordCount(data.input, 2), data.limited, 'Limited by 2 words');
     });
 
     QUnit.cases.init([{

--- a/test/util/strLimiter/test.js
+++ b/test/util/strLimiter/test.js
@@ -15,100 +15,110 @@
  *
  * Copyright (c) 2018-2022 Open Assessment Technologies SA
  */
-define(['util/strLimiter'], function(strLimiter) {
+define(['util/strLimiter'], function (strLimiter) {
     'use strict';
 
     QUnit.module('strLimiter');
 
-    QUnit.cases.init([{
-        title: 'plain text',
-        input: 'Lorem ipsum dolor sit amet',
-        unlimited: 'Lorem ipsum dolor sit amet',
-        limited: 'Lorem ipsum'
-    }, {
-        title: 'plain text with long spaces',
-        input: '  Lorem    ipsum   dolor  sit   amet  ',
-        unlimited: '  Lorem    ipsum   dolor  sit   amet',
-        limited: '  Lorem    ipsum'
-    }, {
-        title: 'simple HTML',
-        input: '<p>Lorem ipsum dolor sit amet</p>',
-        unlimited: '<p>Lorem ipsum dolor sit amet</p>',
-        limited: '<p>Lorem ipsum</p>'
-    }, {
-        title: 'glued HTML',
-        input: '<p> Lorem </p><p> ipsum <br></p><p> dolor </p><p> sit </p><p> amet </p>',
-        unlimited: '<p> Lorem </p><p> ipsum <br></p><p> dolor </p><p> sit </p><p> amet </p>',
-        limited: '<p> Lorem </p><p> ipsum <br></p>'
-    }]).test('limitByWordCount ', (data, assert) => {
-        assert.equal(strLimiter.limitByWordCount(data.input, 5), data.unlimited, 'Limited by 5 words');
-        assert.equal(strLimiter.limitByWordCount(data.input, 10), data.unlimited, 'Limited by 10 words');
-        assert.equal(strLimiter.limitByWordCount(data.input, 2), data.limited, 'Limited by 2 words');
-        assert.equal(strLimiter.limitByWordCount(data.input, 0), '', 'Limited by 0 words');
-        assert.equal(strLimiter.limitByWordCount(data.input, -2), '', 'Limited by negative value');
-    });
+    QUnit.cases
+        .init([
+            {
+                title: 'plain text',
+                input: 'Lorem ipsum dolor sit amet',
+                unlimited: 'Lorem ipsum dolor sit amet',
+                limited: 'Lorem ipsum'
+            },
+            {
+                title: 'plain text with long spaces',
+                input: '  Lorem    ipsum   dolor  sit   amet  ',
+                unlimited: '  Lorem    ipsum   dolor  sit   amet',
+                limited: '  Lorem    ipsum'
+            },
+            {
+                title: 'simple HTML',
+                input: '<p>Lorem ipsum dolor sit amet</p>',
+                unlimited: '<p>Lorem ipsum dolor sit amet</p>',
+                limited: '<p>Lorem ipsum</p>'
+            },
+            {
+                title: 'glued HTML',
+                input: '<p> Lorem </p><p> ipsum <br></p><p> dolor </p><p> sit </p><p> amet </p>',
+                unlimited: '<p> Lorem </p><p> ipsum <br></p><p> dolor </p><p> sit </p><p> amet </p>',
+                limited: '<p> Lorem </p><p> ipsum <br></p>'
+            }
+        ])
+        .test('limitByWordCount ', (data, assert) => {
+            assert.equal(strLimiter.limitByWordCount(data.input, 5), data.unlimited, 'Limited by 5 words');
+            assert.equal(strLimiter.limitByWordCount(data.input, 10), data.unlimited, 'Limited by 10 words');
+            assert.equal(strLimiter.limitByWordCount(data.input, 2), data.limited, 'Limited by 2 words');
+            assert.equal(strLimiter.limitByWordCount(data.input, 0), '', 'Limited by 0 words');
+            assert.equal(strLimiter.limitByWordCount(data.input, -2), '', 'Limited by negative value');
+        });
 
-    QUnit.cases.init([{
-        title: 'input already at the limit',
-        limit: 26,
-        input: 'Lorem ipsum dolor sit amet',
-        expected: 'Lorem ipsum dolor sit amet'
-    }, {
-        title: 'input below the limit',
-        limit: 100,
-        input: 'Lorem ipsum dolor sit amet',
-        expected: 'Lorem ipsum dolor sit amet'
-    }, {
-        title: 'input above the limit',
-        limit: 11,
-        input: 'Lorem ipsum dolor sit amet',
-        expected: 'Lorem ipsum'
-    // }, {
-    //     title: 'input already at the limit - with long spaces',
-    //     limit: 34,
-    //     input: 'Lorem    ipsum   dolor  sit   amet',
-    //     expected: 'Lorem    ipsum   dolor  sit   amet'
-    // }, {
-    //     title: 'input below the limit - with long spaces',
-    //     limit: 100,
-    //     input: 'Lorem    ipsum   dolor  sit   amet',
-    //     expected: 'Lorem    ipsum   dolor  sit   amet'
-    // }, {
-    //     title: 'input above the limit - with long spaces',
-    //     limit: 14,
-    //     input: 'Lorem    ipsum   dolor  sit   amet',
-    //     expected: 'Lorem    ipsum'
-    // }, {
-    //     title: 'input already at the limit - with tags',
-    //     limit: 26,
-    //     input: '<p>Lorem</p><p>ipsum</p><p>dolor</p><p>sit</p><p>amet</p>',
-    //     expected: '<p>Lorem</p><p>ipsum</p><p>dolor</p><p>sit</p><p>amet</p>'
-    // }, {
-    //     title: 'input below the limit - with tags',
-    //     limit: 100,
-    //     input: '<p>Lorem</p><p>ipsum</p><p>dolor</p><p>sit</p><p>amet</p>',
-    //     expected: '<p>Lorem</p><p>ipsum</p><p>dolor</p><p>sit</p><p>amet</p>'
-    // }, {
-    //     title: 'input above the limit - with tags',
-    //     limit: 11,
-    //     input: '<p>Lorem</p><p>ipsum</p><p>dolor</p><p>sit</p><p>amet</p>',
-    //     expected: '<p>Lorem</p><p>ipsum</p>'
-    // }, {
-    //     title: 'input already at the limit - with entities',
-    //     limit: 26,
-    //     input: '<p>Lorem&nbsp;ipsum&nbsp;dolor&nbsp;sit&nbsp;amet</p>',
-    //     expected: '<p>Lorem&nbsp;ipsum&nbsp;dolor&nbsp;sit&nbsp;amet</p>'
-    // }, {
-    //     title: 'input below the limit - with entities',
-    //     limit: 100,
-    //     input: '<p>Lorem&nbsp;ipsum&nbsp;dolor&nbsp;sit&nbsp;amet</p>',
-    //     expected: '<p>Lorem&nbsp;ipsum&nbsp;dolor&nbsp;sit&nbsp;amet</p>'
-    // }, {
-    //     title: 'input above the limit - with entities',
-    //     limit: 11,
-    //     input: '<p>Lorem&nbsp;ipsum&nbsp;dolor&nbsp;sit&nbsp;amet</p>',
-    //     expected: '<p>Lorem&nbsp;ipsum</p>'
-    }]).test('limitByCharCount ', (data, assert) => {
-        assert.equal(strLimiter.limitByCharCount(data.input, data.limit), data.expected, `Limit by ${data.limit} characters`);
-    });
+    QUnit.cases
+        .init([
+            {
+                title: 'plain text',
+                length: 26,
+                limit: 11,
+                input: 'Lorem ipsum dolor sit amet',
+                unlimited: 'Lorem ipsum dolor sit amet',
+                limited: 'Lorem ipsum'
+            },
+            {
+                title: 'plain text with long spaces',
+                length: 38,
+                limit: 19,
+                input: '  Lorem    ipsum   dolor  sit   amet  ',
+                unlimited: '  Lorem    ipsum   dolor  sit   amet  ',
+                limited: '  Lorem    ipsum   '
+            },
+            {
+                title: 'plain text with entities',
+                length: 36,
+                limit: 14,
+                input: 'Lorem &nbsp;&nbsp; ipsum &nbsp; dolor &eacute; sit &agrave; amet',
+                unlimited: 'Lorem &nbsp;&nbsp; ipsum &nbsp; dolor &eacute; sit &agrave; amet',
+                limited: 'Lorem &nbsp;&nbsp; ipsum'
+            },
+            {
+                title: 'simple HTML',
+                length: 26,
+                limit: 11,
+                input: '<p>Lorem ipsum dolor sit amet</p>',
+                unlimited: '<p>Lorem ipsum dolor sit amet</p>',
+                limited: '<p>Lorem ipsum</p>'
+            },
+            {
+                title: 'glued HTML',
+                length: 32,
+                limit: 14,
+                input: '<p> Lorem </p><p> ipsum <br></p><p> dolor </p><p> sit </p><p> amet </p>',
+                unlimited: '<p> Lorem </p><p> ipsum <br></p><p> dolor </p><p> sit </p><p> amet </p>',
+                limited: '<p> Lorem </p><p> ipsum <br></p>'
+            },
+            {
+                title: 'simple HTML with entities',
+                length: 36,
+                limit: 14,
+                input: '<p>Lorem &nbsp;&nbsp; ipsum &nbsp; dolor &nbsp; sit &nbsp; amet</p>',
+                unlimited: '<p>Lorem &nbsp;&nbsp; ipsum &nbsp; dolor &nbsp; sit &nbsp; amet</p>',
+                limited: '<p>Lorem &nbsp;&nbsp; ipsum</p>'
+            }
+        ])
+        .test('limitByCharCount ', (data, assert) => {
+            assert.equal(
+                strLimiter.limitByCharCount(data.input, data.length),
+                data.unlimited,
+                `Limit by ${data.length} characters`
+            );
+            assert.equal(strLimiter.limitByCharCount(data.input, 100), data.unlimited, `Limit by 100 characters`);
+            assert.equal(
+                strLimiter.limitByCharCount(data.input, data.limit),
+                data.limited,
+                `Limit by ${data.limit} characters`
+            );
+            assert.equal(strLimiter.limitByCharCount(data.input, 0), '', 'Limit by 0 characters');
+            assert.equal(strLimiter.limitByCharCount(data.input, -2), '', 'Limit by  negative value');
+        });
 });


### PR DESCRIPTION
1/4

Related to: https://oat-sa.atlassian.net/browse/TR-3995

The helper `util/strLimiter` is aimed at limiting a text to a maximum number of units, either chars or words. Unfortunately, so far it was exclusively expecting plain text and it was producing wrong results with HTML.

This pull request proposes to support either plain text or HTML text.

How to test:
- run the unit tests
- create a test having extended text interactions with a constraint for the max words and for the max length (a test sample is attached to the ticket).
- publish the test, then take it
- type some text in the extended text interaction, then copy it and paste it until the limit is reached.
- try to exhaust the limit by pasting again
- remove a few words, ideally less than the number in the clipboard, then paste again

Without the fix, the limit can be overflown.
With the fix, we cannot overflow the limit.