### PR TITLE
Fix/ADF-1166/ESlint errors in utils source code

### DIFF
--- a/src/util/adaptSize.js
+++ b/src/util/adaptSize.js
@@ -22,39 +22,39 @@ import capitalize from 'util/capitalize';
 /**
  * Adapts the size of several elements
  */
-var adaptSize = (function() {
+const adaptSize = (function () {
     /**
      * The actual resize function
      *
-     * @param {jQueryElements} elements
+     * @param {jQueryElements} $elements
      * @param {Object} dimensions
      * @private
      */
-    var _resize = function($elements, dimensions) {
+    function _resize($elements, dimensions) {
         // This whole function is based on calculating the largest height/width.
         // Therefor the elements need to have style.height/width to be removed
         // otherwise we could never track when something is actually getting smaller than before.
-        $elements.each(function() {
-            for (var dimension in dimensions) {
-                if (dimensions.hasOwnProperty(dimension)) {
+        $elements.each(function () {
+            for (const dimension in dimensions) {
+                if (Object.prototype.hasOwnProperty.call(dimensions, dimension)) {
                     $(this)[dimension]('auto');
                 }
             }
         });
 
-        $elements.each(function() {
-            for (var dimension in dimensions) {
-                if (dimensions.hasOwnProperty(dimension)) {
+        $elements.each(function () {
+            for (const dimension in dimensions) {
+                if (Object.prototype.hasOwnProperty.call(dimensions, dimension)) {
                     dimensions[dimension] = Math.max(
                         Math.floor(dimensions[dimension] || 0),
-                        $(this)['outer' + capitalize(dimension)]()
+                        $(this)[`outer${capitalize(dimension)}`]()
                     );
                 }
             }
         });
 
         $elements.css(dimensions);
-    };
+    }
 
     return {
         /**
@@ -63,7 +63,7 @@ var adaptSize = (function() {
          * @param {jQueryElements} $elements
          * @param {Integer|undefined} [minWidth] default: 0
          */
-        width: function($elements, minWidth) {
+        width($elements, minWidth) {
             _resize($elements, { width: minWidth });
         },
 
@@ -73,7 +73,7 @@ var adaptSize = (function() {
          * @param {jQueryElements} $elements
          * @param {Integer|undefined}[minHeight] default: 0
          */
-        height: function($elements, minHeight) {
+        height($elements, minHeight) {
             _resize($elements, { height: minHeight });
         },
 
@@ -84,7 +84,7 @@ var adaptSize = (function() {
          * @param {Integer|undefined} [minWidth] default: 0
          * @param {Integer|undefined} [minHeight] default: 0
          */
-        both: function($elements, minWidth, minHeight) {
+        both($elements, minWidth, minHeight) {
             _resize($elements, { height: minHeight, width: minWidth });
         },
 
@@ -93,7 +93,7 @@ var adaptSize = (function() {
          *
          * @param {jQueryElements} $elements
          */
-        resetHeight: function($elements) {
+        resetHeight($elements) {
             $elements.height('auto');
         }
     };

--- a/src/util/clipboard.js
+++ b/src/util/clipboard.js
@@ -33,17 +33,16 @@ export default eventifier({
      * Cleans system clipboard
      * rewrites everything with space symbol (because some browsers don't replace content with empty string)
      */
-    clean: function clean() {
+    clean() {
         this.copy(' ');
     },
     /**
      * Place text to the system clipboard
-     * @param text
+     * @param {string} text
      */
-    copy: function copy(text) {
+    copy(text) {
         // create new el to copy from
-        var textAreaToSelContent;
-        textAreaToSelContent = document.createElement('textarea'); // Create a <textarea> element
+        const textAreaToSelContent = document.createElement('textarea'); // Create a <textarea> element
         textAreaToSelContent.setAttribute('id', 'clipboardCleanerPlugin');
         textAreaToSelContent.value = text; // Set its value to the string that you want copied
         textAreaToSelContent.setAttribute('readonly', ''); // Make it readonly to be tamper-proof
@@ -55,36 +54,37 @@ export default eventifier({
     },
     /**
      * Copy text from the element (js or jquery element)
-     * @param elem
+     * @param {jQuery|HTMLElement} elem
      * @fires clipboard#copied - content successfully stored in clipboard
      * @fires clipboard#copyError - content was not stored, returns reason
      */
-    copyFromEl: function copyFromEl(elem) {
-        var textRange, editable, readOnly, range, sel, successful, el;
-
-        el = elem instanceof $ ? elem.get(0) : elem;
+    copyFromEl(elem) {
+        const el = elem instanceof $ ? elem.get(0) : elem;
 
         // Copy textarea, pre, div, etc.
         if (document.body.createTextRange) {
             // IE
-            textRange = document.body.createTextRange();
+            const textRange = document.body.createTextRange();
             textRange.moveToElementText(el);
             textRange.select();
             textRange.execCommand('Copy');
             this.trigger('copied', { srcEl: el });
         } else if (window.getSelection && document.createRange) {
+            let editable;
+            let readOnly;
+
             // non-IE
-            if (el.hasOwnProperty('contentEditable')) {
+            if (Object.prototype.hasOwnProperty.call(el, 'contentEditable')) {
                 editable = el.contentEditable; // Record contentEditable status of element
                 el.contentEditable = true; // iOS will only select text on non-form elements if contentEditable = true;
             }
-            if (el.hasOwnProperty('readOnly')) {
+            if (Object.prototype.hasOwnProperty.call(el, 'readOnly')) {
                 readOnly = el.readOnly; // Record readOnly status of element
                 el.readOnly = false; // iOS will not select in a read only form element
             }
-            range = document.createRange();
+            const range = document.createRange();
             range.selectNodeContents(el);
-            sel = window.getSelection();
+            const sel = window.getSelection();
             sel.removeAllRanges();
             sel.addRange(range); // Does not work for Firefox if a textarea or input
             if (el.nodeName === 'TEXTAREA' || el.nodeName === 'INPUT') {
@@ -93,14 +93,14 @@ export default eventifier({
             if (el.setSelectionRange && navigator.userAgent.match(/ipad|ipod|iphone/i)) {
                 el.setSelectionRange(0, 999999); // iOS only selects "form" elements with SelectionRange
             }
-            if (el.hasOwnProperty('contentEditable')) {
+            if (Object.prototype.hasOwnProperty.call(el, 'contentEditable')) {
                 el.contentEditable = editable; // Restore previous contentEditable status
             }
-            if (el.hasOwnProperty('readOnly')) {
+            if (Object.prototype.hasOwnProperty.call(el, 'readOnly')) {
                 el.readOnly = readOnly; // Restore previous readOnly status
             }
             if (document.queryCommandSupported('copy')) {
-                successful = document.execCommand('copy');
+                const successful = document.execCommand('copy');
                 if (successful) {
                     this.trigger('copied', { srcEl: elem });
                 } else {
@@ -117,14 +117,12 @@ export default eventifier({
      * Paste from clipboard
      * doesn't work for many browsers
      * can be useful article to use it (if required): https://developers.google.com/web/updates/2018/03/clipboardapi
-     * @param elem
+     * @param {jQuery|HTMLElement} elem
      * @fires clipboard#pasted - content from clipboard pasted
      * @fires clipboard#pasteError - content wasn't pasted
      */
-    paste: function paste(elem) {
-        var el, editable, readOnly, range, sel, successful;
-
-        el = elem instanceof $ ? elem.get(0) : elem;
+    paste(elem) {
+        const el = elem instanceof $ ? elem.get(0) : elem;
 
         if (window.clipboardData) {
             // IE
@@ -137,13 +135,13 @@ export default eventifier({
             } else if (el.innerHTML.length < 1) {
                 el.innerHTML = '&nbsp;'; // iOS needs element not to be empty to select it and pop up 'paste' button
             }
-            editable = el.contentEditable; // Record contentEditable status of element
-            readOnly = el.readOnly; // Record readOnly status of element
+            const editable = el.contentEditable; // Record contentEditable status of element
+            const readOnly = el.readOnly; // Record readOnly status of element
             el.contentEditable = true; // iOS will only select text on non-form elements if contentEditable = true;
             el.readOnly = false; // iOS will not select in a read only form element
-            range = document.createRange();
+            const range = document.createRange();
             range.selectNodeContents(el);
-            sel = window.getSelection();
+            const sel = window.getSelection();
             sel.removeAllRanges();
             sel.addRange(range);
             if (el.nodeName === 'TEXTAREA' || el.nodeName === 'INPUT') {
@@ -153,7 +151,7 @@ export default eventifier({
                 el.setSelectionRange(0, 999999); // iOS only selects "form" elements with SelectionRange
             }
             if (document.queryCommandSupported('paste')) {
-                successful = document.execCommand('Paste');
+                const successful = document.execCommand('Paste');
                 if (successful) {
                     this.trigger('pasted', { srcEl: elem });
                 } else {

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -30,7 +30,7 @@ export default {
      * @returns {Object}
      * @throws Error if a required entry is missing
      */
-    build: function build(config, defaults) {
+    build(config, defaults) {
         return _.defaults(config || {}, defaults);
     },
 
@@ -44,13 +44,13 @@ export default {
      * @returns {Object}
      * @throws Error if a required entry is missing
      */
-    from: function from(source, entries, defaults) {
-        var config = {};
-        _.forEach(entries, function(value, name) {
+    from(source, entries, defaults) {
+        const config = {};
+        _.forEach(entries, (value, name) => {
             if ('undefined' !== typeof source[name]) {
                 config[name] = source[name];
             } else if (value) {
-                throw new Error('The config entry "' + name + '" is required!');
+                throw new Error(`The config entry "${name}" is required!`);
             }
         });
         return _.defaults(config, defaults);

--- a/src/util/download.js
+++ b/src/util/download.js
@@ -40,9 +40,7 @@ const type = iOS ? 'data:application/octet-stream' : 'data:text/plain';
  * @throws {TypeError}
  * @returns {Boolean}
  */
-var download = function download(filename, content) {
-    var element;
-
+function download(filename, content) {
     if (_.isEmpty(filename) || !_.isString(filename)) {
         throw new TypeError('Invalid filename');
     }
@@ -60,16 +58,16 @@ var download = function download(filename, content) {
         return true;
     }
 
-    element = document.createElement('a');
+    const element = document.createElement('a');
     iOS && element.setAttribute('target', '_blank');
-    element.setAttribute('href', type + ';charset=utf-8,' + encodeURIComponent(content));
+    element.setAttribute('href', `${type};charset=utf-8,${encodeURIComponent(content)}`);
     element.setAttribute('download', filename);
     element.style.display = 'none';
     document.body.appendChild(element);
     element.click();
     document.body.removeChild(element);
     return true;
-};
+}
 
 /**
  * @exports download

--- a/src/util/encode.js
+++ b/src/util/encode.js
@@ -22,8 +22,8 @@
  * @author dieter <dieter@taotesting.com>
  */
 
-var _reQuot = /"/g;
-var _reApos = /'/g;
+const _reQuot = /"/g;
+const _reApos = /'/g;
 
 /**
  * Encodes an HTML string to be safely displayed without code interpretation
@@ -31,10 +31,10 @@ var _reApos = /'/g;
  * @param {String} html
  * @returns {String}
  */
-var encodeHTML = function encodeHTML(html) {
+function encodeHTML(html) {
     // @see http://tinyurl.com/ko75kph
     return document.createElement('a').appendChild(document.createTextNode(html)).parentNode.innerHTML;
-};
+}
 
 /**
  * Encodes an HTML string to be safely use inside an attribute
@@ -42,13 +42,11 @@ var encodeHTML = function encodeHTML(html) {
  * @param {String} html
  * @returns {String}
  */
-var encodeAttribute = function encodeAttribute(html) {
+function encodeAttribute(html) {
     // use replaces chain instead of unified replace with map for performances reasons
     // @see http://jsperf.com/htmlencoderegex/68
-    return encodeHTML(html)
-        .replace(_reQuot, '&quot;')
-        .replace(_reApos, '&apos;');
-};
+    return encodeHTML(html).replace(_reQuot, '&quot;').replace(_reApos, '&apos;');
+}
 
 /**
  * Encodes a Unicode string to Base64.
@@ -62,7 +60,7 @@ function encodeBase64(str) {
     // can be fed into btoa.
     return btoa(
         encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function toSolidBytes(match, p1) {
-            return String.fromCharCode('0x' + p1);
+            return String.fromCharCode(`0x${p1}`);
         })
     );
 }
@@ -77,8 +75,9 @@ function decodeBase64(str) {
     // Going backwards: from bytestream, to percent-encoding, to original string.
     return decodeURIComponent(
         Array.prototype.map
-            .call(atob(str), function(c) {
-                return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+            .call(atob(str), c => {
+                const num = `00${c.charCodeAt(0).toString(16)}`;
+                return `%${num.slice(-2)}`;
             })
             .join('')
     );

--- a/src/util/locale.js
+++ b/src/util/locale.js
@@ -23,7 +23,7 @@
 import module from 'module';
 import moment from 'moment';
 
-var configuration = module.config();
+let configuration = module.config();
 
 /**
  * Util object for manipulate locale dependent data
@@ -32,17 +32,17 @@ var configuration = module.config();
 export default {
     /**
      * Returns config of component
-     * @returns {*}
+     * @returns {object}
      */
-    getConfig: function getConfig() {
+    getConfig() {
         return configuration;
     },
 
     /**
      * Sets config of component
-     * @param config
+     * @param {object} config
      */
-    setConfig: function setConfig(config) {
+    setConfig(config) {
         configuration = config || {};
     },
 
@@ -50,7 +50,7 @@ export default {
      * Returns current system decimal separator
      * @returns {string}
      */
-    getDecimalSeparator: function getDecimalSeparator() {
+    getDecimalSeparator() {
         return this.getConfig() && this.getConfig().decimalSeparator ? this.getConfig().decimalSeparator : '.';
     },
 
@@ -58,15 +58,15 @@ export default {
      * Returns current system thousands separator
      * @returns {string}
      */
-    getThousandsSeparator: function getThousandsSeparator() {
+    getThousandsSeparator() {
         return this.getConfig() && this.getConfig().thousandsSeparator ? this.getConfig().thousandsSeparator : '';
     },
 
     /**
      * Returns datetime format
-     * @return {string}
+     * @returns {string}
      */
-    getDateTimeFormat: function getDateTimeFormat() {
+    getDateTimeFormat() {
         return this.getConfig() && this.getConfig().dateTimeFormat
             ? this.getConfig().dateTimeFormat
             : 'DD/MM/YYYY HH:mm:ss';
@@ -74,23 +74,21 @@ export default {
 
     /**
      * Parse float values with process locale features
-     * @param numStr
+     * @param {string} numStr
      * @returns {Number}
      */
-    parseFloat: function(numStr) {
-        var thousandsSeparator = this.getThousandsSeparator(),
-            decimalSeparator = this.getDecimalSeparator();
+    parseFloat(numStr) {
+        const thousandsSeparator = this.getThousandsSeparator();
+        const decimalSeparator = this.getDecimalSeparator();
 
         // discard all thousand separators:
         if (thousandsSeparator.length) {
-            numStr = numStr.replace(new RegExp('\\' + thousandsSeparator, 'g'), '');
+            numStr = numStr.replace(new RegExp(`\\${thousandsSeparator}`, 'g'), '');
         }
 
         // standardise the decimal separator as '.':
         if (decimalSeparator !== '.') {
-            numStr = numStr
-                .replace(new RegExp('\\' + '.', 'g'), '_')
-                .replace(new RegExp('\\' + decimalSeparator, 'g'), '.');
+            numStr = numStr.replace(new RegExp('\\.', 'g'), '_').replace(new RegExp(`\\${decimalSeparator}`, 'g'), '.');
         }
 
         // now the numeric string can be correctly parsed with the native parseFloat:
@@ -99,15 +97,15 @@ export default {
 
     /**
      * Parse integer values with process locale features
-     * @param number
-     * @param numericBase
+     * @param {string} number
+     * @param {number} numericBase
      * @returns {Number}
      */
-    parseInt: function(number, numericBase) {
-        var thousandsSeparator = this.getThousandsSeparator();
+    parseInt(number, numericBase) {
+        const thousandsSeparator = this.getThousandsSeparator();
 
         if (thousandsSeparator.length) {
-            number = number.replace(new RegExp('\\' + thousandsSeparator, 'g'), '');
+            number = number.replace(new RegExp(`\\${thousandsSeparator}`, 'g'), '');
         }
 
         return parseInt(number, numericBase);
@@ -118,7 +116,7 @@ export default {
      * Note that user's (browser's) timezone will be used by default, unless the utc parameter is set to true.
      * @param {Number} timestamp - The timestamp to format. It is considered as in the target timezone.
      * @param {Boolean} [utc=false] - For the UTC timezone. By default the user's timezone will be used.
-     * @return string
+     * @returns {string}
      */
     formatDateTime(timestamp, utc = false) {
         const datetime = utc ? moment.utc(timestamp, 'X') : moment(timestamp, 'X');
@@ -128,27 +126,24 @@ export default {
     /**
      * Determine direction for language
      * @param {String} lang
-     * @return boolean
+     * @returns {boolean}
      */
-    isLanguageRTL: function(lang) {
+    isLanguageRTL(lang) {
         if (!(this.getConfig() && this.getConfig().rtl) || !lang) {
             return false;
         }
 
-        return this.getConfig().rtl
-            .some(function (lng) {
-                return String(lng).toLowerCase() === lang.toLowerCase();
-            });
+        return this.getConfig().rtl.some(function (lng) {
+            return String(lng).toLowerCase() === lang.toLowerCase();
+        });
     },
 
     /**
      * Determine direction for language
      * @param {String} lang
-     * @return String {rtl|ltr}
+     * @returns {String} rtl|ltr
      */
-    getLanguageDirection: function(lang) {
-        return this.isLanguageRTL(lang)
-            ? 'rtl'
-            : 'ltr';
+    getLanguageDirection(lang) {
+        return this.isLanguageRTL(lang) ? 'rtl' : 'ltr';
     }
 };

--- a/src/util/mathsEvaluator.js
+++ b/src/util/mathsEvaluator.js
@@ -22,27 +22,27 @@ import _ from 'lodash';
 import Decimal from 'lib/decimal/decimal';
 import exprEval from 'lib/expr-eval/expr-eval';
 
-var Parser = exprEval.Parser;
+const Parser = exprEval.Parser;
 
 /**
  * Good precision value of PI
  * @type {String}
  */
-var numberPI =
+const numberPI =
     '3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679821480865132823066470938446095505822317253594081284811174502841027019385211055596446229489549303819644288109756659334461284756482337867831652712019091456485669234603486104543266482133936072602491412737245870066063155881748815209209628292540917153643678925903600113305305488204665213841469519415116094330572703657595919530921861173819326117931051185480744623799627495673518857527248912279381830119491298336733624406566430860213949463952247371907021798609437027705392171762931767523846748184676694051320005681271452635608277857713427577896091736371787214684409012249534301465495853710507922796892589235420199561121290219608640344181598136297747713099605187072113499999983729780499510597317328160963185950244594553469083026425223082533446850352619311881710100031378387528865875332083814206171776691473035982534904287554687311595628638823537875937519577818577805321712268066130019278766111959092164201989';
 
 /**
  * Good precision value of Euler's number
  * @type {String}
  */
-var numberE =
+const numberE =
     '2.7182818284590452353602874713526624977572470936999595749669676277240766303535475945713821785251664274274663919320030599218174135966290435729003342952605956307381323286279434907632338298807531952510190115738341879307021540891499348841675092447614606680822648001684774118537423454424371075390777449920695517027618386062613313845830007520449338265602976067371132007093287091274437470472306969772093101416928368190255151086574637721112523897844250569536967707854499699679468644549059879316368892300987931277361782154249992295763514822082698951936680331825288693984964651058209392398294887933203625094431173012381970684161403970198376793206832823764648042953118023287825098194558153017567173613320698112509961818815930416903515988885193458072738667385894228792284998920868058257492796104841984443634632449684875602336248270419786232090021609902353043699418491463140934317381436405462531520961836908887070167683964243781405927145635490613031072085103837505101157477041718986106873969655212671546889570350354';
 
 /**
  * Defaults config for the evaluator
  * @type {Object}
  */
-var defaultConfig = {
+const defaultConfig = {
     internalPrecision: 100,
     degree: false
 };
@@ -51,7 +51,7 @@ var defaultConfig = {
  * Defaults config for the Decimal constructor
  * @type {Object}
  */
-var defaultDecimalConfig = {
+const defaultDecimalConfig = {
     defaults: true
 };
 
@@ -59,13 +59,13 @@ var defaultDecimalConfig = {
  * List of config entries the Decimal constructor accepts
  * @type {String[]}
  */
-var decimalConfigEntries = ['precision', 'rounding', 'toExpNeg', 'toExpPos', 'maxE', 'minE', 'modulo', 'crypto'];
+const decimalConfigEntries = ['precision', 'rounding', 'toExpNeg', 'toExpPos', 'maxE', 'minE', 'modulo', 'crypto'];
 
 /**
  * List of config entries the Parser constructor accepts
  * @type {String[]}
  */
-var parserConfigEntries = ['operators'];
+const parserConfigEntries = ['operators'];
 
 /**
  * Gets an arbitrary decimal precision number using a string representation.
@@ -74,7 +74,7 @@ var parserConfigEntries = ['operators'];
  * @returns {String}
  */
 function toPrecisionNumber(number, precision) {
-    var dot = number.indexOf('.');
+    const dot = number.indexOf('.');
     if (dot > 0) {
         number = number.substr(0, dot + precision + 1);
     }
@@ -114,54 +114,54 @@ function toPrecisionNumber(number, precision) {
  * @returns {Function<expression, variables>} - The maths expression parser
  */
 function mathsEvaluatorFactory(config) {
-    var localConfig = _.defaults({}, config, defaultConfig);
-    var decimalConfig = _.pick(localConfig, decimalConfigEntries);
-    var parserConfig = _.pick(localConfig, parserConfigEntries);
-    var parser = new Parser(parserConfig);
-    var ConfiguredDecimal = Decimal.set(_.isEmpty(decimalConfig) ? defaultDecimalConfig : decimalConfig);
-    var EPSILON = new ConfiguredDecimal(2).pow(-52);
-    var PI = new ConfiguredDecimal(toPrecisionNumber(numberPI, localConfig.internalPrecision));
-    var E = new ConfiguredDecimal(toPrecisionNumber(numberE, localConfig.internalPrecision));
+    const localConfig = _.defaults({}, config, defaultConfig);
+    const decimalConfig = _.pick(localConfig, decimalConfigEntries);
+    const parserConfig = _.pick(localConfig, parserConfigEntries);
+    const parser = new Parser(parserConfig);
+    const ConfiguredDecimal = Decimal.set(_.isEmpty(decimalConfig) ? defaultDecimalConfig : decimalConfig);
+    const EPSILON = new ConfiguredDecimal(2).pow(-52);
+    const PI = new ConfiguredDecimal(toPrecisionNumber(numberPI, localConfig.internalPrecision));
+    const E = new ConfiguredDecimal(toPrecisionNumber(numberE, localConfig.internalPrecision));
 
     /**
      * Map expr-eval API to decimal.js
      * @type {Object}
      */
-    var mapAPI = {
+    const mapAPI = {
         unary: [
             {
                 entry: 'sin',
-                action: function(a) {
+                action(a) {
                     return trigoOperator('sin', a);
                 }
             },
             {
                 entry: 'cos',
-                action: function(a) {
+                action(a) {
                     return trigoOperator('cos', a);
                 }
             },
             {
                 entry: 'tan',
-                action: function(a) {
+                action(a) {
                     return trigoOperator('tan', a);
                 }
             },
             {
                 entry: 'asin',
-                action: function(a) {
+                action(a) {
                     return inverseTrigoOperator('asin', a);
                 }
             },
             {
                 entry: 'acos',
-                action: function(a) {
+                action(a) {
                     return inverseTrigoOperator('acos', a);
                 }
             },
             {
                 entry: 'atan',
-                action: function(a) {
+                action(a) {
                     return inverseTrigoOperator('atan', a);
                 }
             },
@@ -247,7 +247,7 @@ function mathsEvaluatorFactory(config) {
             },
             {
                 entry: 'not',
-                action: function(a) {
+                action(a) {
                     return !native(a);
                 }
             },
@@ -287,7 +287,7 @@ function mathsEvaluatorFactory(config) {
             },
             {
                 entry: '!=',
-                action: function(a, b) {
+                action(a, b) {
                     return !binaryOperator('equals', a, b);
                 }
             },
@@ -309,23 +309,23 @@ function mathsEvaluatorFactory(config) {
             },
             {
                 entry: 'and',
-                action: function(a, b) {
+                action(a, b) {
                     return Boolean(native(a) && native(b));
                 }
             },
             {
                 entry: 'or',
-                action: function(a, b) {
+                action(a, b) {
                     return Boolean(native(a) || native(b));
                 }
             },
             {
                 entry: 'in',
-                action: function(array, obj) {
+                action(array, obj) {
                     obj = native(obj);
                     return (
                         'undefined' !==
-                        typeof _.find(array, function(el) {
+                        typeof _.find(array, function (el) {
                             return native(el) === obj;
                         })
                     );
@@ -341,7 +341,7 @@ function mathsEvaluatorFactory(config) {
         functions: [
             {
                 entry: 'random',
-                action: function(dp) {
+                action(dp) {
                     return ConfiguredDecimal.random(dp);
                 }
             },
@@ -371,8 +371,8 @@ function mathsEvaluatorFactory(config) {
             },
             {
                 entry: 'atan2',
-                action: function(y, x) {
-                    var result = functionOperator('atan2', y, x);
+                action(y, x) {
+                    const result = functionOperator('atan2', y, x);
                     return localConfig.degree ? radianToDegree(result) : result;
                 }
             },
@@ -390,17 +390,14 @@ function mathsEvaluatorFactory(config) {
             },
             {
                 entry: 'nthrt',
-                action: function(n, x) {
+                action(n, x) {
                     x = decimalNumber(x);
                     n = parseInt(n, 10);
                     if (x.isNeg() && n % 2 !== 1) {
                         // not a real number (complex not supported)
                         return decimalNumber(NaN);
                     }
-                    return x
-                        .abs()
-                        .pow(decimalNumber(1).div(n))
-                        .mul(Decimal.sign(x));
+                    return x.abs().pow(decimalNumber(1).div(n)).mul(Decimal.sign(x));
                 }
             }
         ],
@@ -451,11 +448,11 @@ function mathsEvaluatorFactory(config) {
 
     /**
      * Map an original function using possible Decimal arguments
+     * @param {...*} args
      * @returns {*}
      */
-    function useOrigin() {
-        var args = [].slice.call(arguments);
-        var origin = args.pop();
+    function useOrigin(...args) {
+        const origin = args.pop();
         return origin.apply(this, args.map(native));
     }
 
@@ -477,9 +474,7 @@ function mathsEvaluatorFactory(config) {
      * @returns {Decimal} - Always returns a Decimal
      */
     function degreeToRadian(value) {
-        return decimalNumber(value)
-            .mul(PI)
-            .div(180);
+        return decimalNumber(value).mul(PI).div(180);
     }
 
     /**
@@ -488,9 +483,7 @@ function mathsEvaluatorFactory(config) {
      * @returns {Decimal} - Always returns a Decimal
      */
     function radianToDegree(value) {
-        return decimalNumber(value)
-            .mul(180)
-            .div(PI);
+        return decimalNumber(value).mul(180).div(PI);
     }
 
     /**
@@ -502,7 +495,7 @@ function mathsEvaluatorFactory(config) {
     function unaryOperator(operator, operand) {
         operand = decimalNumber(operand);
         if (!_.isFunction(operand[operator])) {
-            throw new TypeError(operator + ' is not a valid operator!');
+            throw new TypeError(`${operator} is not a valid operator!`);
         }
         return operand[operator]();
     }
@@ -517,7 +510,7 @@ function mathsEvaluatorFactory(config) {
     function binaryOperator(operator, left, right) {
         left = decimalNumber(left);
         if (!_.isFunction(left[operator])) {
-            throw new TypeError(operator + ' is not a valid operator!');
+            throw new TypeError(`${operator} is not a valid operator!`);
         }
         return left[operator](decimalNumber(right));
     }
@@ -525,16 +518,15 @@ function mathsEvaluatorFactory(config) {
     /**
      * Apply the mentioned function operator on the operands
      * @param {String} operator - The operator to apply
-     * @param {Number|String|Decimal} ... - operands
+     * @param {Number|String|Decimal} operands
      * @returns {Decimal} - Always returns a Decimal
      */
-    function functionOperator(operator) {
-        var operands = [].slice.call(arguments, 1);
+    function functionOperator(operator, ...operands) {
         if (!_.isFunction(ConfiguredDecimal[operator])) {
-            throw new TypeError(operator + ' is not a valid function!');
+            throw new TypeError(`${operator} is not a valid function!`);
         }
 
-        return ConfiguredDecimal[operator].apply(ConfiguredDecimal, operands.map(decimalNumber));
+        return ConfiguredDecimal[operator](...operands.map(decimalNumber));
     }
 
     /**
@@ -545,7 +537,7 @@ function mathsEvaluatorFactory(config) {
      */
     function trigoOperator(operator, operand) {
         if (!_.isFunction(Decimal[operator])) {
-            throw new TypeError(operator + ' is not a valid operator!');
+            throw new TypeError(`${operator} is not a valid operator!`);
         }
 
         if (localConfig.degree) {
@@ -568,7 +560,7 @@ function mathsEvaluatorFactory(config) {
      * @returns {Decimal} - Always returns a Decimal
      */
     function inverseTrigoOperator(operator, operand) {
-        var result = checkZero(unaryOperator(operator, operand));
+        const result = checkZero(unaryOperator(operator, operand));
         return localConfig.degree ? radianToDegree(result) : result;
     }
 
@@ -579,7 +571,7 @@ function mathsEvaluatorFactory(config) {
      * @param {Object} api
      */
     function mapping(wrapper, origin, api) {
-        var fn;
+        let fn;
         if (api.value) {
             fn = api.value;
         } else if (api.action) {
@@ -598,16 +590,14 @@ function mathsEvaluatorFactory(config) {
      * @returns {mathsExpression}
      */
     function evaluate(expression, variables) {
-        var parsedExpression, result, value;
-
         if (_.isPlainObject(expression)) {
             variables = variables || expression.variables;
             expression = expression.expression;
         }
 
-        parsedExpression = parser.parse(expression);
-        result = parsedExpression.evaluate(variables);
-        value = native(result);
+        const parsedExpression = parser.parse(expression);
+        const result = parsedExpression.evaluate(variables);
+        const value = native(result);
 
         /**
          * @typedef {Object} mathsExpression

--- a/src/util/regexEscape.js
+++ b/src/util/regexEscape.js
@@ -24,6 +24,6 @@
  * @author dieter <dieter@taotesting.com>
  */
 
-export default function(s) {
-    return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+export default function (s) {
+    return s.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
 }

--- a/src/util/shortcut/registry.js
+++ b/src/util/shortcut/registry.js
@@ -40,13 +40,13 @@ import namespaceHelper from 'util/namespace';
 /**
  * All shortcuts have a namespace, this one is the default
  */
-var defaultNs = '*';
+const defaultNs = '*';
 
 /**
  * Translation map from name of modifiers to event property
  * @type {Object}
  */
-var modifiers = {
+const modifiers = {
     ctrl: 'ctrlKey',
     alt: 'altKey',
     option: 'altKey',
@@ -60,7 +60,7 @@ var modifiers = {
  * Translation map from normalized name of keys
  * @type {Object}
  */
-var translateKeys = {
+const translateKeys = {
     escape: 'esc',
     arrowdown: 'down',
     arrowleft: 'left',
@@ -72,7 +72,7 @@ var translateKeys = {
  * List of special keys with their codes
  * @type {Object}
  */
-var specialKeys = {
+const specialKeys = {
     8: 'backspace',
     9: 'tab',
     13: 'enter',
@@ -117,9 +117,9 @@ function registerEvent(target, eventName, listener) {
     if (target.addEventListener) {
         target.addEventListener(eventName, listener, false);
     } else if (target.attachEvent) {
-        target.attachEvent('on' + eventName, listener);
+        target.attachEvent(`on${eventName}`, listener);
     } else {
-        target['on' + eventName] = listener;
+        target[`on${eventName}`] = listener;
     }
 }
 
@@ -133,9 +133,9 @@ function unregisterEvent(target, eventName, listener) {
     if (target.removeEventListener) {
         target.removeEventListener(eventName, listener, false);
     } else if (target.detachEvent) {
-        target.detachEvent('on' + eventName, listener);
+        target.detachEvent(`on${eventName}`, listener);
     } else {
-        target['on' + eventName] = null;
+        target[`on${eventName}`] = null;
     }
 }
 
@@ -146,15 +146,15 @@ function unregisterEvent(target, eventName, listener) {
  */
 function getActualKey(event) {
     // Get the code of the key, used to identify special keys on browser that does not support the full KeyboardEvent API
-    var code = event.which || event.keyCode;
-    var character = code >= 32 ? String.fromCharCode(code).toLowerCase() : '';
+    const code = event.which || event.keyCode;
+    const character = code >= 32 ? String.fromCharCode(code).toLowerCase() : '';
 
     // Get the name of the key on browser that have a good support of the KeyboardEvent API
-    var key = event.key && event.key.toLowerCase();
+    let key = event.key && event.key.toLowerCase();
 
     // If the browser supports the KeyboardEvent API it may provide the result of the shortcut instead of the actual key.
     // For instance on Mac if you input "Alt+V" the key property will contain "◊"
-    var keyName = event.code && event.code.toLowerCase();
+    const keyName = event.code && event.code.toLowerCase();
     if (keyName) {
         if (keyName.indexOf('key') === 0) {
             // fix the result key only if the actual key name is not alpha (diff due to local layout)
@@ -175,10 +175,10 @@ function getActualKey(event) {
 /**
  * Gets the pressed buttons
  * @param {MouseEvent} event
- * @return {Object}
+ * @returns {Object}
  */
 function getActualButton(event) {
-    var buttons = {
+    const buttons = {
         clickLeft: false,
         clickRight: false,
         clickMiddle: false,
@@ -222,7 +222,7 @@ function getActualButton(event) {
 /**
  * Gets the scroll direction
  * @param {WheelEvent} event
- * @return {Object}
+ * @returns {Object}
  */
 function getActualScroll(event) {
     return {
@@ -237,8 +237,8 @@ function getActualScroll(event) {
  * @returns {String}
  */
 function normalizeCommand(descriptor) {
-    var key = translateKeys[descriptor.key] || descriptor.key;
-    var parts = [];
+    const key = translateKeys[descriptor.key] || descriptor.key;
+    const parts = [];
 
     if (descriptor.ctrlKey) {
         parts.push('control');
@@ -289,8 +289,8 @@ function normalizeCommand(descriptor) {
  * @returns {Object}
  */
 function parseCommand(shortcut) {
-    var parts = namespaceHelper.getName(shortcut).split('+');
-    var descriptor = {
+    const parts = namespaceHelper.getName(shortcut).split('+');
+    const descriptor = {
         keyboardInvolved: false,
         mouseClickInvolved: false,
         mouseWheelInvolved: false,
@@ -308,7 +308,7 @@ function parseCommand(shortcut) {
         clickForward: null
     };
 
-    _.forEach(parts, function(part) {
+    _.forEach(parts, function (part) {
         if (modifiers[part]) {
             descriptor[modifiers[part]] = true;
         } else if (part.indexOf('mouse') >= 0) {
@@ -356,17 +356,17 @@ function parseCommand(shortcut) {
  * @returns {shortcut}
  */
 export default function shortcutFactory(root, defaultOptions) {
-    var keyboardIsRegistered = false;
-    var mouseClickIsRegistered = false;
-    var mouseWheelIsRegistered = false;
+    let keyboardIsRegistered = false;
+    let mouseClickIsRegistered = false;
+    let mouseWheelIsRegistered = false;
 
-    var keyboardCount = 0;
-    var mouseClickCount = 0;
-    var mouseWheelCount = 0;
+    let keyboardCount = 0;
+    let mouseClickCount = 0;
+    let mouseWheelCount = 0;
 
-    var shortcuts = {};
-    var handlers = {};
-    var states = {};
+    let shortcuts = {};
+    let handlers = {};
+    const states = {};
 
     /**
      * Gets the handlers for a shortcut
@@ -388,7 +388,7 @@ export default function shortcutFactory(root, defaultOptions) {
     function getCommandHandlers(command) {
         return _.reduce(
             handlers,
-            function(acc, nsHandlers) {
+            function (acc, nsHandlers) {
                 if (nsHandlers[command]) {
                     acc = acc.concat(nsHandlers[command]);
                 }
@@ -407,7 +407,7 @@ export default function shortcutFactory(root, defaultOptions) {
         if (namespace && !command) {
             handlers[namespace] = {};
         } else {
-            _.forEach(handlers, function(nsHandlers, ns) {
+            _.forEach(handlers, function (nsHandlers, ns) {
                 if (nsHandlers[command] && (namespace === defaultNs || namespace === ns)) {
                     nsHandlers[command] = [];
                 }
@@ -532,7 +532,7 @@ export default function shortcutFactory(root, defaultOptions) {
      * @param {String} command
      */
     function unregisterCommand(command) {
-        var descriptor = shortcuts[command];
+        const descriptor = shortcuts[command];
         shortcuts[command] = null;
 
         if (descriptor) {
@@ -609,14 +609,12 @@ export default function shortcutFactory(root, defaultOptions) {
      * @param {Object} descriptor
      */
     function processShortcut(event, descriptor) {
-        var command = normalizeCommand(descriptor);
-        var shortcut = shortcuts[command];
-        var shortcutHandlers;
-        var $target;
+        const command = normalizeCommand(descriptor);
+        const shortcut = shortcuts[command];
 
         if (shortcut && !states.disabled) {
             if (shortcut.options.avoidInput === true) {
-                $target = $(event.target);
+                const $target = $(event.target);
                 if ($target.closest('[type="text"],textarea').length) {
                     if (!shortcut.options.allowIn || !$target.closest(shortcut.options.allowIn).length) {
                         return;
@@ -630,10 +628,10 @@ export default function shortcutFactory(root, defaultOptions) {
                 event.preventDefault();
             }
 
-            shortcutHandlers = getCommandHandlers(command);
+            const shortcutHandlers = getCommandHandlers(command);
 
             if (shortcutHandlers) {
-                _.forEach(shortcutHandlers, function(handler) {
+                _.forEach(shortcutHandlers, function (handler) {
                     handler(event, command);
                 });
             }
@@ -661,10 +659,10 @@ export default function shortcutFactory(root, defaultOptions) {
          * the provided CSS class, even if the shortcut is triggered from an input field.
          * @returns {shortcut} this
          */
-        set: function set(shortcut, options) {
-            _.forEach(namespaceHelper.split(shortcut, true), function(normalized) {
-                var descriptor = parseCommand(normalized);
-                var command = normalizeCommand(descriptor);
+        set(shortcut, options) {
+            _.forEach(namespaceHelper.split(shortcut, true), function (normalized) {
+                const descriptor = parseCommand(normalized);
+                const command = normalizeCommand(descriptor);
 
                 setOptions(descriptor, options);
                 registerCommand(command, descriptor);
@@ -685,12 +683,12 @@ export default function shortcutFactory(root, defaultOptions) {
          * the provided CSS class, even if the shortcut is triggered from an input field.
          * @returns {shortcut} this
          */
-        add: function add(shortcut, handler, options) {
+        add(shortcut, handler, options) {
             if (_.isFunction(handler)) {
-                _.forEach(namespaceHelper.split(shortcut, true), function(normalized) {
-                    var namespace = namespaceHelper.getNamespace(normalized, defaultNs);
-                    var descriptor = parseCommand(normalized);
-                    var command = normalizeCommand(descriptor);
+                _.forEach(namespaceHelper.split(shortcut, true), function (normalized) {
+                    const namespace = namespaceHelper.getNamespace(normalized, defaultNs);
+                    const descriptor = parseCommand(normalized);
+                    const command = normalizeCommand(descriptor);
 
                     setOptions(descriptor, options);
                     registerCommand(command, descriptor);
@@ -706,11 +704,11 @@ export default function shortcutFactory(root, defaultOptions) {
          * @param {String} shortcut
          * @returns {shortcut} this
          */
-        remove: function remove(shortcut) {
-            _.forEach(namespaceHelper.split(shortcut, true), function(normalized) {
-                var namespace = namespaceHelper.getNamespace(normalized, defaultNs);
-                var descriptor = parseCommand(normalized);
-                var command = normalizeCommand(descriptor);
+        remove(shortcut) {
+            _.forEach(namespaceHelper.split(shortcut, true), function (normalized) {
+                const namespace = namespaceHelper.getNamespace(normalized, defaultNs);
+                const descriptor = parseCommand(normalized);
+                const command = normalizeCommand(descriptor);
 
                 clearHandlers(command, namespace);
 
@@ -727,14 +725,12 @@ export default function shortcutFactory(root, defaultOptions) {
          * @param {String} shortcut
          * @returns {Boolean}
          */
-        exists: function exists(shortcut) {
-            var normalized = String(shortcut)
-                .trim()
-                .toLowerCase();
-            var namespace = namespaceHelper.getNamespace(normalized, defaultNs);
-            var descriptor = parseCommand(normalized);
-            var command = normalizeCommand(descriptor);
-            var shortcutExists = false;
+        exists(shortcut) {
+            const normalized = String(shortcut).trim().toLowerCase();
+            const namespace = namespaceHelper.getNamespace(normalized, defaultNs);
+            const descriptor = parseCommand(normalized);
+            const command = normalizeCommand(descriptor);
+            let shortcutExists = false;
 
             if (shortcuts[command]) {
                 shortcutExists = namespace === defaultNs || !!getHandlers(command, namespace).length;
@@ -749,7 +745,7 @@ export default function shortcutFactory(root, defaultOptions) {
          * Removes all registered shortcuts
          * @returns {shortcut} this
          */
-        clear: function clear() {
+        clear() {
             shortcuts = {};
             handlers = {};
             keyboardCount = 0;
@@ -768,7 +764,7 @@ export default function shortcutFactory(root, defaultOptions) {
          * @param {String} name
          * @returns {Boolean}
          */
-        getState: function getState(name) {
+        getState(name) {
             return !!states[name];
         },
 
@@ -778,7 +774,7 @@ export default function shortcutFactory(root, defaultOptions) {
          * @param {Boolean} state
          * @returns {shortcut}
          */
-        setState: function setState(name, state) {
+        setState(name, state) {
             states[name] = !!state;
             return this;
         },
@@ -787,7 +783,7 @@ export default function shortcutFactory(root, defaultOptions) {
          * Enables the shortcuts to be listened
          * @returns {shortcut}
          */
-        enable: function enable() {
+        enable() {
             this.setState('disabled', false);
             return this;
         },
@@ -796,7 +792,7 @@ export default function shortcutFactory(root, defaultOptions) {
          * Prevents the shortcuts to be listened
          * @returns {shortcut}
          */
-        disable: function disable() {
+        disable() {
             this.setState('disabled', true);
             return this;
         }

--- a/src/util/strPad.js
+++ b/src/util/strPad.js
@@ -16,18 +16,18 @@
  * example 2: str_pad('Kevin van Zonneveld', 30, '-', 'STR_PAD_BOTH');
  * returns 2: '------Kevin van Zonneveld-----'
  *
- * @param input
- * @param pad_length
- * @param pad_string
- * @param pad_type
+ * @param {string} input
+ * @param {number} pad_length
+ * @param {string} pad_string
+ * @param {string} pad_type
  * @returns {*}
  */
-var strPad = function(input, pad_length, pad_string, pad_type) {
-    var half = '',
-        pad_to_go;
+function strPad(input, pad_length, pad_string, pad_type) {
+    let half = '';
+    let pad_to_go;
 
-    var str_pad_repeater = function(s, len) {
-        var collect = '';
+    function str_pad_repeater(s, len) {
+        let collect = '';
 
         while (collect.length < len) {
             collect += s;
@@ -35,12 +35,12 @@ var strPad = function(input, pad_length, pad_string, pad_type) {
         collect = collect.substr(0, len);
 
         return collect;
-    };
+    }
 
     input = input.toString();
 
     input += '';
-    pad_string = pad_string !== undefined ? pad_string : ' ';
+    pad_string = typeof pad_string !== 'undefined' ? pad_string : ' ';
 
     if (pad_type !== 'STR_PAD_LEFT' && pad_type !== 'STR_PAD_RIGHT' && pad_type !== 'STR_PAD_BOTH') {
         pad_type = 'STR_PAD_RIGHT';
@@ -58,6 +58,6 @@ var strPad = function(input, pad_length, pad_string, pad_type) {
     }
 
     return input;
-};
+}
 
 export default strPad;

--- a/src/util/url.js
+++ b/src/util/url.js
@@ -25,18 +25,18 @@
 import _ from 'lodash';
 import context from 'context';
 
-var parsers = {
+const parsers = {
     absolute: /^(?:[a-z]+:)?\/\//i,
-    base64: /^data:[^\/]+\/[^;]+(;charset=[\w]+)?;base64,/,
+    base64: /^data:[^/]+\/[^;]+(;charset=[\w]+)?;base64,/,
     query: /(?:^|&)([^&=]*)=?([^&]*)/g,
-    url: /^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@]*)(?::([^:@]*))?)?@)?([^:\/?#]*)(?::(\d*))?))?((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/
+    url: /^(?:([^:/?#]+):)?(?:\/\/((?:(([^:@]*)(?::([^:@]*))?)?@)?([^:/?#]*)(?::(\d*))?))?((((?:[^?#/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/
 };
 
 /**
  * The Url util
  * @exports util/url
  */
-var urlUtil = {
+const urlUtil = {
     /*
      * The parse method is a adaptation of parseUri from
      * Steven Levithan <stevenlevithan.com> under the MIT License
@@ -52,9 +52,8 @@ var urlUtil = {
      * @param {String} url - the URL to parse
      * @returns {Object} parsedUrl with the properties available in key below and query that contains query string key/values.
      */
-    parse: function parse(url) {
-        var matches;
-        var keys = [
+    parse(url) {
+        const keys = [
             'source',
             'protocol',
             'authority',
@@ -70,9 +69,9 @@ var urlUtil = {
             'queryString',
             'hash'
         ];
-        var i = keys.length;
-        var parsed = Object.create({
-            toString: function() {
+
+        const parsed = Object.create({
+            toString: function () {
                 return this.source;
             }
         });
@@ -82,12 +81,13 @@ var urlUtil = {
         if (parsed.base64) {
             parsed.source = url;
         } else {
-            matches = parsers.url.exec(url);
+            const matches = parsers.url.exec(url);
+            let i = keys.length;
             while (i--) {
                 parsed[keys[i]] = matches[i] || '';
             }
             parsed.query = {};
-            parsed.queryString.replace(parsers.query, function($0, $1, $2) {
+            parsed.queryString.replace(parsers.query, function ($0, $1, $2) {
                 if ($1) {
                     parsed.query[$1] = $2;
                 }
@@ -101,9 +101,9 @@ var urlUtil = {
      * @param {String|Object} url - the url to check. It can be a parsed URL (result of {@link util/url#parse})
      * @returns {Boolean|undefined} true if the url is absolute, or undefined if the URL cannot be checked
      */
-    isAbsolute: function isAbsolute(url) {
+    isAbsolute(url) {
         //url from parse
-        if (typeof url === 'object' && url.hasOwnProperty('source')) {
+        if (typeof url === 'object' && Object.prototype.hasOwnProperty.call(url, 'source')) {
             return url.source !== url.relative;
         }
         if (typeof url === 'string') {
@@ -116,8 +116,8 @@ var urlUtil = {
      * @param {String|Object} url - the url to check. It can be a parsed URL (result of {@link util/url#parse})
      * @returns {Boolean|undefined} true if the url is relative, or undefined if the URL cannot be checked
      */
-    isRelative: function isRelative(url) {
-        var absolute = this.isAbsolute(url);
+    isRelative(url) {
+        const absolute = this.isAbsolute(url);
         if (typeof absolute === 'boolean') {
             return !absolute;
         }
@@ -128,8 +128,8 @@ var urlUtil = {
      * @param {String|Object} url - the url to check. It can be a parsed URL (result of {@link util/url#parse})
      * @returns {Boolean|undefined} true if the url is base64, or undefined if the URL cannot be checked
      */
-    isBase64: function isBase64(url) {
-        if (typeof url === 'object' && url.hasOwnProperty('source')) {
+    isBase64(url) {
+        if (typeof url === 'object' && Object.prototype.hasOwnProperty.call(url, 'source')) {
             return url.base64;
         }
         if (typeof url === 'string') {
@@ -139,10 +139,10 @@ var urlUtil = {
 
     /**
      * Determine whether encoding is required to match XML standards for attributes
-     * @param {String} url
+     * @param {String} uri
      * @returns {String}
      */
-    encodeAsXmlAttr: function encodeAsXmlAttr(uri) {
+    encodeAsXmlAttr(uri) {
         return /[<>&']+/.test(uri) ? encodeURIComponent(uri) : uri;
     },
 
@@ -154,10 +154,8 @@ var urlUtil = {
      * @param {Object} [params] - params to add to the URL
      * @returns {String} the URL
      */
-    build: function build(path, params) {
-        var url,
-            queryString = '',
-            hasQueryString;
+    build(path, params) {
+        let url;
 
         if (path) {
             if (_.isString(path)) {
@@ -165,40 +163,36 @@ var urlUtil = {
             }
             if (_.isArray(path)) {
                 url = '';
-                _.forEach(path, function(chunk) {
+                _.forEach(path, function (chunk) {
                     if (/\/$/.test(url) && /^\//.test(chunk)) {
                         url += chunk.substr(1);
                     } else if (url !== '' && !/\/$/.test(url) && !/^\//.test(chunk)) {
-                        url += '/' + chunk;
+                        url += `/${chunk}`;
                     } else {
                         url += chunk;
                     }
                 });
             }
             if (_.isPlainObject(params)) {
-                hasQueryString = url.indexOf('?') > -1;
-                queryString = _.reduce(
+                const hasQueryString = url.indexOf('?') > -1;
+                const queryString = _.reduce(
                     params,
-                    function(acc, value, key) {
+                    function (acc, value, key) {
                         if (!_.isEmpty(acc) || hasQueryString) {
                             acc += '&';
                         }
                         if (typeof value === 'object' && !_.isArray(value)) {
-                            _.forOwn(value, function(parameterValue, parameterName) {
-                                acc +=
-                                    encodeURIComponent(key) +
-                                    '[' +
-                                    encodeURIComponent(parameterName) +
-                                    ']=' +
-                                    encodeURIComponent(parameterValue) +
-                                    '&';
+                            _.forOwn(value, function (parameterValue, parameterName) {
+                                acc += `${encodeURIComponent(key)}[${encodeURIComponent(
+                                    parameterName
+                                )}]=${encodeURIComponent(parameterValue)}&`;
                             });
                         } else {
-                            acc += encodeURIComponent(key) + '=' + encodeURIComponent(value);
+                            acc += `${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
                         }
                         return acc;
                     },
-                    queryString
+                    ''
                 );
                 if (!_.isEmpty(queryString)) {
                     if (!hasQueryString) {
@@ -217,17 +211,17 @@ var urlUtil = {
      * @param {String} action - The controller's action
      * @param {String} controller - The controller's name
      * @param {String} extension - The controller's extension
-     * @param {String} [rootUrl] - to change the root url, otherwise taken from context
      * @param {Object} [params] - params to add to the URL
+     * @param {String} [rootUrl] - to change the root url, otherwise taken from context
      * @returns {String} the url
      *
      * @throws {TypeError} if one of the required parameter is missing or empty
      */
-    route: function route(action, controller, extension, params, rootUrl) {
-        var routeParts = [extension, controller, action];
+    route(action, controller, extension, params, rootUrl) {
+        const routeParts = [extension, controller, action];
 
         if (
-            _.some(routeParts, function(value) {
+            _.some(routeParts, function (value) {
                 return _.isEmpty(value) || !_.isString(value);
             })
         ) {

--- a/src/util/urlParser.js
+++ b/src/util/urlParser.js
@@ -30,7 +30,7 @@
  */
 import _ from 'lodash';
 
-var urlParts = ['hash', 'host', 'hostname', 'pathname', 'port', 'protocol', 'search'];
+const urlParts = ['hash', 'host', 'hostname', 'pathname', 'port', 'protocol', 'search'];
 
 /**
  * Parse an URL and gives you access to its parts
@@ -44,12 +44,11 @@ var urlParts = ['hash', 'host', 'hostname', 'pathname', 'port', 'protocol', 'sea
  * @param {String} url
  */
 function UrlParser(url) {
-    var detachedAnchor;
     this.url = url;
 
     //use the parser within the browser DOM engine
     //thanks to https://gist.github.com/jlong/2428561
-    detachedAnchor = document.createElement('a');
+    const detachedAnchor = document.createElement('a');
     detachedAnchor.href = url;
     this.data = _.pick(detachedAnchor, urlParts);
     this.params = UrlParser.extractParams(this.data.search);
@@ -62,9 +61,9 @@ function UrlParser(url) {
  * @param {String} search
  * @returns {Object} key : value
  */
-UrlParser.extractParams = function(search) {
-    var params = {};
-    search.replace(/^\?/, '').replace(/([^=&]+)=([^&]*)/g, function(m, key, value) {
+UrlParser.extractParams = function (search) {
+    const params = {};
+    search.replace(/^\?/, '').replace(/([^=&]+)=([^&]*)/g, function (m, key, value) {
         params[decodeURIComponent(key)] = decodeURIComponent(value);
     });
     return params;
@@ -77,7 +76,7 @@ UrlParser.extractParams = function(search) {
  * @param {string} what - in 'hash', 'host', 'hostname', 'pathname', 'port', 'protocol', 'search'
  * @returns {String|Boolean} the requested url part or false
  */
-UrlParser.prototype.get = function(what) {
+UrlParser.prototype.get = function (what) {
     return _.contains(urlParts, what) ? this.data[what] : false;
 };
 
@@ -87,7 +86,7 @@ UrlParser.prototype.get = function(what) {
  * @memberOf UrlParser
  * @returns {Object} key : value
  */
-UrlParser.prototype.getParams = function() {
+UrlParser.prototype.getParams = function () {
     return this.params;
 };
 
@@ -97,7 +96,7 @@ UrlParser.prototype.getParams = function() {
  * @memberOf UrlParser
  * @param {Object} params - of key:value
  */
-UrlParser.prototype.setParams = function(params) {
+UrlParser.prototype.setParams = function (params) {
     if (_.isObject(params)) {
         this.params = params;
     }
@@ -110,7 +109,7 @@ UrlParser.prototype.setParams = function(params) {
  * @param {String} key
  * @param {String} value
  */
-UrlParser.prototype.addParam = function(key, value) {
+UrlParser.prototype.addParam = function (key, value) {
     if (key) {
         this.params[key] = value;
     }
@@ -121,7 +120,7 @@ UrlParser.prototype.addParam = function(key, value) {
  * @memberOf UrlParser
  * @returns {Array} - the paths
  */
-UrlParser.prototype.getPaths = function() {
+UrlParser.prototype.getPaths = function () {
     return this.data.pathname.replace(/^\/|\/$/g, '').split('/');
 };
 
@@ -131,16 +130,16 @@ UrlParser.prototype.getPaths = function() {
  * @param {Array} [exclude] - url parts to exclude in hosts, params and hash
  * @returns {String} the url
  */
-UrlParser.prototype.getUrl = function(exclude) {
-    var url = '';
+UrlParser.prototype.getUrl = function (exclude) {
+    let url = '';
     exclude = exclude || [];
     if (this.data) {
         if (this.data.hostname && !_.contains(exclude, 'host')) {
-            url += (this.data.protocol ? this.data.protocol : 'http:') + '//' + this.data.hostname.replace(/\/$/, '');
+            url += `${this.data.protocol ? this.data.protocol : 'http:'}//${this.data.hostname.replace(/\/$/, '')}`;
 
             //the value of the port seems to be different regardign the browser, so we prevent adding port if not usual
             if (this.data.port && this.data.port !== 80 && this.data.port !== '80' && this.data.port !== '0') {
-                url += ':' + this.data.port;
+                url += `:${this.data.port}`;
             }
         }
         if (!/\/$/.test(url) && !/^\//.test(this.data.pathname)) {
@@ -150,8 +149,8 @@ UrlParser.prototype.getUrl = function(exclude) {
 
         if (this.params && !_.contains(exclude, 'params')) {
             url += '?';
-            _.forEach(this.params, function(value, key) {
-                url += encodeURIComponent(key) + '=' + encodeURIComponent(value) + '&';
+            _.forEach(this.params, function (value, key) {
+                url += `${encodeURIComponent(key)}=${encodeURIComponent(value)}&`;
             });
             url = url.substring(0, url.length - 1);
         }
@@ -168,10 +167,10 @@ UrlParser.prototype.getUrl = function(exclude) {
  * @deprecated
  * @returns {String} the url
  */
-UrlParser.prototype.getBaseUrl = function() {
-    var baseUrl = this.getUrl(['params', 'hash']);
-    var paths = this.getPaths();
-    var lastPart = paths[paths.length - 1];
+UrlParser.prototype.getBaseUrl = function () {
+    let baseUrl = this.getUrl(['params', 'hash']);
+    const paths = this.getPaths();
+    const lastPart = paths[paths.length - 1];
 
     //remove if trailing path token is a file
     if (paths.length > 0 && /\.[a-z]+$/.test(lastPart)) {
@@ -189,8 +188,8 @@ UrlParser.prototype.getBaseUrl = function() {
  * @returns {Boolean} true if same domain
  * @throws {TypeError} with wrong parameters
  */
-UrlParser.prototype.sameDomain = function(url) {
-    var parsedUrl;
+UrlParser.prototype.sameDomain = function (url) {
+    let parsedUrl;
     if (typeof url === 'undefined') {
         parsedUrl = new UrlParser(window.location);
     }

--- a/src/util/wrapLongWords.js
+++ b/src/util/wrapLongWords.js
@@ -30,16 +30,16 @@ import regexEscape from 'util/regexEscape';
  * even when they're preceded by a space. To address this chunks starting with one of the problematic characters
  * will have this removed and it will be appended to the previous chunk.
  *
- * @param longWord
- * @param chunkExp
+ * @param {string} longWord
+ * @param {RegExp} chunkExp
  * @returns {string}
  */
-var getCutTerm = function getCutTerm(longWord, chunkExp) {
-    var cutTerms = longWord.match(chunkExp),
-        i = cutTerms.length,
-        oldFirst = '',
-        newFirst = '',
-        offenders = ['.', ':', ';'];
+function getCutTerm(longWord, chunkExp) {
+    const cutTerms = longWord.match(chunkExp);
+    let i = cutTerms.length;
+    let oldFirst = '';
+    let newFirst = '';
+    const offenders = ['.', ':', ';'];
 
     while (i--) {
         newFirst = cutTerms[i].charAt(0);
@@ -52,26 +52,25 @@ var getCutTerm = function getCutTerm(longWord, chunkExp) {
         oldFirst = newFirst;
     }
     return cutTerms.join(' ');
-};
+}
 
 /**
  * Wrap very long strings after n characters
  *
- * @param str
- * @param threshold number of characters to break after
+ * @param {string} str
+ * @param {number} threshold number of characters to break after
  * @returns {string}
  */
 function wrapLongWords(str, threshold) {
     // add whitespaces to provoke line breaks before HTML tags
     str = str.toString().replace(/([\w])</g, '$1 <');
 
-    var chunkExp = new RegExp('.{1,' + threshold + '}', 'g'),
-        longWords = str.match(new RegExp('[\\S]{' + threshold + ',}', 'g')) || [],
-        i = longWords.length,
-        cut;
+    const chunkExp = new RegExp(`.{1,${threshold}}`, 'g');
+    const longWords = str.match(new RegExp(`[\\S]{${threshold},}`, 'g')) || [];
+    let i = longWords.length;
 
     while (i--) {
-        cut = getCutTerm(longWords[i], chunkExp);
+        const cut = getCutTerm(longWords[i], chunkExp);
         str = str.replace(new RegExp(regexEscape(longWords[i]), 'g'), cut);
     }
 


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1166

### Summary

Fix the ESLint error in the source code for `tao-core-utils`.

**Note:** as the changes are pretty heavy, I split them all into several pull requests.

### Details

This pull request only targets the `util/*` part of the library.
The full picture can be seen from the main branch which contains all the fixes: https://github.com/oat-sa/tao-core-sdk-fe.git#fix/ADF-1166/eslint-errors

What has been made:
- fix errors that can be automated using `eslint --fix`, then adjust the changes in case by case (mostly string literals)
- fix the wrong annotations (missing/wrong return or param definition)
- fix the more complex cases with some refactoring (rest operator instead of `.apply()`)
- replace `var` by `const` or `let` (but not in all places, only in the touched files when it was not adding too much noise)
- apply object shorthand instead of duplicated function names
- apply arrow functions here and there when it helped, but not systematically to reduce the noise

### How to test
- checkout and install the source code `npm i`
- run the linter: `npm run lint:src`, errors and warnings coming from the `utils` folder should have gone.
- run the unit tests: `npm run test utils`
- install with other repositories, using the following scheme: `"@oat-sa/tao-core-sdk": "https://github.com/oat-sa/tao-core-sdk-fe.git#fix/ADF-1166/eslint-errors",`, then checking the unit tests and playing with TAO