### PR TITLE
Force the babel object spread plugin

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -89,7 +89,8 @@ export default inputs.map(input => {
                     [
                         '@babel/env',
                         {
-                            useBuiltIns: false
+                            useBuiltIns: false,
+                            include: ['@babel/plugin-proposal-object-rest-spread']
                         }
                     ]
                 ]


### PR DESCRIPTION
- r.js parser doesn't support object spread, so we need to force the transpilation