### PR TITLE
Fix/ADF-1166/ESlint errors in tests of utils

### DIFF
--- a/test/util/adaptSize/test.js
+++ b/test/util/adaptSize/test.js
@@ -17,8 +17,8 @@
  *
  *
  */
-define(['jquery', 'util/adaptSize'], function($, adaptSize) {
-    QUnit.test('API', function(assert) {
+define(['jquery', 'util/adaptSize'], function ($, adaptSize) {
+    QUnit.test('API', function (assert) {
         assert.expect(4);
 
         assert.ok(typeof adaptSize === 'object', 'adaptSize returns an object');
@@ -27,77 +27,77 @@ define(['jquery', 'util/adaptSize'], function($, adaptSize) {
         assert.ok(typeof adaptSize.both === 'function', 'Exposes method both()');
     });
 
-    QUnit.test('Height adaptation, optional argument minHeight omitted', function(assert) {
+    QUnit.test('Height adaptation, optional argument minHeight omitted', function (assert) {
         assert.expect(1);
 
-        var $targets = $('.target'),
+        const $targets = $('.target'),
             $e1 = $('#e-1'),
             $e2 = $('#e-2'),
             $e3 = $('#e-3');
 
         adaptSize.height($targets);
 
-        var assertion = $e1.height() === $e2.height() && $e1.height() === $e3.height() && $e1.height() > 0;
+        const assertion = $e1.height() === $e2.height() && $e1.height() === $e3.height() && $e1.height() > 0;
 
         assert.ok(assertion, 'Adapts height of several elements');
     });
 
-    QUnit.test('Height adaptation, minHeight set to 2000', function(assert) {
+    QUnit.test('Height adaptation, minHeight set to 2000', function (assert) {
         assert.expect(1);
 
-        var $targets = $('.target'),
+        const $targets = $('.target'),
             $e1 = $('#e-1'),
             $e2 = $('#e-2'),
             $e3 = $('#e-3');
 
         adaptSize.height($targets, 2000);
 
-        var assertion = $e1.height() === $e2.height() && $e1.height() === $e3.height() && $e1.height() >= 2000;
+        const assertion = $e1.height() === $e2.height() && $e1.height() === $e3.height() && $e1.height() >= 2000;
 
         assert.ok(assertion, 'Adapts height of several elements when a minimal height is given');
     });
 
-    QUnit.test('Width adaptation, optional argument minWidth omitted', function(assert) {
+    QUnit.test('Width adaptation, optional argument minWidth omitted', function (assert) {
         assert.expect(1);
 
-        var $targets = $('.target'),
+        const $targets = $('.target'),
             $e1 = $('#e-1'),
             $e2 = $('#e-2'),
             $e3 = $('#e-3');
 
         adaptSize.width($targets);
 
-        var assertion = $e1.width() === $e2.width() && $e1.width() === $e3.width() && $e1.width() > 0;
+        const assertion = $e1.width() === $e2.width() && $e1.width() === $e3.width() && $e1.width() > 0;
 
         assert.ok(assertion, 'Adapts width of several elements');
     });
 
-    QUnit.test('Width adaptation, minWidth set to 2000', function(assert) {
+    QUnit.test('Width adaptation, minWidth set to 2000', function (assert) {
         assert.expect(1);
 
-        var $targets = $('.target'),
+        const $targets = $('.target'),
             $e1 = $('#e-1'),
             $e2 = $('#e-2'),
             $e3 = $('#e-3');
 
         adaptSize.width($targets, 2000);
 
-        var assertion = $e1.width() === $e2.width() && $e1.width() === $e3.width() && $e1.width() >= 2000;
+        const assertion = $e1.width() === $e2.width() && $e1.width() === $e3.width() && $e1.width() >= 2000;
 
         assert.ok(assertion, 'Adapts width of several elements when a minimal width is given');
     });
 
-    QUnit.test('Size adaptation of both sides, optional arguments minWidth and minHeight omitted', function(assert) {
+    QUnit.test('Size adaptation of both sides, optional arguments minWidth and minHeight omitted', function (assert) {
         assert.expect(1);
 
-        var $targets = $('.target'),
+        const $targets = $('.target'),
             $e1 = $('#e-1'),
             $e2 = $('#e-2'),
             $e3 = $('#e-3');
 
         adaptSize.both($targets);
 
-        var assertion =
+        const assertion =
             $e1.width() === $e2.width() &&
             $e1.width() === $e3.width() &&
             $e1.width() > 0 &&
@@ -108,17 +108,17 @@ define(['jquery', 'util/adaptSize'], function($, adaptSize) {
         assert.ok(assertion, 'Adapts height and width of several elements in one go');
     });
 
-    QUnit.test('Size adaptation of both sides, minWidth set to 2000, minHeight omitted', function(assert) {
+    QUnit.test('Size adaptation of both sides, minWidth set to 2000, minHeight omitted', function (assert) {
         assert.expect(1);
 
-        var $targets = $('.target'),
+        const $targets = $('.target'),
             $e1 = $('#e-1'),
             $e2 = $('#e-2'),
             $e3 = $('#e-3');
 
         adaptSize.both($targets, 2000);
 
-        var assertion =
+        const assertion =
             $e1.width() === $e2.width() &&
             $e1.width() === $e3.width() &&
             $e1.width() >= 2000 &&
@@ -129,17 +129,17 @@ define(['jquery', 'util/adaptSize'], function($, adaptSize) {
         assert.ok(assertion, 'Adapts height and width of several elements in one go when a minimal width is given');
     });
 
-    QUnit.test('Size adaptation of both sides, minWidth omitted, minHeight set to 2000', function(assert) {
+    QUnit.test('Size adaptation of both sides, minWidth omitted, minHeight set to 2000', function (assert) {
         assert.expect(1);
 
-        var $targets = $('.target'),
+        const $targets = $('.target'),
             $e1 = $('#e-1'),
             $e2 = $('#e-2'),
             $e3 = $('#e-3');
 
         adaptSize.both($targets, null, 2000);
 
-        var assertion =
+        const assertion =
             $e1.width() === $e2.width() &&
             $e1.width() === $e3.width() &&
             $e1.width() > 0 &&
@@ -150,10 +150,10 @@ define(['jquery', 'util/adaptSize'], function($, adaptSize) {
         assert.ok(assertion, 'Adapts height and width of several elements in one go when a minimal height is given');
     });
 
-    QUnit.test('Size adaptation of both sides, minWidth and minHeight set to 2000', function(assert) {
+    QUnit.test('Size adaptation of both sides, minWidth and minHeight set to 2000', function (assert) {
         assert.expect(1);
 
-        var $targets = $('.target'),
+        const $targets = $('.target'),
             $e1 = $('#e-1'),
             $e2 = $('#e-2'),
             $e3 = $('#e-3');
@@ -161,7 +161,7 @@ define(['jquery', 'util/adaptSize'], function($, adaptSize) {
         // Expect the adapter to set all other to the same height
         adaptSize.both($targets, 2000, 2000);
 
-        var assertion =
+        const assertion =
             $e1.width() === $e2.width() &&
             $e1.width() === $e3.width() &&
             $e1.width() >= 2000 &&

--- a/test/util/capitalize/test.js
+++ b/test/util/capitalize/test.js
@@ -17,10 +17,10 @@
  *
  *
  */
-define(['util/capitalize', 'lodash'], function(capitalize, _) {
+define(['util/capitalize', 'lodash'], function (capitalize, _) {
     QUnit.module('API');
 
-    QUnit.test('util api', function(assert) {
+    QUnit.test('util api', function (assert) {
         assert.equal(capitalize('lorem'), 'Lorem', 'Single word input');
         assert.equal(capitalize('lorem ipsum dolor sit amet'), 'Lorem Ipsum Dolor Sit Amet', 'Multiple words input');
         assert.equal(
@@ -35,7 +35,7 @@ define(['util/capitalize', 'lodash'], function(capitalize, _) {
         );
         assert.equal(capitalize('12.3'), '12.3', 'valid but nonsense arg string "12.3"');
         assert.equal(capitalize('üabc éabc'), 'Üabc Éabc', 'Accents and such');
-        assert.equal(capitalize(undefined), undefined, '1st arg must be String but is undefined');
+        assert.equal(capitalize(void 0), void 0, '1st arg must be String but is undefined');
         assert.ok(_.isPlainObject(capitalize({})) && _.isEmpty(capitalize({})), '1st arg must be String but is {}');
     });
 });

--- a/test/util/config/test.js
+++ b/test/util/config/test.js
@@ -19,26 +19,26 @@
 /**
  * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
  */
-define(['util/config'], function(configHelper) {
+define(['util/config'], function (configHelper) {
     'use strict';
 
     QUnit.module('helpers/config');
 
-    QUnit.test('module', function(assert) {
+    QUnit.test('module', function (assert) {
         assert.expect(1);
         assert.equal(typeof configHelper, 'object', 'The config helper module exposes an object');
     });
 
-    QUnit.cases.init([{ title: 'build' }, { title: 'from' }]).test('helpers/config API ', function(data, assert) {
+    QUnit.cases.init([{ title: 'build' }, { title: 'from' }]).test('helpers/config API ', function (data, assert) {
         assert.expect(1);
         assert.equal(
             typeof configHelper[data.title],
             'function',
-            'The config helper exposes a "' + data.title + '" function'
+            `The config helper exposes a "${data.title}" function`
         );
     });
 
-    QUnit.test('helpers/config.build', function(assert) {
+    QUnit.test('helpers/config.build', function (assert) {
         var source = {
             foo: 'bar'
         };
@@ -66,7 +66,7 @@ define(['util/config'], function(configHelper) {
         );
     });
 
-    QUnit.test('helpers/config.from', function(assert) {
+    QUnit.test('helpers/config.from', function (assert) {
         var source = {
             foo: 'bar',
             tro: 'lolo',
@@ -111,7 +111,7 @@ define(['util/config'], function(configHelper) {
             'The config helper from() returns the expected config with defaults values'
         );
 
-        assert.throws(function() {
+        assert.throws(function () {
             configHelper.from(source, { no: true });
         }, 'The config helper from() throws an error is a required config entry is missing');
     });

--- a/test/util/encode/test.js
+++ b/test/util/encode/test.js
@@ -15,12 +15,11 @@
  *
  * Copyright (c) 2015 (original work) Open Assessment Technologies SA ;
  */
-define(['util/encode', 'lodash', 'jquery'], function(encode, _, $) {
+define(['util/encode', 'lodash', 'jquery'], function (encode) {
     var htmlDataProvider = [
         {
             title: 'HTML content',
-            html:
-                '<div class="tao-content">Lorem ipsum <i>dummy</i>i> <strong>blabla</strong> <span id="fragment">text</span> <a href="http://www.tao.com/lorem-ipsum#tatata">with a link</a></div>',
+            html: '<div class="tao-content">Lorem ipsum <i>dummy</i>i> <strong>blabla</strong> <span id="fragment">text</span> <a href="http://www.tao.com/lorem-ipsum#tatata">with a link</a></div>',
             expected:
                 '&lt;div class="tao-content"&gt;Lorem ipsum &lt;i&gt;dummy&lt;/i&gt;i&gt; &lt;strong&gt;blabla&lt;/strong&gt; &lt;span id="fragment"&gt;text&lt;/span&gt; &lt;a href="http://www.tao.com/lorem-ipsum#tatata"&gt;with a link&lt;/a&gt;&lt;/div&gt;'
         },
@@ -34,8 +33,7 @@ define(['util/encode', 'lodash', 'jquery'], function(encode, _, $) {
     var attributeDataProvider = [
         {
             title: 'HTML content',
-            html:
-                '<div class="tao-content">Lorem ipsum <i>dummy</i>i> <strong>blabla</strong> éàü <span id="fragment">text</span> <a href="http://www.tao.com/lorem-ipsum#tatata">with a link</a></div>',
+            html: '<div class="tao-content">Lorem ipsum <i>dummy</i>i> <strong>blabla</strong> éàü <span id="fragment">text</span> <a href="http://www.tao.com/lorem-ipsum#tatata">with a link</a></div>',
             expected:
                 '&lt;div class=&quot;tao-content&quot;&gt;Lorem ipsum &lt;i&gt;dummy&lt;/i&gt;i&gt; &lt;strong&gt;blabla&lt;/strong&gt; éàü &lt;span id=&quot;fragment&quot;&gt;text&lt;/span&gt; &lt;a href=&quot;http://www.tao.com/lorem-ipsum#tatata&quot;&gt;with a link&lt;/a&gt;&lt;/div&gt;'
         },
@@ -66,25 +64,25 @@ define(['util/encode', 'lodash', 'jquery'], function(encode, _, $) {
 
     QUnit.module('API');
 
-    QUnit.cases.init(htmlDataProvider).test('encode HTML ', function(data, assert) {
+    QUnit.cases.init(htmlDataProvider).test('encode HTML ', function (data, assert) {
         var result = encode.html(data.html);
         assert.ok(typeof result === 'string', 'The result is a string');
         assert.equal(result, data.expected, 'The result is equal to the expected value');
     });
 
-    QUnit.cases.init(attributeDataProvider).test('encode Attribute ', function(data, assert) {
+    QUnit.cases.init(attributeDataProvider).test('encode Attribute ', function (data, assert) {
         var result = encode.attribute(data.html);
         assert.ok(typeof result === 'string', 'The result is a string');
         assert.equal(result, data.expected, 'The result is equal to the expected value');
     });
 
-    QUnit.cases.init(base64DataProvider).test('encode base64 ', function(data, assert) {
+    QUnit.cases.init(base64DataProvider).test('encode base64 ', function (data, assert) {
         var result = encode.encodeBase64(data.string);
         assert.ok(typeof result === 'string', 'The result is a string');
         assert.equal(result, data.base64, 'The result is equal to the expected value');
     });
 
-    QUnit.cases.init(base64DataProvider).test('decode base64 ', function(data, assert) {
+    QUnit.cases.init(base64DataProvider).test('decode base64 ', function (data, assert) {
         var result = encode.decodeBase64(data.base64);
         assert.ok(typeof result === 'string', 'The result is a string');
         assert.equal(result, data.string, 'The result is equal to the expected value');

--- a/test/util/mathsEvaluator/test.js
+++ b/test/util/mathsEvaluator/test.js
@@ -18,7 +18,7 @@
 /**
  * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
  */
-define(['jquery', 'lodash', 'util/mathsEvaluator', 'json!test/util/mathsEvaluator/testCases.json'], function(
+define(['jquery', 'lodash', 'util/mathsEvaluator', 'json!test/util/mathsEvaluator/testCases.json'], function (
     $,
     _,
     mathsEvaluatorFactory,
@@ -28,7 +28,7 @@ define(['jquery', 'lodash', 'util/mathsEvaluator', 'json!test/util/mathsEvaluato
 
     QUnit.module('API');
 
-    QUnit.test('module', function(assert) {
+    QUnit.test('module', function (assert) {
         assert.expect(3);
 
         assert.equal(typeof mathsEvaluatorFactory, 'function', 'The module exposes a function');
@@ -42,7 +42,7 @@ define(['jquery', 'lodash', 'util/mathsEvaluator', 'json!test/util/mathsEvaluato
 
     QUnit.module('Behavior');
 
-    QUnit.cases.init(testCases).test('expression ', function(data, assert) {
+    QUnit.cases.init(testCases).test('expression ', function (data, assert) {
         var evaluate = mathsEvaluatorFactory(data.config);
         var output = evaluate(data.expression, data.variables);
 
@@ -53,14 +53,14 @@ define(['jquery', 'lodash', 'util/mathsEvaluator', 'json!test/util/mathsEvaluato
         assert.equal(
             output.value,
             data.expected,
-            'The expression ' + data.expression + ' is correctly computed to ' + data.expected
+            `The expression ${data.expression} is correctly computed to ${data.expected}`
         );
         assert.equal(output.expression, data.expression, 'The expression is provided in the output');
         assert.equal(output.variables, data.variables, 'The variables are provided in the output');
         assert.notEqual(typeof output.result, 'undefined', 'The internal result is provided in the output');
     });
 
-    QUnit.test('expression as object', function(assert) {
+    QUnit.test('expression as object', function (assert) {
         var evaluate = mathsEvaluatorFactory();
         var mathsExpression = {
             expression: '3*x + 1',
@@ -76,18 +76,14 @@ define(['jquery', 'lodash', 'util/mathsEvaluator', 'json!test/util/mathsEvaluato
 
         assert.expect(8);
 
-        assert.equal(output.value, '7', 'The expression ' + mathsExpression.expression + ' is correctly computed to 7');
+        assert.equal(output.value, '7', `The expression ${mathsExpression.expression} is correctly computed to 7`);
         assert.equal(output.expression, mathsExpression.expression, 'The expression is provided in the output');
         assert.equal(output.variables, mathsExpression.variables, 'The variables are provided in the output');
         assert.notEqual(typeof output.result, 'undefined', 'The internal result is provided in the output');
 
         output = evaluate(mathsExpression, variables);
 
-        assert.equal(
-            output.value,
-            '10',
-            'The expression ' + mathsExpression.expression + ' is correctly computed to 10'
-        );
+        assert.equal(output.value, '10', `The expression ${mathsExpression.expression} is correctly computed to 10`);
         assert.equal(output.expression, mathsExpression.expression, 'The expression is provided in the output');
         assert.equal(output.variables, variables, 'The variables are provided in the output');
         assert.notEqual(typeof output.result, 'undefined', 'The internal result is provided in the output');
@@ -102,8 +98,8 @@ define(['jquery', 'lodash', 'util/mathsEvaluator', 'json!test/util/mathsEvaluato
          * @param {String} myValue
          * @returns {jQuery}
          */
-        insertAtCaret: function(myValue) {
-            return this.each(function() {
+        insertAtCaret: function (myValue) {
+            return this.each(function () {
                 var sel, startPos, endPos, scrollTop;
                 if (document.selection) {
                     //For browsers like Internet Explorer
@@ -130,7 +126,7 @@ define(['jquery', 'lodash', 'util/mathsEvaluator', 'json!test/util/mathsEvaluato
         }
     });
 
-    QUnit.test('Visual test', function(assert) {
+    QUnit.test('Visual test', function (assert) {
         var evaluate = mathsEvaluatorFactory();
         var $container = $('#visual-test');
         var $screen = $container.find('.screen');
@@ -148,14 +144,15 @@ define(['jquery', 'lodash', 'util/mathsEvaluator', 'json!test/util/mathsEvaluato
             try {
                 return evaluate(expr, variables).value;
             } catch (err) {
+                // eslint-disable-next-line
                 console.log(err);
                 return 'Syntax error!';
             }
         }
 
         function showResult(expression, result) {
-            var $expr = $('<p class="expression">' + expression + '</p>');
-            var $res = $('<p class="result">' + result + '</p>');
+            var $expr = $(`'<p class="expression">${expression}</p>'`);
+            var $res = $(`<p class="result">${result}</p>`);
             var currentScrollTop, scrollTop;
             $screen.append($expr);
             $screen.append($res);
@@ -175,14 +172,14 @@ define(['jquery', 'lodash', 'util/mathsEvaluator', 'json!test/util/mathsEvaluato
             var lines = [];
             var variables = _.reduce(
                 parts,
-                function(acc, part) {
+                function (acc, part) {
                     var s = part.split('=');
                     var name = (s[0] || '').trim();
                     var value = (s[1] || '').trim();
                     if (name && value) {
                         value = processExpression(value);
                         acc[name] = value;
-                        lines.push(name + '=' + value);
+                        lines.push(`${name}=${value}`);
                     }
                     return acc;
                 },
@@ -199,17 +196,19 @@ define(['jquery', 'lodash', 'util/mathsEvaluator', 'json!test/util/mathsEvaluato
         $keyboard.find('[data-switch="radian"]').click();
 
         $keyboard
-            .on('change', 'input', function() {
+            .on('change', 'input', function () {
                 switch (this.name) {
                     case 'degree':
                         degree = !!parseInt(this.value, 10);
                         setupMathsEvaluator();
                 }
             })
-            .on('click', 'button', function() {
+            .on('click', 'button', function () {
                 switch (this.dataset.action) {
                     case 'compute':
                         compute();
+                        clear();
+                        break;
                     case 'clear':
                         clear();
                         break;
@@ -218,7 +217,7 @@ define(['jquery', 'lodash', 'util/mathsEvaluator', 'json!test/util/mathsEvaluato
                 }
             });
 
-        $input.on('keydown', function(e) {
+        $input.on('keydown', function (e) {
             switch (e.keyCode) {
                 case 13:
                     e.preventDefault();

--- a/test/util/mathsEvaluator/test.js
+++ b/test/util/mathsEvaluator/test.js
@@ -151,7 +151,7 @@ define(['jquery', 'lodash', 'util/mathsEvaluator', 'json!test/util/mathsEvaluato
         }
 
         function showResult(expression, result) {
-            var $expr = $(`'<p class="expression">${expression}</p>'`);
+            var $expr = $(`<p class="expression">${expression}</p>`);
             var $res = $(`<p class="result">${result}</p>`);
             var currentScrollTop, scrollTop;
             $screen.append($expr);

--- a/test/util/namespace/test.js
+++ b/test/util/namespace/test.js
@@ -18,7 +18,7 @@
 /**
  * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
  */
-define(['util/namespace'], function(namespaceHelper) {
+define(['util/namespace'], function (namespaceHelper) {
     'use strict';
 
     var namespaceApi = [
@@ -30,22 +30,22 @@ define(['util/namespace'], function(namespaceHelper) {
 
     QUnit.module('namespace');
 
-    QUnit.test('module', function(assert) {
+    QUnit.test('module', function (assert) {
         assert.expect(1);
 
         assert.equal(typeof namespaceHelper, 'object', 'The namespaceHelper module exposes an object');
     });
 
-    QUnit.cases.init(namespaceApi).test('has API ', function(data, assert) {
+    QUnit.cases.init(namespaceApi).test('has API ', function (data, assert) {
         assert.expect(1);
         assert.equal(
             typeof namespaceHelper[data.name],
             'function',
-            'The namespaceHelper exposes a "' + data.name + '" function'
+            `The namespaceHelper exposes a "${data.name}" function`
         );
     });
 
-    QUnit.test('split', function(assert) {
+    QUnit.test('split', function (assert) {
         assert.expect(7);
 
         assert.deepEqual(namespaceHelper.split(), [], 'An empty array is returned from an undefined list');
@@ -65,7 +65,7 @@ define(['util/namespace'], function(namespaceHelper) {
         );
     });
 
-    QUnit.test('getName', function(assert) {
+    QUnit.test('getName', function (assert) {
         assert.expect(6);
 
         assert.equal(namespaceHelper.getName(), '', 'An empty name is returned from an undefined string');
@@ -88,7 +88,7 @@ define(['util/namespace'], function(namespaceHelper) {
         );
     });
 
-    QUnit.test('getNamespace', function(assert) {
+    QUnit.test('getNamespace', function (assert) {
         assert.expect(7);
 
         assert.equal(namespaceHelper.getNamespace(), '', 'An empty namespace is returned from an undefined string');
@@ -116,7 +116,7 @@ define(['util/namespace'], function(namespaceHelper) {
         );
     });
 
-    QUnit.test('namespaceAll', function(assert) {
+    QUnit.test('namespaceAll', function (assert) {
         assert.expect(20);
 
         assert.equal(namespaceHelper.namespaceAll(), '', 'An empty list is returned from an undefined string');

--- a/test/util/shortcut/registry/test.js
+++ b/test/util/shortcut/registry/test.js
@@ -18,7 +18,11 @@
 /**
  * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
  */
-define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], function($, Promise, shortcutRegistry) {
+define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], function (
+    $,
+    Promise,
+    shortcutRegistry
+) {
     'use strict';
 
     var shortcutApi = [
@@ -31,7 +35,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
 
     QUnit.module('shortcut');
 
-    QUnit.test('module', function(assert) {
+    QUnit.test('module', function (assert) {
         var $target = $('#qunit-fixture');
 
         assert.expect(3);
@@ -49,19 +53,19 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
         );
     });
 
-    QUnit.cases.init(shortcutApi).test('has API ', function(data, assert) {
+    QUnit.cases.init(shortcutApi).test('has API ', function (data, assert) {
         var $target = $('#qunit-fixture');
         var instance = shortcutRegistry($target.get(0));
         assert.equal(
             typeof instance[data.name],
             'function',
-            'The shortcutRegistry instance exposes a "' + data.name + '" function'
+            `The shortcutRegistry instance exposes a "${data.name}" function`
         );
     });
 
     QUnit.module('Keyboard');
 
-    QUnit.test('add', function(assert) {
+    QUnit.test('add', function (assert) {
         var ready = assert.async();
         var $target = $('#qunit-fixture');
         var shortcuts = shortcutRegistry($target.get(0));
@@ -69,7 +73,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
 
         assert.expect(4);
 
-        res = shortcuts.add('Meta+C', function(event, keystroke) {
+        res = shortcuts.add('Meta+C', function (event, keystroke) {
             assert.ok(true, 'The shortcut has been caught');
             assert.equal(typeof event, 'object', 'The event object is provided');
             assert.equal(keystroke, 'meta+c', 'The keystroke is provided');
@@ -92,7 +96,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
         });
     });
 
-    QUnit.test('remove', function(assert) {
+    QUnit.test('remove', function (assert) {
         var ready = assert.async();
         var $target = $('#qunit-fixture');
         var shortcuts = shortcutRegistry($target.get(0));
@@ -100,7 +104,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
 
         assert.expect(5);
 
-        shortcuts.add('Ctrl+C', function(event, keystroke) {
+        shortcuts.add('Ctrl+C', function (event, keystroke) {
             assert.ok(true, 'The shortcut has been caught');
             assert.equal(typeof event, 'object', 'The event object is provided');
             assert.equal(keystroke, 'control+c', 'The keystroke is provided');
@@ -108,7 +112,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
             res = shortcuts.remove('Ctrl+C');
             assert.equal(res, shortcuts, 'The helper returns itself');
 
-            $target.on('keydown.test-remove', function() {
+            $target.on('keydown.test-remove', function () {
                 $target.off('keydown.test-remove');
                 assert.ok(true, 'The shortcut has been removed');
                 ready();
@@ -140,7 +144,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
         });
     });
 
-    QUnit.test('exists', function(assert) {
+    QUnit.test('exists', function (assert) {
         var $target = $('#qunit-fixture');
         var shortcuts = shortcutRegistry($target.get(0));
 
@@ -156,7 +160,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
         assert.ok(!shortcuts.exists('meta+c'), 'The removed shortcut must not exists anymore');
     });
 
-    QUnit.test('clear', function(assert) {
+    QUnit.test('clear', function (assert) {
         var ready = assert.async();
         var $target = $('#qunit-fixture');
         var shortcuts = shortcutRegistry($target.get(0));
@@ -164,7 +168,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
 
         assert.expect(7);
 
-        shortcuts.add('Shift+C', function(event, keystroke) {
+        shortcuts.add('Shift+C', function (event, keystroke) {
             assert.ok(true, 'The shortcut has been caught');
             assert.equal(typeof event, 'object', 'The event object is provided');
             assert.equal(keystroke, 'shift+c', 'The keystroke is provided');
@@ -175,7 +179,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
             assert.equal(res, shortcuts, 'The helper returns itself');
             assert.ok(!shortcuts.exists('shift+c'), 'The removed shortcut must not exists anymore');
 
-            $target.on('keydown.test-remove', function() {
+            $target.on('keydown.test-remove', function () {
                 $target.off('keydown.test-remove');
                 assert.ok(true, 'The shortcut has been removed');
                 ready();
@@ -207,7 +211,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
         });
     });
 
-    QUnit.test('modifiers', function(assert) {
+    QUnit.test('modifiers', function (assert) {
         var ready = assert.async();
         var $target = $('#qunit-fixture');
         var shortcuts = shortcutRegistry($target.get(0));
@@ -215,7 +219,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
 
         assert.expect(4);
 
-        res = shortcuts.add('Ctrl+Alt+Shift+Meta+C', function(event, keystroke) {
+        res = shortcuts.add('Ctrl+Alt+Shift+Meta+C', function (event, keystroke) {
             assert.ok(true, 'The shortcut has been caught');
             assert.equal(typeof event, 'object', 'The event object is provided');
             assert.equal(keystroke, 'control+alt+shift+meta+c', 'The keystroke is provided');
@@ -238,21 +242,21 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
         });
     });
 
-    QUnit.test('options.prevent', function(assert) {
+    QUnit.test('options.prevent', function (assert) {
         var ready = assert.async();
         var $fixture = $('#qunit-fixture');
         var shortcuts = shortcutRegistry($fixture);
 
         assert.expect(1);
 
-        $('form', $fixture).on('submit', function(event) {
+        $('form', $fixture).on('submit', function (event) {
             assert.ok(false, 'The submit event should not be triggered!');
             event.preventDefault();
         });
 
         shortcuts.add(
             'Enter',
-            function() {
+            function () {
                 assert.ok(true, 'The Enter shortcut has been caught');
                 shortcuts.remove('Enter');
                 ready();
@@ -275,7 +279,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
         });
     });
 
-    QUnit.test('options.propagate', function(assert) {
+    QUnit.test('options.propagate', function (assert) {
         var ready = assert.async();
         var $fixture = $('#qunit-fixture');
         var $container = $('<div />').appendTo($fixture);
@@ -286,7 +290,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
 
         shortcuts.add(
             'Alt+C',
-            function() {
+            function () {
                 assert.ok(true, 'The Alt+C shortcut has been caught');
                 shortcuts.remove('Alt+C');
                 ready();
@@ -296,7 +300,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
             }
         );
 
-        $container.on('keydown', function() {
+        $container.on('keydown', function () {
             assert.ok(false, 'The event should not be propagated!');
         });
 
@@ -313,7 +317,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
         });
     });
 
-    QUnit.test('options.avoidInput', function(assert) {
+    QUnit.test('options.avoidInput', function (assert) {
         var ready = assert.async();
         var $fixture = $('#qunit-fixture');
         var shortcuts = shortcutRegistry($fixture);
@@ -322,7 +326,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
 
         shortcuts.add(
             'Alt+C',
-            function(event) {
+            function (event) {
                 assert.ok(true, 'The Alt+C shortcut has been caught');
                 assert.ok(!$(event.target).closest(':input').length, 'The shortcut does not come from an input');
                 shortcuts.remove('Alt+C');
@@ -370,7 +374,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
         });
     });
 
-    QUnit.test('options.allowIn', function(assert) {
+    QUnit.test('options.allowIn', function (assert) {
         var ready = assert.async();
         var $fixture = $('#qunit-fixture');
         var shortcuts = shortcutRegistry($fixture);
@@ -382,7 +386,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
 
         shortcuts.add(
             'Alt+C',
-            function() {
+            function () {
                 assert.ok(true, 'The Alt+C shortcut has been caught');
                 if (!--expected) {
                     shortcuts.remove('Alt+C');
@@ -434,14 +438,14 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
 
     QUnit.module('Mouse');
 
-    QUnit.test('add', function(assert) {
+    QUnit.test('add', function (assert) {
         var ready = assert.async();
         var $target = $(document);
         var shortcuts = shortcutRegistry($target.get(0));
 
         assert.expect(3);
 
-        shortcuts.add('Alt+LeftMouseClick', function(event, keystroke) {
+        shortcuts.add('Alt+LeftMouseClick', function (event, keystroke) {
             assert.ok(true, 'The shortcut has been caught');
             assert.equal(typeof event, 'object', 'The event object is provided');
             assert.equal(keystroke, 'alt+clickLeft', 'The keystroke is provided');
@@ -457,21 +461,21 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
         });
     });
 
-    QUnit.test('remove', function(assert) {
+    QUnit.test('remove', function (assert) {
         var ready = assert.async();
         var $target = $(document);
         var shortcuts = shortcutRegistry($target.get(0));
 
         assert.expect(4);
 
-        shortcuts.add('Ctrl+RightMouseClick', function(event, keystroke) {
+        shortcuts.add('Ctrl+RightMouseClick', function (event, keystroke) {
             assert.ok(true, 'The shortcut has been caught');
             assert.equal(typeof event, 'object', 'The event object is provided');
             assert.equal(keystroke, 'control+clickRight', 'The keystroke is provided');
 
             shortcuts.remove('Ctrl+RightMouseClick');
 
-            $target.on('click.test-remove', function() {
+            $target.on('click.test-remove', function () {
                 $target.off('click.test-remove');
                 assert.ok(true, 'The shortcut has been removed');
                 ready();
@@ -495,7 +499,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
         });
     });
 
-    QUnit.test('exists', function(assert) {
+    QUnit.test('exists', function (assert) {
         var $target = $('#qunit-fixture');
         var shortcuts = shortcutRegistry($target.get(0));
 
@@ -511,14 +515,14 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
         assert.ok(!shortcuts.exists('shift+mouseScrollUp'), 'The removed shortcut must not exists anymore');
     });
 
-    QUnit.test('clear', function(assert) {
+    QUnit.test('clear', function (assert) {
         var ready = assert.async();
         var $target = $(document);
         var shortcuts = shortcutRegistry($target.get(0));
 
         assert.expect(6);
 
-        shortcuts.add('shift+mouseMiddleClick', function(event, keystroke) {
+        shortcuts.add('shift+mouseMiddleClick', function (event, keystroke) {
             assert.ok(true, 'The shortcut has been caught');
             assert.equal(typeof event, 'object', 'The event object is provided');
             assert.equal(keystroke, 'shift+clickMiddle', 'The keystroke is provided');
@@ -527,7 +531,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
             shortcuts.clear();
             assert.ok(!shortcuts.exists('shift+mouseMiddleClick'), 'The removed shortcut must not exists anymore');
 
-            $target.on('click.test-remove', function() {
+            $target.on('click.test-remove', function () {
                 $target.off('click.test-remove');
                 assert.ok(true, 'The shortcut has been removed');
                 ready();
@@ -551,7 +555,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
         });
     });
 
-    QUnit.test('all buttons', function(assert) {
+    QUnit.test('all buttons', function (assert) {
         var ready = assert.async();
         var $target = $(document);
         var shortcuts = shortcutRegistry($target.get(0));
@@ -559,40 +563,40 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
         assert.expect(16);
 
         Promise.all([
-            new Promise(function(resolve) {
-                shortcuts.add('Alt+LeftMouseClick', function(event, keystroke) {
+            new Promise(function (resolve) {
+                shortcuts.add('Alt+LeftMouseClick', function (event, keystroke) {
                     assert.ok(true, 'The shortcut has been caught');
                     assert.equal(typeof event, 'object', 'The event object is provided');
                     assert.equal(keystroke, 'alt+clickLeft', 'The keystroke is provided');
                     resolve();
                 });
             }),
-            new Promise(function(resolve) {
-                shortcuts.add('Alt+RightMouseClick', function(event, keystroke) {
+            new Promise(function (resolve) {
+                shortcuts.add('Alt+RightMouseClick', function (event, keystroke) {
                     assert.ok(true, 'The shortcut has been caught');
                     assert.equal(typeof event, 'object', 'The event object is provided');
                     assert.equal(keystroke, 'alt+clickRight', 'The keystroke is provided');
                     resolve();
                 });
             }),
-            new Promise(function(resolve) {
-                shortcuts.add('Alt+MiddleMouseClick', function(event, keystroke) {
+            new Promise(function (resolve) {
+                shortcuts.add('Alt+MiddleMouseClick', function (event, keystroke) {
                     assert.ok(true, 'The shortcut has been caught');
                     assert.equal(typeof event, 'object', 'The event object is provided');
                     assert.equal(keystroke, 'alt+clickMiddle', 'The keystroke is provided');
                     resolve();
                 });
             }),
-            new Promise(function(resolve) {
-                shortcuts.add('Alt+BackMouseClick', function(event, keystroke) {
+            new Promise(function (resolve) {
+                shortcuts.add('Alt+BackMouseClick', function (event, keystroke) {
                     assert.ok(true, 'The shortcut has been caught');
                     assert.equal(typeof event, 'object', 'The event object is provided');
                     assert.equal(keystroke, 'alt+clickBack', 'The keystroke is provided');
                     resolve();
                 });
             }),
-            new Promise(function(resolve) {
-                shortcuts.add('Alt+ForwardMouseClick', function(event, keystroke) {
+            new Promise(function (resolve) {
+                shortcuts.add('Alt+ForwardMouseClick', function (event, keystroke) {
                     assert.ok(true, 'The shortcut has been caught');
                     assert.equal(typeof event, 'object', 'The event object is provided');
                     assert.equal(keystroke, 'alt+clickForward', 'The keystroke is provided');
@@ -600,12 +604,12 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
                 });
             })
         ])
-            .then(function() {
+            .then(function () {
                 shortcuts.clear();
                 assert.ok(true, 'All done!');
                 ready();
             })
-            .catch(function() {
+            .catch(function () {
                 assert.ok(false, 'The promise should not fail!');
                 ready();
             });
@@ -649,24 +653,24 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
 
     QUnit.module('Error');
 
-    QUnit.test('keyboard and mouse', function(assert) {
+    QUnit.test('keyboard and mouse', function (assert) {
         var $target = $('#qunit-fixture');
         var shortcuts = shortcutRegistry($target.get(0));
 
         assert.expect(2);
 
-        assert.throws(function() {
+        assert.throws(function () {
             shortcuts.add('Ctrl+C+mouseLeftClick', $.noop);
         }, 'The helper refuses to register shortcut that mix keyboard and mouse');
 
-        assert.throws(function() {
+        assert.throws(function () {
             shortcuts.add('mouseLeftClick+V', $.noop);
         }, 'The helper refuses to register shortcut that mix keyboard and mouse');
     });
 
     QUnit.module('Namespace');
 
-    QUnit.test('add 2 namespaces, remove by using the full name', function(assert) {
+    QUnit.test('add 2 namespaces, remove by using the full name', function (assert) {
         var ready = assert.async();
         var $target = $('#qunit-fixture');
         var shortcuts = shortcutRegistry($target.get(0));
@@ -675,8 +679,8 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
         assert.expect(4);
 
         Promise.all([
-            new Promise(function(resolve) {
-                shortcuts.add('Meta+C.first', function(event, keystroke) {
+            new Promise(function (resolve) {
+                shortcuts.add('Meta+C.first', function (event, keystroke) {
                     assert.ok(true, 'The first shortcut handler has been called');
 
                     if (resolved) {
@@ -689,8 +693,8 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
                     }
                 });
             }),
-            new Promise(function(resolve) {
-                shortcuts.add('Meta+C.second', function(event, keystroke) {
+            new Promise(function (resolve) {
+                shortcuts.add('Meta+C.second', function (event, keystroke) {
                     assert.ok(true, 'The second shortcut handler has been called');
 
                     if (resolved) {
@@ -704,7 +708,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
                 });
             })
         ])
-            .then(function() {
+            .then(function () {
                 resolved = true;
                 shortcuts.remove('Meta+C.first');
 
@@ -720,7 +724,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
                     metaKey: true
                 });
             })
-            .catch(function() {
+            .catch(function () {
                 assert.ok(false, 'The promise should not fail!');
                 ready();
             });
@@ -738,7 +742,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
         });
     });
 
-    QUnit.test('add 2 namespaces, remove by using the namespace', function(assert) {
+    QUnit.test('add 2 namespaces, remove by using the namespace', function (assert) {
         var ready = assert.async();
         var $target = $('#qunit-fixture');
         var shortcuts = shortcutRegistry($target.get(0));
@@ -747,8 +751,8 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
         assert.expect(4);
 
         Promise.all([
-            new Promise(function(resolve) {
-                shortcuts.add('Meta+C.first', function(event, keystroke) {
+            new Promise(function (resolve) {
+                shortcuts.add('Meta+C.first', function (event, keystroke) {
                     assert.ok(true, 'The first shortcut handler has been called');
 
                     if (resolved) {
@@ -761,8 +765,8 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
                     }
                 });
             }),
-            new Promise(function(resolve) {
-                shortcuts.add('Meta+C.second', function(event, keystroke) {
+            new Promise(function (resolve) {
+                shortcuts.add('Meta+C.second', function (event, keystroke) {
                     assert.ok(true, 'The second shortcut handler has been called');
 
                     if (resolved) {
@@ -776,7 +780,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
                 });
             })
         ])
-            .then(function() {
+            .then(function () {
                 resolved = true;
                 shortcuts.remove('.first');
 
@@ -792,7 +796,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
                     metaKey: true
                 });
             })
-            .catch(function() {
+            .catch(function () {
                 assert.ok(false, 'The promise should not fail!');
                 ready();
             });
@@ -810,7 +814,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
         });
     });
 
-    QUnit.test('exists', function(assert) {
+    QUnit.test('exists', function (assert) {
         var $target = $('#qunit-fixture');
         var shortcuts = shortcutRegistry($target.get(0));
 
@@ -832,7 +836,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
         assert.ok(!shortcuts.exists('meta+c'), 'The shortcut has been removed');
     });
 
-    QUnit.test('clear', function(assert) {
+    QUnit.test('clear', function (assert) {
         var ready = assert.async();
         var $target = $('#qunit-fixture');
         var shortcuts = shortcutRegistry($target.get(0));
@@ -840,7 +844,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
 
         assert.expect(7);
 
-        shortcuts.add('Shift+C.first', function(event, keystroke) {
+        shortcuts.add('Shift+C.first', function (event, keystroke) {
             assert.ok(true, 'The shortcut has been caught');
             assert.equal(typeof event, 'object', 'The event object is provided');
             assert.equal(keystroke, 'shift+c', 'The keystroke is provided');
@@ -851,7 +855,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
             assert.equal(res, shortcuts, 'The helper returns itself');
             assert.ok(!shortcuts.exists('shift+c'), 'The removed shortcut must not exists anymore');
 
-            $target.on('keydown.test-remove', function() {
+            $target.on('keydown.test-remove', function () {
                 $target.off('keydown.test-remove');
                 assert.ok(true, 'The shortcut has been removed');
                 ready();
@@ -885,7 +889,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
 
     QUnit.module('State');
 
-    QUnit.test('setState/getState', function(assert) {
+    QUnit.test('setState/getState', function (assert) {
         var $target = $('#qunit-fixture');
         var shortcuts = shortcutRegistry($target.get(0));
         var res;
@@ -900,7 +904,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
         assert.ok(shortcuts.getState('disabled'), 'The shortcuts registry is disabled');
     });
 
-    QUnit.test('enable/disable', function(assert) {
+    QUnit.test('enable/disable', function (assert) {
         var $target = $('#qunit-fixture');
         var shortcuts = shortcutRegistry($target.get(0));
         var res;
@@ -920,7 +924,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
         assert.ok(!shortcuts.getState('disabled'), 'The shortcuts registry is enabled');
     });
 
-    QUnit.test('disable', function(assert) {
+    QUnit.test('disable', function (assert) {
         var ready = assert.async();
         var $target = $('#qunit-fixture');
         var shortcuts = shortcutRegistry($target.get(0));
@@ -928,7 +932,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
 
         assert.expect(6);
 
-        res = shortcuts.add('Meta+C', function(event, keystroke) {
+        res = shortcuts.add('Meta+C', function (event, keystroke) {
             assert.ok(true, 'The shortcut has been caught');
             assert.equal(typeof event, 'object', 'The event object is provided');
             assert.equal(keystroke, 'meta+c', 'The keystroke is provided');
@@ -936,7 +940,7 @@ define(['jquery', 'core/promise', 'util/shortcut/registry', 'jquery.simulate'], 
             res = shortcuts.disable();
             assert.equal(res, shortcuts, 'The helper returns itself');
 
-            $target.on('keydown.test-disabled', function() {
+            $target.on('keydown.test-disabled', function () {
                 $target.off('keydown.test-disabled');
                 assert.ok(true, 'The shortcut has been disabled');
                 ready();

--- a/test/util/shortcut/shortcut/test.js
+++ b/test/util/shortcut/shortcut/test.js
@@ -18,12 +18,12 @@
 /**
  * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
  */
-define(['jquery', 'util/shortcut', 'jquery.simulate'], function($, shortcutHelper) {
+define(['jquery', 'lodash', 'util/shortcut', 'jquery.simulate'], function ($, _, shortcutHelper) {
     'use strict';
 
     QUnit.module('shortcut');
 
-    QUnit.test('module', function(assert) {
+    QUnit.test('module', function (assert) {
         assert.expect(3);
 
         assert.equal(typeof shortcutHelper, 'object', 'The shortcutHelper module exposes an object');
@@ -33,17 +33,18 @@ define(['jquery', 'util/shortcut', 'jquery.simulate'], function($, shortcutHelpe
 
     QUnit.module('Keyboard');
 
-    QUnit.test('add', function(assert) {
+    QUnit.test('add', function (assert) {
         var ready = assert.async();
-        assert.expect(4);
 
-        var res = shortcutHelper.add('Meta+C', function(event, keystroke) {
+        var res = shortcutHelper.add('Meta+C', function (event, keystroke) {
             assert.ok(true, 'The shortcut has been caught');
             assert.equal(typeof event, 'object', 'The event object is provided');
             assert.equal(keystroke, 'meta+c', 'The keystroke is provided');
             shortcutHelper.remove('Meta+C');
             ready();
         });
+
+        assert.expect(4);
 
         assert.equal(res, shortcutHelper, 'The helper returns itself');
 
@@ -60,19 +61,19 @@ define(['jquery', 'util/shortcut', 'jquery.simulate'], function($, shortcutHelpe
         });
     });
 
-    QUnit.test('remove', function(assert) {
+    QUnit.test('remove', function (assert) {
         var ready = assert.async();
         assert.expect(5);
 
-        shortcutHelper.add('Ctrl+C', function(event, keystroke) {
+        shortcutHelper.add('Ctrl+C', function (event, keystroke) {
             assert.ok(true, 'The shortcut has been caught');
             assert.equal(typeof event, 'object', 'The event object is provided');
             assert.equal(keystroke, 'control+c', 'The keystroke is provided');
 
-            var res = shortcutHelper.remove('Ctrl+C');
+            const res = shortcutHelper.remove('Ctrl+C');
             assert.equal(res, shortcutHelper, 'The helper returns itself');
 
-            $(document).on('keydown.test-remove', function() {
+            $(document).on('keydown.test-remove', function () {
                 $(document).off('keydown.test-remove');
                 assert.ok(true, 'The shortcut has been removed');
                 ready();
@@ -104,7 +105,7 @@ define(['jquery', 'util/shortcut', 'jquery.simulate'], function($, shortcutHelpe
         });
     });
 
-    QUnit.test('exists', function(assert) {
+    QUnit.test('exists', function (assert) {
         assert.expect(3);
 
         shortcutHelper.add('Meta+C', _.noop);
@@ -117,22 +118,22 @@ define(['jquery', 'util/shortcut', 'jquery.simulate'], function($, shortcutHelpe
         assert.ok(!shortcutHelper.exists('meta+c'), 'The removed shortcut must not exists anymore');
     });
 
-    QUnit.test('clear', function(assert) {
+    QUnit.test('clear', function (assert) {
         var ready = assert.async();
         assert.expect(7);
 
-        shortcutHelper.add('Shift+C', function(event, keystroke) {
+        shortcutHelper.add('Shift+C', function (event, keystroke) {
             assert.ok(true, 'The shortcut has been caught');
             assert.equal(typeof event, 'object', 'The event object is provided');
             assert.equal(keystroke, 'shift+c', 'The keystroke is provided');
 
             assert.ok(shortcutHelper.exists('shift+c'), 'The registered shortcut must exists');
-            var res = shortcutHelper.clear();
+            const res = shortcutHelper.clear();
 
             assert.equal(res, shortcutHelper, 'The helper returns itself');
             assert.ok(!shortcutHelper.exists('shift+c'), 'The removed shortcut must not exists anymore');
 
-            $(document).on('keydown.test-remove', function() {
+            $(document).on('keydown.test-remove', function () {
                 $(document).off('keydown.test-remove');
                 assert.ok(true, 'The shortcut has been removed');
                 ready();
@@ -166,11 +167,11 @@ define(['jquery', 'util/shortcut', 'jquery.simulate'], function($, shortcutHelpe
 
     QUnit.module('Mouse');
 
-    QUnit.test('add', function(assert) {
+    QUnit.test('add', function (assert) {
         var ready = assert.async();
         assert.expect(3);
 
-        shortcutHelper.add('Meta+LeftMouseClick', function(event, keystroke) {
+        shortcutHelper.add('Meta+LeftMouseClick', function (event, keystroke) {
             assert.ok(true, 'The shortcut has been caught');
             assert.equal(typeof event, 'object', 'The event object is provided');
             assert.equal(keystroke, 'meta+clickLeft', 'The keystroke is provided');
@@ -186,18 +187,18 @@ define(['jquery', 'util/shortcut', 'jquery.simulate'], function($, shortcutHelpe
         });
     });
 
-    QUnit.test('remove', function(assert) {
+    QUnit.test('remove', function (assert) {
         var ready = assert.async();
         assert.expect(4);
 
-        shortcutHelper.add('Ctrl+RightMouseClick', function(event, keystroke) {
+        shortcutHelper.add('Ctrl+RightMouseClick', function (event, keystroke) {
             assert.ok(true, 'The shortcut has been caught');
             assert.equal(typeof event, 'object', 'The event object is provided');
             assert.equal(keystroke, 'control+clickRight', 'The keystroke is provided');
 
             shortcutHelper.remove('Ctrl+RightMouseClick');
 
-            $(document).on('click.test-remove', function() {
+            $(document).on('click.test-remove', function () {
                 $(document).off('click.test-remove');
                 assert.ok(true, 'The shortcut has been removed');
                 ready();
@@ -221,7 +222,7 @@ define(['jquery', 'util/shortcut', 'jquery.simulate'], function($, shortcutHelpe
         });
     });
 
-    QUnit.test('exists', function(assert) {
+    QUnit.test('exists', function (assert) {
         assert.expect(3);
 
         shortcutHelper.add('Shift+MouseScrollUp', $.noop);
@@ -234,11 +235,11 @@ define(['jquery', 'util/shortcut', 'jquery.simulate'], function($, shortcutHelpe
         assert.ok(!shortcutHelper.exists('shift+mouseScrollUp'), 'The removed shortcut must not exists anymore');
     });
 
-    QUnit.test('clear', function(assert) {
+    QUnit.test('clear', function (assert) {
         var ready = assert.async();
         assert.expect(6);
 
-        shortcutHelper.add('shift+mouseMiddleClick', function(event, keystroke) {
+        shortcutHelper.add('shift+mouseMiddleClick', function (event, keystroke) {
             assert.ok(true, 'The shortcut has been caught');
             assert.equal(typeof event, 'object', 'The event object is provided');
             assert.equal(keystroke, 'shift+clickMiddle', 'The keystroke is provided');
@@ -247,7 +248,7 @@ define(['jquery', 'util/shortcut', 'jquery.simulate'], function($, shortcutHelpe
             shortcutHelper.clear();
             assert.ok(!shortcutHelper.exists('shift+mouseMiddleClick'), 'The removed shortcut must not exists anymore');
 
-            $(document).on('click.test-remove', function() {
+            $(document).on('click.test-remove', function () {
                 $(document).off('click.test-remove');
                 assert.ok(true, 'The shortcut has been removed');
                 ready();
@@ -273,14 +274,14 @@ define(['jquery', 'util/shortcut', 'jquery.simulate'], function($, shortcutHelpe
 
     QUnit.module('Error');
 
-    QUnit.test('keyboard and mouse', function(assert) {
+    QUnit.test('keyboard and mouse', function (assert) {
         assert.expect(2);
 
-        assert.throws(function() {
+        assert.throws(function () {
             shortcutHelper.add('Ctrl+C+mouseLeftClick', $.noop);
         }, 'The helper refuses to register shortcut that mix keyboard and mouse');
 
-        assert.throws(function() {
+        assert.throws(function () {
             shortcutHelper.add('mouseLeftClick+V', $.noop);
         }, 'The helper refuses to register shortcut that mix keyboard and mouse');
     });

--- a/test/util/url/test.js
+++ b/test/util/url/test.js
@@ -22,7 +22,7 @@
  *
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
-define(['util/url', 'context'], function(urlUtil, context) {
+define(['util/url', 'context'], function (urlUtil, context) {
     'use strict';
 
     var parseDataProvider;
@@ -34,7 +34,7 @@ define(['util/url', 'context'], function(urlUtil, context) {
 
     QUnit.module('API');
 
-    QUnit.test('util api', function(assert) {
+    QUnit.test('util api', function (assert) {
         assert.expect(8);
 
         assert.ok(typeof urlUtil === 'object', 'The urlUtil module exposes an object');
@@ -94,12 +94,12 @@ define(['util/url', 'context'], function(urlUtil, context) {
         }
     ];
 
-    QUnit.cases.init(parseDataProvider).test('parse ', function(data, assert) {
+    QUnit.cases.init(parseDataProvider).test('parse ', function (data, assert) {
         var key;
         var result = urlUtil.parse(data.url);
         assert.ok(typeof result === 'object', 'The result is an object');
         for (key in data.expected) {
-            assert.equal(result[key], data.expected[key], key + ' has the expected value');
+            assert.equal(result[key], data.expected[key], `${key} has the expected value`);
         }
     });
 
@@ -153,29 +153,29 @@ define(['util/url', 'context'], function(urlUtil, context) {
         }
     ];
 
-    QUnit.cases.init(isAbsoluteDataProvider).test('isAbsolute ', function(data, assert) {
+    QUnit.cases.init(isAbsoluteDataProvider).test('isAbsolute ', function (data, assert) {
         assert.equal(
             urlUtil.isAbsolute(data.url),
             data.absolute,
-            'The URL ' + data.url + ' ' + (data.absolute ? 'is' : 'is not') + ' absolute'
+            `The URL ${data.url} ${data.absolute ? 'is' : 'is not'} absolute`
         );
         assert.equal(
             urlUtil.isAbsolute(urlUtil.parse(data.url)),
             data.absolute,
-            'The parsed URL ' + data.url + ' ' + (data.absolute ? 'is' : 'is not') + ' absolute'
+            `The parsed URL ${data.url} ${data.absolute ? 'is' : 'is not'} absolute`
         );
     });
 
-    QUnit.cases.init(isAbsoluteDataProvider).test('isRelative ', function(data, assert) {
+    QUnit.cases.init(isAbsoluteDataProvider).test('isRelative ', function (data, assert) {
         assert.equal(
             urlUtil.isRelative(data.url),
             !data.absolute,
-            'The URL ' + data.url + ' ' + (!data.absolute ? 'is' : 'is not') + ' relative'
+            `'The URL ${data.url} ${!data.absolute ? 'is' : 'is not'} relative`
         );
         assert.equal(
             urlUtil.isRelative(urlUtil.parse(data.url)),
             !data.absolute,
-            'The parsed URL ' + data.url + ' ' + (!data.absolute ? 'is' : 'is not') + ' relative'
+            `The parsed URL ${data.url} ${!data.absolute ? 'is' : 'is not'} relative`
         );
     });
 
@@ -197,22 +197,17 @@ define(['util/url', 'context'], function(urlUtil, context) {
         },
         {
             title: 'base64 image',
-            url:
-                'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29mdHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAFiSURBVBgZpcEhbpRRGIXh99x7IU0asGBJWEIdCLaAqcFiCArFCkjA0KRJF0EF26kkFbVVdEj6/985zJ0wBjfp8ygJD6G3n358fP3m5NvtJscJYBObchEHx6QKJ6SKsnn6eLm7urr5/PP76cU4eXVy/ujouD074hDHd5s6By7GZknb3P7mUH+WNLZGKnx595JDvf96zTQSM92vRYA4lMEEO5RNraHWUDH3FV48f0K5mAYJk5pQQpqIgixaE1JDKtRDd2OsYfJaTKNcTA2IBIIesMAOPdDUGYJSqGYml5lGHHYkSGhAJBBIkAoWREAT3Z3JLqZhF3uS2EloQCQ8xLBxoAEWO7aZxros7EgISIIkwlZCY6s1OlAJTWFal5VppMzUgbAlQcIkiT0DXSI2U2ymYZs9AWJL4n+df3pncsI0bn5dX344W05dhctUFbapZcE2ToiLVHBMbGymS7aUhIdoPNBf7Jjw/gQ77u4AAAAASUVORK5CYII=',
+            url: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29mdHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAFiSURBVBgZpcEhbpRRGIXh99x7IU0asGBJWEIdCLaAqcFiCArFCkjA0KRJF0EF26kkFbVVdEj6/985zJ0wBjfp8ygJD6G3n358fP3m5NvtJscJYBObchEHx6QKJ6SKsnn6eLm7urr5/PP76cU4eXVy/ujouD074hDHd5s6By7GZknb3P7mUH+WNLZGKnx595JDvf96zTQSM92vRYA4lMEEO5RNraHWUDH3FV48f0K5mAYJk5pQQpqIgixaE1JDKtRDd2OsYfJaTKNcTA2IBIIesMAOPdDUGYJSqGYml5lGHHYkSGhAJBBIkAoWREAT3Z3JLqZhF3uS2EloQCQ8xLBxoAEWO7aZxros7EgISIIkwlZCY6s1OlAJTWFal5VppMzUgbAlQcIkiT0DXSI2U2ymYZs9AWJL4n+df3pncsI0bn5dX344W05dhctUFbapZcE2ToiLVHBMbGymS7aUhIdoPNBf7Jjw/gQ77u4AAAAASUVORK5CYII=',
             b64: true
         }
     ];
 
-    QUnit.cases.init(isB64DataProvider).test('isBase64 ', function(data, assert) {
-        assert.equal(
-            urlUtil.isBase64(data.url),
-            data.b64,
-            'The URL ' + (data.b64 ? 'is' : 'is not') + ' encoded in base 64'
-        );
+    QUnit.cases.init(isB64DataProvider).test('isBase64 ', function (data, assert) {
+        assert.equal(urlUtil.isBase64(data.url), data.b64, `The URL ${data.b64 ? 'is' : 'is not'} encoded in base 64`);
         assert.equal(
             urlUtil.isBase64(urlUtil.parse(data.url)),
             data.b64,
-            'The URL ' + (data.b64 ? 'is' : 'is not') + ' encoded in base 64'
+            `The URL ${data.b64 ? 'is' : 'is not'} encoded in base 64`
         );
     });
 
@@ -246,7 +241,7 @@ define(['util/url', 'context'], function(urlUtil, context) {
         }
     ];
 
-    QUnit.cases.init(attributesDataProvider).test('encodeAsXmlAttr ', function(data, assert) {
+    QUnit.cases.init(attributesDataProvider).test('encodeAsXmlAttr ', function (data, assert) {
         assert.equal(urlUtil.encodeAsXmlAttr(data.url), data.encoded);
         assert.equal(decodeURIComponent(data.encoded), data.url);
     });
@@ -304,7 +299,7 @@ define(['util/url', 'context'], function(urlUtil, context) {
         }
     ];
 
-    QUnit.cases.init(buildDataProvider).test('from ', function(data, assert) {
+    QUnit.cases.init(buildDataProvider).test('from ', function (data, assert) {
         var result = urlUtil.build(data.path, data.params);
         assert.equal(result, data.expected, 'The URL is built');
     });
@@ -372,11 +367,11 @@ define(['util/url', 'context'], function(urlUtil, context) {
         }
     ];
 
-    QUnit.cases.init(routeDataProvider).test('route ', function(data, assert) {
+    QUnit.cases.init(routeDataProvider).test('route ', function (data, assert) {
         var result;
         if (data.exception) {
             assert.throws(
-                function() {
+                function () {
                     urlUtil.route(data.action, data.controller, data.extension, data.params, data.rootUrl);
                 },
                 TypeError,


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1166

### Summary

Fix the ESLint error in the unit tests for `tao-core-utils`.

**Note:** as the changes are pretty heavy, I split them all into several pull requests.

### Details

This pull request only targets the `test/util/*` part of the library.
The full picture can be seen from the main branch which contains all the fixes: https://github.com/oat-sa/tao-core-sdk-fe.git#fix/ADF-1166/eslint-errors

What has been made:
- fix errors that can be automated using `eslint --fix`, then adjust the changes in case by case (mostly string literals)
- fix the wrong annotations (missing/wrong return or param definition)
- fix the more complex cases with some refactoring (rest operator instead of `.apply()`)
- replace `var` by `const` or `let` (but not in all places, only in the touched files when it was not adding too much noise)
- apply object shorthand instead of duplicated function names
- apply arrow functions here and there when it helped, but not systematically to reduce the noise

### How to test
- checkout and install the source code `npm i`
- run the linter: `npm run lint:test`, errors and warnings coming from the `utils` folder should have gone.
- run the unit tests: `npm run test utils`
- install with other repositories, using the following scheme: `"@oat-sa/tao-core-sdk": "https://github.com/oat-sa/tao-core-sdk-fe.git#fix/ADF-1166/eslint-errors",`, then checking the unit tests and playing with TAO