### PR TITLE
Fix/ADF-1166/ESlint errors in core source code

### DIFF
--- a/src/core/cachedStore.js
+++ b/src/core/cachedStore.js
@@ -24,7 +24,7 @@ import store from 'core/store';
  * The default name of the key storage indexing the persisted data
  * @type {String}
  */
-var defaultKey = 'cachedData';
+const defaultKey = 'cachedData';
 
 /**
  * Builds a cached store.
@@ -38,8 +38,8 @@ var defaultKey = 'cachedData';
 function cachedStoreFactory(storageName, storageKey) {
     storageKey = storageKey || defaultKey;
 
-    return store(storageName).then(function(storage) {
-        return storage.getItem(storageKey).then(function(data) {
+    return store(storageName).then(function (storage) {
+        return storage.getItem(storageKey).then(function (data) {
             // the persisted data set is always an object
             data = data || {};
 
@@ -52,7 +52,7 @@ function cachedStoreFactory(storageName, storageKey) {
                  * @param {String} name
                  * @returns {Object}
                  */
-                getItem: function getItem(name) {
+                getItem(name) {
                     return data[name];
                 },
 
@@ -62,7 +62,7 @@ function cachedStoreFactory(storageName, storageKey) {
                  * @param {Object} value
                  * @returns {Promise} Returns a promise that will be resolved if the data have been successfully stored
                  */
-                setItem: function setItem(name, value) {
+                setItem(name, value) {
                     data[name] = value;
                     return storage.setItem(storageKey, data);
                 },
@@ -72,8 +72,8 @@ function cachedStoreFactory(storageName, storageKey) {
                  * @param {String} name
                  * @returns {Promise} Returns a promise that will be resolved if the data have been successfully stored
                  */
-                removeItem: function removeItem(name) {
-                    data[name] = undefined;
+                removeItem(name) {
+                    data[name] = void 0;
                     return storage.setItem(storageKey, data);
                 },
 
@@ -81,7 +81,7 @@ function cachedStoreFactory(storageName, storageKey) {
                  * Clears the full data set
                  * @returns {Promise} Returns a promise that will be resolved if the data have been successfully erased
                  */
-                clear: function clear() {
+                clear() {
                     data = {};
                     return storage.removeItem(storageKey);
                 },
@@ -90,7 +90,7 @@ function cachedStoreFactory(storageName, storageKey) {
                  * Delete the database related to the current store
                  * @returns {Promise} with true in resolve once cleared
                  */
-                removeStore: function removeStore() {
+                removeStore() {
                     data = {};
                     return storage.removeStore();
                 }

--- a/src/core/customEvent.js
+++ b/src/core/customEvent.js
@@ -19,8 +19,8 @@
  * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
  */
 
-var createEvent;
-var dispatchEvent;
+let createEvent;
+let dispatchEvent;
 
 /**
  * Creates an event
@@ -30,7 +30,7 @@ var dispatchEvent;
  */
 if (window.CustomEvent) {
     createEvent = function createEventUsingCustomEvent(eventName, data) {
-        var event;
+        let event;
         try {
             event = new CustomEvent(eventName, {
                 detail: data,
@@ -45,14 +45,14 @@ if (window.CustomEvent) {
     };
 } else if (document.createEvent) {
     createEvent = function createEventUsingCreateEvent(eventName, data) {
-        var event = document.createEvent('Event');
+        const event = document.createEvent('Event');
         event.initEvent(eventName, true, true);
         event.detail = data;
         return event;
     };
 } else if (document.createEventObject) {
     createEvent = function createEventUsingCreateEventObject(eventName, data) {
-        var event = document.createEventObject();
+        const event = document.createEventObject();
         event.detail = data;
         return event;
     };
@@ -79,7 +79,7 @@ if (document.dispatchEvent) {
 } else if (document.fireEvent) {
     dispatchEvent = function dispatchEventUsingFireEvent(element, eventName, event) {
         if (element) {
-            element.fireEvent('on' + eventName, event);
+            element.fireEvent(`on${eventName}`, event);
             return true;
         }
         return false;
@@ -97,9 +97,9 @@ if (document.dispatchEvent) {
  * @param {*} data
  * @returns {Boolean} Returns true if the event has been successfully triggered
  */
-var triggerCustomEvent = function triggerCustomEvent(element, eventName, data) {
-    var event = createEvent(eventName, data);
+function triggerCustomEvent(element, eventName, data) {
+    const event = createEvent(eventName, data);
     return dispatchEvent(element, eventName, event);
-};
+}
 
 export default triggerCustomEvent;

--- a/src/core/dataProvider/proxy.js
+++ b/src/core/dataProvider/proxy.js
@@ -25,7 +25,7 @@ import Promise from 'core/promise';
 import providerRegistry from 'core/providerRegistry';
 import tokenHandlerFactory from 'core/tokenHandler';
 
-var _defaults = {};
+const _defaults = {};
 
 /**
  * Defines a CRUD proxy bound to a particular adapter. Each adapter will have to provide the following API:
@@ -43,16 +43,16 @@ var _defaults = {};
  * @returns {proxy} - The proxy instance, bound to the selected proxy adapter
  */
 function crudProxyFactory(proxyName, middlewares) {
-    var proxyAdapter = crudProxyFactory.getProvider(proxyName);
-    var tokenHandler = tokenHandlerFactory();
-    var extraParams = {};
-    var initialized = false;
-    var initConfig;
+    const proxyAdapter = crudProxyFactory.getProvider(proxyName);
+    const tokenHandler = tokenHandlerFactory();
+    let extraParams = {};
+    let initialized = false;
+    let initConfig;
 
     /**
      * @typedef {proxy}
      */
-    var proxy = eventifier({
+    const proxy = eventifier({
         /**
          * Initializes the proxy
          * @param {Object} [config] - Some optional config depending of implementation,
@@ -62,7 +62,7 @@ function crudProxyFactory(proxyName, middlewares) {
          *                      Any error will be provided if rejected.
          * @fires init
          */
-        init: function init(config) {
+        init(config) {
             initConfig = _.defaults({}, config, _defaults);
 
             /**
@@ -70,7 +70,7 @@ function crudProxyFactory(proxyName, middlewares) {
              * @param {Promise} promise
              * @param {Object} params
              */
-            return delegate('init', initConfig).then(function() {
+            return delegate('init', initConfig).then(function () {
                 // If the delegate call succeed the proxy is initialized.
                 initialized = true;
                 return proxy;
@@ -83,12 +83,12 @@ function crudProxyFactory(proxyName, middlewares) {
          *                      Any error will be provided if rejected.
          * @fires destroy
          */
-        destroy: function destroy() {
+        destroy() {
             /**
              * @event destroy
              * @param {Promise} promise
              */
-            return delegate('destroy').then(function() {
+            return delegate('destroy').then(function () {
                 // The proxy is now destroyed. A call to init() is mandatory to be able to use it again.
                 initialized = false;
                 initConfig = null;
@@ -103,7 +103,7 @@ function crudProxyFactory(proxyName, middlewares) {
          *                      Any error will be provided if rejected.
          * @fires create
          */
-        create: function create(params) {
+        create(params) {
             /**
              * @event create
              * @param {Promise} promise
@@ -119,7 +119,7 @@ function crudProxyFactory(proxyName, middlewares) {
          *                      Any error will be provided if rejected.
          * @fires read
          */
-        read: function read(params) {
+        read(params) {
             /**
              * @event read
              * @param {Promise} promise
@@ -135,7 +135,7 @@ function crudProxyFactory(proxyName, middlewares) {
          *                      Any error will be provided if rejected.
          * @fires write
          */
-        write: function write(params) {
+        write(params) {
             /**
              * @event write
              * @param {Promise} promise
@@ -151,7 +151,7 @@ function crudProxyFactory(proxyName, middlewares) {
          *                      Any error will be provided if rejected.
          * @fires remove
          */
-        remove: function remove(params) {
+        remove(params) {
             /**
              * @event remove
              * @param {Promise} promise
@@ -168,7 +168,7 @@ function crudProxyFactory(proxyName, middlewares) {
          *                      Any error will be provided if rejected.
          * @fires action
          */
-        action: function action(name, params) {
+        action(name, params) {
             /**
              * @event action
              * @param {Promise} promise
@@ -183,7 +183,7 @@ function crudProxyFactory(proxyName, middlewares) {
          * @param {Object} params - the extra parameters
          * @returns {proxy}
          */
-        addExtraParams: function addExtraParams(params) {
+        addExtraParams(params) {
             if (_.isPlainObject(params)) {
                 _.merge(extraParams, params);
             }
@@ -194,7 +194,7 @@ function crudProxyFactory(proxyName, middlewares) {
          * Gets the security token handler
          * @returns {tokenHandler}
          */
-        getTokenHandler: function getTokenHandler() {
+        getTokenHandler() {
             return tokenHandler;
         },
 
@@ -202,7 +202,7 @@ function crudProxyFactory(proxyName, middlewares) {
          * Gets the config object
          * @returns {Object}
          */
-        getConfig: function getConfig() {
+        getConfig() {
             return initConfig;
         },
 
@@ -210,7 +210,7 @@ function crudProxyFactory(proxyName, middlewares) {
          * Gets the middlewares handler
          * @returns {middlewareHandler}
          */
-        getMiddlewares: function getMidlewares() {
+        getMiddlewares() {
             return middlewares;
         },
 
@@ -219,15 +219,15 @@ function crudProxyFactory(proxyName, middlewares) {
          * @param {middlewareHandler} [handler] - An optional middlewares handler
          * @returns {proxy}
          */
-        setMiddlewares: function setMidlewares(handler) {
+        setMiddlewares(handler) {
             middlewares = handler;
             return this;
         }
     });
 
-    var delegateProxy = delegator(proxy, proxyAdapter, {
+    const delegateProxy = delegator(proxy, proxyAdapter, {
         name: 'proxy',
-        wrapper: function proxyWrapper(response) {
+        wrapper(response) {
             return Promise.resolve(response);
         }
     });
@@ -235,11 +235,11 @@ function crudProxyFactory(proxyName, middlewares) {
     /**
      * Gets parameters merged with extra parameters
      * @param {Object} [params]
-     * @return {Object}
+     * @returns {Object}
      * @private
      */
     function getParams(params) {
-        var mergedParams = _.merge({}, params, extraParams);
+        const mergedParams = _.merge({}, params, extraParams);
         extraParams = {};
         return mergedParams;
     }
@@ -248,24 +248,24 @@ function crudProxyFactory(proxyName, middlewares) {
      * Delegates the call to the proxy implementation and apply the middleware.
      *
      * @param {String} fnName - The name of the delegated method to call
+     * @param {...*} [params] - Additional parameters
      * @returns {Promise} - The delegated method must return a promise
      * @private
      * @throws Error
      */
-    function delegate(fnName) {
-        var request = { command: fnName, params: Array.prototype.slice.call(arguments, 1) };
+    function delegate(fnName, ...params) {
+        const request = { command: fnName, params };
         if (!initialized && fnName !== 'init') {
             return Promise.reject(new Error('Proxy is not properly initialized or has been destroyed!'));
         }
-        return delegateProxy
-            .apply(null, arguments)
-            .then(function(data) {
+        return delegateProxy(fnName, ...params)
+            .then(function (data) {
                 if (middlewares) {
                     return middlewares.apply(request, data);
                 }
                 return data;
             })
-            .catch(function(err) {
+            .catch(function (err) {
                 proxy.trigger('error', err);
                 return Promise.reject(err);
             });

--- a/src/core/dataProvider/proxy/ajax.js
+++ b/src/core/dataProvider/proxy/ajax.js
@@ -22,7 +22,7 @@ import _ from 'lodash';
 import request from 'core/dataProvider/request';
 import Promise from 'core/promise';
 
-var _defaults = {
+const _defaults = {
     noCache: true,
     noToken: false,
     actions: {}
@@ -81,14 +81,20 @@ export default {
      * @param {Boolean} [config.noCache] - Prevent the request to be cached by the client (default: true)
      * @param {Boolean} [config.noToken] - Prevent the request to be use the security token when available (default: false)
      */
-    init: function init(config) {
-        // Will request the server for the wanted action.
-        // May reject the request if the action is not implemented.
+    init(config) {
+        /**
+         * Will request the server for the wanted action.
+         * May reject the request if the action is not implemented.
+         * @param {string} action
+         * @param {object} params
+         * @param {string} method
+         * @returns {Promise|*}
+         */
         this.processRequest = function processRequest(action, params, method) {
-            var descriptor = config.actions[action];
-            var headers = {};
-            var tokenHandler = this.getTokenHandler();
-            var token;
+            let descriptor = config.actions[action];
+            const headers = {};
+            const tokenHandler = this.getTokenHandler();
+            let token;
 
             if (_.isString(descriptor)) {
                 descriptor = {
@@ -118,14 +124,14 @@ export default {
             }
 
             return request(descriptor.url, params, descriptor.method || method, headers)
-                .then(function(data) {
+                .then(function (data) {
                     if (data && data.token) {
                         tokenHandler.setToken(data.token);
                     }
                     return data;
                 })
-                .catch(function(err) {
-                    var t = err.response && (err.response.token || (err.response.data && err.response.data.token));
+                .catch(function (err) {
+                    const t = err.response && (err.response.token || (err.response.data && err.response.data.token));
                     if (t) {
                         tokenHandler.setToken(t);
                     } else if (!config.noToken) {
@@ -142,39 +148,43 @@ export default {
     /**
      * Cleans up the instance when destroying
      */
-    destroy: function destroy() {
+    destroy() {
         this.processRequest = null;
     },
 
     /**
      * Requests the server for a create action
      * @param {Object} params
+     * @returns {Promise}
      */
-    create: function create(params) {
+    create(params) {
         return this.processRequest('create', params, 'POST');
     },
 
     /**
      * Requests the server for a read action
      * @param {Object} params
+     * @returns {Promise}
      */
-    read: function read(params) {
+    read(params) {
         return this.processRequest('read', params, 'GET');
     },
 
     /**
      * Requests the server for a write action
      * @param {Object} params
+     * @returns {Promise}
      */
-    write: function write(params) {
+    write(params) {
         return this.processRequest('write', params, 'POST');
     },
 
     /**
      * Requests the server for a remove action
      * @param {Object} params
+     * @returns {Promise}
      */
-    remove: function remove(params) {
+    remove(params) {
         return this.processRequest('remove', params, 'GET');
     },
 
@@ -182,8 +192,9 @@ export default {
      * Requests the server using a particular action
      * @param {String} actionName
      * @param {Object} params
+     * @returns {Promise}
      */
-    action: function action(actionName, params) {
+    action(actionName, params) {
         return this.processRequest(actionName, params, 'POST');
     }
 };

--- a/src/core/dataProvider/request.js
+++ b/src/core/dataProvider/request.js
@@ -62,8 +62,7 @@ export default function request(url, data, method, headers, background, noToken)
             return Promise.resolve();
         } else if (response.success) {
             return Promise.resolve(response.data);
-        }
-        else {
+        } else {
             return Promise.reject(response); // in case success:false different types of response
         }
     })

--- a/src/core/dataattrhandler.js
+++ b/src/core/dataattrhandler.js
@@ -24,29 +24,29 @@
 import $ from 'jquery';
 import _ from 'lodash';
 
-var defaults = {
+const defaults = {
     container: false,
     listenerEvent: 'click',
     useTarget: true,
     bubbled: false
 };
 
-var letDefaultOn = [':radio', ':checkbox'];
+const letDefaultOn = [':radio', ':checkbox'];
 
 /**
  * Some elements (listed in letDefaultOn) need the usual action to be triggered, check that
- * @param {jQueryElement} $elt
+ * @param {jQuery} $elt
  * @returns {boolean}
  */
-var shouldPreventDefault = function shouldPreventDefault($elt) {
+function shouldPreventDefault($elt) {
     return !$elt.is(letDefaultOn.join(','));
-};
+}
 
 /**
  * This callback is used either to perform actions on data-attr element
  * @callback dataAttrCallback
- * @params {jQueryElmement} $elt - the element that contains the data-attr
- * @params {jQueryElmement} $target - the element targeted by the data-attr
+ * @params {jQuery} $elt - the element that contains the data-attr
+ * @params {jQuery} $target - the element targeted by the data-attr
  */
 
 /**
@@ -54,21 +54,20 @@ var shouldPreventDefault = function shouldPreventDefault($elt) {
  * and bound a jQuery plugin behavior.
  * @exports core/dataattrhandler
  *
- * @contructor
+ * @constructor
  * @param {string} attrName - the name of the attribute, ie. `toggle` for `data-toggle`
  * @param {Object} options - the handler options
  * @param {string} options.namespace - the jQuery plugin namespace
- * @param {jQueryElement|boolean} [options.container = false] - the root context to listen in
+ * @param {jQuery|boolean} [options.container = false] - the root context to listen in
  * @param {string} [options.listenerEvent = 'click'] - the event to listen on
  * @param {boolean} [options.preventDefault = true] - to prevent the default event to be fired
  * @param {string} [options.inner] - a selector inside the element to bind the event to
  * @param {boolean} [options.useTarget = true] - if the content of the data-attr is as target or not
  * @param {boolean} [options.bubbled = false] - handle the event if bubbled from a child
  */
-var DataAttrHandler = function construct(attrName, options) {
-    var self = this;
+function DataAttrHandler(attrName, options) {
     this.options = _.defaults(options, defaults);
-    var selector = '[data-' + attrName + ']';
+    let selector = `[data-${attrName}]`;
 
     //check namespace
     if (!_.has(this.options, 'namespace') || !_.isString(this.options.namespace)) {
@@ -76,57 +75,57 @@ var DataAttrHandler = function construct(attrName, options) {
     }
 
     if (this.options.container && this.options.container.selector) {
-        selector = this.options.container.selector + ' ' + selector;
+        selector = `${this.options.container.selector} ${selector}`;
     }
 
     if (this.options.inner) {
-        selector += ' ' + this.options.inner;
+        selector += ` ${this.options.inner}`;
     }
 
     //listen for events on selector (the listening works even though the DOM changes).
     $(document)
         .off(this.options.listenerEvent, selector)
-        .on(this.options.listenerEvent, selector, function(e) {
-            var $elt = $(e.target);
-            if (self.options.bubbled === true || $elt.is(selector)) {
-                var $target, $outer;
+        .on(this.options.listenerEvent, selector, e => {
+            let $elt = $(e.target);
+            if (this.options.bubbled === true || $elt.is(selector)) {
+                let $outer;
 
-                if ($elt.data(attrName) === undefined && (self.options.inner || self.options.bubbled)) {
+                if (typeof $elt.data(attrName) === 'undefined' && (this.options.inner || this.options.bubbled)) {
                     $outer = $elt;
-                    $elt = $elt.parents('[data-' + attrName + ']');
+                    $elt = $elt.parents(`[data-${attrName}]`);
                 }
 
-                $target =
-                    self.options.useTarget === true
-                        ? DataAttrHandler.getTarget(attrName, $elt)
-                        : self.options.inner
-                        ? $outer
-                        : undefined;
+                let $target;
+                if (this.options.useTarget === true) {
+                    $target = DataAttrHandler.getTarget(attrName, $elt);
+                } else if (this.options.inner) {
+                    $target = $outer;
+                }
 
                 //check if the plugin is already bound to the element
-                if (!$elt.data(self.options.namespace)) {
-                    if (typeof self.createPlugin === 'function') {
-                        self.createPlugin($elt, $target);
+                if (!$elt.data(this.options.namespace)) {
+                    if (typeof this.createPlugin === 'function') {
+                        this.createPlugin($elt, $target);
                     }
 
                     //for radio bind also the method call to the group...
                     if ($elt.is(':radio') && $elt.attr('name')) {
-                        $(':radio[name="' + $elt.attr('name') + '"]')
+                        $(`:radio[name="${$elt.attr('name')}"]`)
                             .not($elt)
-                            .on(self.options.listenerEvent, function(e) {
-                                if (typeof self.callPluginMethod === 'function') {
-                                    self.callPluginMethod($elt, $target);
+                            .on(this.options.listenerEvent, ev => {
+                                if (typeof this.callPluginMethod === 'function') {
+                                    this.callPluginMethod($elt, $target);
                                 }
                                 if (shouldPreventDefault($elt)) {
-                                    e.preventDefault();
+                                    ev.preventDefault();
                                 }
                             });
                     }
                 }
 
                 //call the method bound to this event
-                if (typeof self.callPluginMethod === 'function') {
-                    self.callPluginMethod($elt, $target);
+                if (typeof this.callPluginMethod === 'function') {
+                    this.callPluginMethod($elt, $target);
                 } /*else {
                     //if there is no action to call we top listening (init plugin only)
                     $(document).off(self.options.listenerEvent, selector);
@@ -137,7 +136,7 @@ var DataAttrHandler = function construct(attrName, options) {
                 }
             }
         });
-};
+}
 
 /**
  * Add the callback used to initialise the plugin,
@@ -145,7 +144,7 @@ var DataAttrHandler = function construct(attrName, options) {
  * @param {dataAttrCallback} cb - callback
  * @returns {DataAttrHandler} for chaining
  */
-DataAttrHandler.prototype.init = function(cb) {
+DataAttrHandler.prototype.init = function init(cb) {
     this.createPlugin = cb;
 
     return this;
@@ -156,7 +155,7 @@ DataAttrHandler.prototype.init = function(cb) {
  * @param {dataAttrCallback} cb - callback
  * @returns {DataAttrHandler} for chaining
  */
-DataAttrHandler.prototype.trigger = function(cb) {
+DataAttrHandler.prototype.trigger = function trigger(cb) {
     this.callPluginMethod = cb;
 
     return this;
@@ -167,18 +166,18 @@ DataAttrHandler.prototype.trigger = function(cb) {
  * The value of the data-attr is a CSS selector, it will be applied directly or with $elt as context.
  *
  * @param {String} attrName - the name of the attribute, ie. `toggle` for `data-toggle`
- * @param {jQueryElement} $elt - the element that holds the data attr
- * @returns {jQueryElement} the target
+ * @param {jQuery} $elt - the element that holds the data attr
+ * @returns {jQuery} the target
  */
 DataAttrHandler.getTarget = function getTarget(attrName, $elt) {
-    var relativeRegex = /^(\+|>|~|:parent|<)/;
-    var $target = [];
-    var targetSelector = $elt.attr('data-' + attrName) || $elt.attr('href') || $elt.attr('attrName');
+    const relativeRegex = /^(\+|>|~|:parent|<)/;
+    let $target = [];
+    const targetSelector = $elt.attr(`data-${attrName}`) || $elt.attr('href') || $elt.attr('attrName');
     if (!_.isEmpty(targetSelector)) {
         //try to contextualize from the current element before selcting globally
-        var matches = relativeRegex.exec(targetSelector);
+        const matches = relativeRegex.exec(targetSelector);
         if (matches !== null) {
-            var selector = targetSelector.replace(relativeRegex, '');
+            const selector = targetSelector.replace(relativeRegex, '');
             if (matches[0] === ':parent' || matches[0] === '<') {
                 $target = $elt.parents(selector);
             } else if (matches[0] === '~') {

--- a/src/core/databindcontroller.js
+++ b/src/core/databindcontroller.js
@@ -21,16 +21,16 @@ import _ from 'lodash';
 import DataBinder from 'core/databinder';
 
 export default {
-    takeControl: function($container, options) {
-        var control = {};
-        var model = {};
-        var binderOpts = _.pick(options, function(value, key) {
+    takeControl($container, options) {
+        const control = {};
+        let model = {};
+        const binderOpts = _.pick(options, function (value, key) {
             return key === 'encoders' || key === 'filters' || key === 'templates';
         });
 
         if (options.get) {
-            control.get = function get(cb, errBack) {
-                $.getJSON(options.get).done(function(data) {
+            control.get = function get(cb) {
+                $.getJSON(options.get).done(function (data) {
                     if (data) {
                         model = data;
                         new DataBinder($container, model, binderOpts).bind();
@@ -44,7 +44,7 @@ export default {
         }
         if (options.save) {
             control.save = function save(cb, errBack) {
-                var allowSave = true;
+                let allowSave = true;
                 if (typeof options.beforeSave === 'function') {
                     allowSave = !!options.beforeSave(model);
                 }
@@ -52,7 +52,7 @@ export default {
                     $.post(
                         options.save,
                         { model: JSON.stringify(model) },
-                        function(data) {
+                        function (data) {
                             if (data) {
                                 if (typeof cb === 'function') {
                                     cb(data);
@@ -60,7 +60,7 @@ export default {
                             }
                         },
                         'json'
-                    ).fail(function() {
+                    ).fail(function () {
                         if (typeof errBack === 'function') {
                             errBack();
                         }

--- a/src/core/delegator.js
+++ b/src/core/delegator.js
@@ -20,12 +20,10 @@
  */
 import _ from 'lodash';
 
-var defaults = {
+const defaults = {
     name: 'provided',
     eventifier: true
 };
-
-var _slice = [].slice;
 
 /**
  * Creates a function that delegates api calls to an provider
@@ -41,12 +39,12 @@ var _slice = [].slice;
  * @returns {delegate} - The delegate function
  */
 function delegator(api, provider, config) {
-    var extendedConfig = _.defaults(config || {}, defaults);
-    var eventifier = !!(extendedConfig.eventifier && api && api.trigger);
-    var context = extendedConfig.forward ? provider : api;
-    var defaultProvider = _.isFunction(extendedConfig.defaultProvider) ? extendedConfig.defaultProvider : _.noop;
-    var wrapper = _.isFunction(extendedConfig.wrapper) ? extendedConfig.wrapper : null;
-    var name = extendedConfig.name;
+    const extendedConfig = _.defaults(config || {}, defaults);
+    const eventifier = !!(extendedConfig.eventifier && api && api.trigger);
+    const context = extendedConfig.forward ? provider : api;
+    let defaultProvider = _.isFunction(extendedConfig.defaultProvider) ? extendedConfig.defaultProvider : _.noop;
+    const wrapper = _.isFunction(extendedConfig.wrapper) ? extendedConfig.wrapper : null;
+    const name = extendedConfig.name;
 
     if (extendedConfig.required) {
         defaultProvider = null;
@@ -57,19 +55,16 @@ function delegator(api, provider, config) {
      * If the api supports eventifier, fires the related event
      *
      * @param {String} fnName - The name of the delegated method to call
-     * @param {Object} ... - Following parameters will be forwarded as is
+     * @param {...*} [args] - Following parameters will be forwarded as is
      * @returns {Object} - The delegated method must return a response
      * @private
      * @throws Error
      */
-    function delegate(fnName) {
-        var response, args;
+    function delegate(fnName, ...args) {
+        let response;
 
         if (provider) {
             if (_.isFunction(provider[fnName]) || defaultProvider) {
-                // need real array of params, even if empty
-                args = _slice.call(arguments, 1);
-
                 // delegate the call to the provider
                 response = (provider[fnName] || defaultProvider).apply(context, args);
 
@@ -80,13 +75,13 @@ function delegator(api, provider, config) {
                 // if supported fires the method related event
                 if (eventifier) {
                     // the response has to be provided as first argument in all events
-                    api.trigger.apply(api, [fnName, response].concat(args));
+                    api.trigger(fnName, response, ...args);
                 }
             } else {
-                throw new Error('There is no method called ' + fnName + ' in the ' + name + ' provider!');
+                throw new Error(`There is no method called ${fnName} in the ${name} provider!`);
             }
         } else {
-            throw new Error('There is no ' + name + ' provider!');
+            throw new Error(`There is no ${name} provider!`);
         }
 
         return response;

--- a/src/core/encoder/array.js
+++ b/src/core/encoder/array.js
@@ -19,12 +19,12 @@
 import _ from 'lodash';
 
 export default {
-    encode: function(modelValue, glue) {
+    encode(modelValue, glue) {
         glue = glue || ',';
         return _.isArray(modelValue) ? modelValue.join(glue) : modelValue;
     },
 
-    decode: function(nodeValue, glue) {
+    decode(nodeValue, glue) {
         glue = glue || ',';
         return nodeValue.split(glue);
     }

--- a/src/core/encoder/array2str.js
+++ b/src/core/encoder/array2str.js
@@ -19,12 +19,12 @@
 import _ from 'lodash';
 
 export default {
-    encode: function(modelValue, glue) {
+    encode(modelValue, glue) {
         glue = glue || ',';
         return modelValue.split(glue);
     },
 
-    decode: function(nodeValue, glue) {
+    decode(nodeValue, glue) {
         glue = glue || ',';
         return _.isArray(nodeValue) ? nodeValue.join(glue) : nodeValue;
     }

--- a/src/core/encoder/boolean.js
+++ b/src/core/encoder/boolean.js
@@ -17,11 +17,11 @@
  */
 
 export default {
-    encode: function(modelValue) {
+    encode(modelValue) {
         return modelValue === true ? 'true' : 'false';
     },
 
-    decode: function(nodeValue) {
+    decode(nodeValue) {
         return nodeValue === 'true';
     }
 };

--- a/src/core/encoder/encoders.js
+++ b/src/core/encoder/encoders.js
@@ -29,35 +29,34 @@ import entity from 'core/encoder/entity';
  * @param {string} name - the declaration : array(a,b)
  * @returns {array} of extracted args
  */
-var extractArgs = function extractArgs(name) {
-    var args = [];
-    var matches = [];
+function extractArgs(name) {
+    let args = [];
     if (name.indexOf('(') > -1) {
-        matches = /\((.+?)\)/.exec(name);
+        const matches = /\((.+?)\)/.exec(name);
         if (matches && matches.length >= 1) {
             args = matches[1].split(',');
         }
     }
     return args;
-};
+}
 
 /**
  * Extract the name from a function declaration:   "foo(a,b)" return foo
  * @param {string} name - the declaration : foo(a,b)
  * @returns {string} the name
  */
-var extractName = function extractName(name) {
+function extractName(name) {
     if (name.indexOf('(') > -1) {
         return name.substr(0, name.indexOf('('));
     }
     return name;
-};
+}
 
 /**
  * Provides multi sources encoding decoding
  * @exports core/encoder/encoders
  */
-var encoders = {
+const encoders = {
     number: number,
     float: float,
     time: time,
@@ -66,7 +65,7 @@ var encoders = {
     str2array: str2array,
     entity: entity,
 
-    register: function(name, encode, decode) {
+    register(name, encode, decode) {
         if (!_.isString(name)) {
             throw new Error('An encoder must have a valid name');
         }
@@ -76,29 +75,25 @@ var encoders = {
         if (!_.isFunction(decode)) {
             throw new Error('Decode must be a function');
         }
-        this[name] = { encode: encode, decode: decode };
+        this[name] = { encode, decode };
     },
 
-    encode: function(name, value) {
-        var encoder, args;
-
+    encode(name, value) {
         name = extractName(name);
         if (this[name]) {
-            encoder = this[name];
-            args = [value];
-            return encoder.encode.apply(encoder, args.concat(extractArgs(name)));
+            const encoder = this[name];
+            const args = [value, ...extractArgs(name)];
+            return encoder.encode(...args);
         }
         return value;
     },
 
-    decode: function(name, value) {
-        var decoder, args;
-
+    decode(name, value) {
         name = extractName(name);
         if (this[name]) {
-            decoder = this[name];
-            args = [value];
-            return decoder.decode.apply(decoder, args.concat(extractArgs(name)));
+            const decoder = this[name];
+            const args = [value, ...extractArgs(name)];
+            return decoder.decode(...args);
         }
         return value;
     }

--- a/src/core/encoder/entity.js
+++ b/src/core/encoder/entity.js
@@ -26,7 +26,7 @@
  * The list of chars to be encoded
  * @type {String[]}
  */
-var guiltyChars = ['&', '<', '>', '"'];
+const guiltyChars = ['&', '<', '>', '"'];
 
 export default {
     /**
@@ -34,13 +34,13 @@ export default {
      * @param {String} input
      * @returns {String} encoded input
      */
-    encode: function encode(input) {
-        input = input + '';
+    encode(input) {
+        input = `${input}`;
 
         return input
             .split('')
-            .map(function(character) {
-                return guiltyChars.indexOf(character) > -1 ? '&#' + character.charCodeAt() + ';' : character;
+            .map(function (character) {
+                return guiltyChars.indexOf(character) > -1 ? `&#${character.charCodeAt()};` : character;
             })
             .join('');
     },
@@ -50,10 +50,10 @@ export default {
      * @param {String} input - with html entity chars
      * @returns {String} decoded
      */
-    decode: function decode(input) {
-        input = input + '';
+    decode(input) {
+        input = `${input}`;
 
-        return input.replace(/&#(\d+);/g, function(matches, code) {
+        return input.replace(/&#(\d+);/g, function (matches, code) {
             return String.fromCharCode(code);
         });
     }

--- a/src/core/encoder/float.js
+++ b/src/core/encoder/float.js
@@ -17,11 +17,11 @@
  */
 
 export default {
-    encode: function(modelValue) {
-        return modelValue + '';
+    encode(modelValue) {
+        return `${modelValue}`;
     },
 
-    decode: function(nodeValue) {
+    decode(nodeValue) {
         return parseFloat(nodeValue.replace(',', '.'));
     }
 };

--- a/src/core/encoder/number.js
+++ b/src/core/encoder/number.js
@@ -17,11 +17,11 @@
  */
 
 export default {
-    encode: function(modelValue) {
-        return modelValue + '';
+    encode(modelValue) {
+        return `${modelValue}`;
     },
 
-    decode: function(nodeValue) {
+    decode(nodeValue) {
         return parseInt(nodeValue, 10);
     }
 };

--- a/src/core/encoder/str2array.js
+++ b/src/core/encoder/str2array.js
@@ -31,7 +31,7 @@ export default {
      * @param {String} [glue = ','] - the join glue
      * @returns {String} the encoded string
      */
-    encode: function encode(modelValue, glue) {
+    encode(modelValue, glue) {
         glue = glue || ',';
         return _.isArray(modelValue) ? modelValue.join(glue) : modelValue;
     },
@@ -42,9 +42,9 @@ export default {
      * @param {String} [glue = ','] - the split glue
      * @returns {String[]} the encoded array
      */
-    decode: function decode(nodeValue, glue) {
+    decode(nodeValue, glue) {
         glue = glue || ',';
-        var input = _.isString(nodeValue) ? nodeValue.trim() : nodeValue;
+        const input = _.isString(nodeValue) ? nodeValue.trim() : nodeValue;
         return _.isEmpty(input) ? [] : input.split(glue);
     }
 };

--- a/src/core/encoder/time.js
+++ b/src/core/encoder/time.js
@@ -18,25 +18,25 @@
 
 import moment from 'moment';
 
-var format = 'HH:mm:ss';
+const format = 'HH:mm:ss';
 
 export default {
-    encode: function(modelValue) {
+    encode(modelValue) {
         //seconds to hh:mm:ss
-        var seconds = parseInt(modelValue, 10);
+        let seconds = parseInt(modelValue, 10);
         if (isNaN(seconds)) {
             seconds = 0;
         }
-        var time = moment.duration(seconds, 'seconds');
-        var h = time.get('hours') >= 10 ? time.get('hours') : '0' + time.get('hours');
-        var m = time.get('minutes') >= 10 ? time.get('minutes') : '0' + time.get('minutes');
-        var s = time.get('seconds') >= 10 ? time.get('seconds') : '0' + time.get('seconds');
-        return h + ':' + m + ':' + s;
+        const time = moment.duration(seconds, 'seconds');
+        const h = time.get('hours') >= 10 ? time.get('hours') : `0${time.get('hours')}`;
+        const m = time.get('minutes') >= 10 ? time.get('minutes') : `0${time.get('minutes')}`;
+        const s = time.get('seconds') >= 10 ? time.get('seconds') : `0${time.get('seconds')}`;
+        return `${h}:${m}:${s}`;
     },
 
-    decode: function(nodeValue) {
+    decode(nodeValue) {
         //hh:mm:ss to seconds
-        var time = moment(nodeValue, format);
+        const time = moment(nodeValue, format);
         return time.seconds() + time.minutes() * 60 + time.hours() * 3600;
     }
 };

--- a/src/core/errorHandler.js
+++ b/src/core/errorHandler.js
@@ -19,7 +19,7 @@
 
 /**
  * Enables you to manage errors.
- * The error handler is context based, you throw errors in a conntext and
+ * The error handler is context based, you throw errors in a context and
  * then you can listen either a context or all errors.
  *
  * @example <caption>Listen for your context errors</caption>
@@ -36,7 +36,7 @@ import _ from 'lodash';
 /**
  * The error handler
  */
-var errorHandler = {
+const errorHandler = {
     /**
      * Keep contexts
      */
@@ -47,7 +47,7 @@ var errorHandler = {
      * @param {String} name - the context name
      * @returns {Object} the handling context
      */
-    getContext: function getContext(name) {
+    getContext(name) {
         if (_.isString(name) && name.length) {
             this._contexts[name] = this._contexts[name] || {
                 typedHandlers: {},
@@ -63,8 +63,8 @@ var errorHandler = {
      * @param {String} [type] - to listen by type of errors (it uses Error.name)
      * @param {Function} handler - the error handler, it has the error in parameter
      */
-    listen: function listen(name, type, handler) {
-        var context = this.getContext(name);
+    listen(name, type, handler) {
+        const context = this.getContext(name);
         if (context) {
             if (_.isFunction(type) && !handler) {
                 handler = type;
@@ -80,12 +80,13 @@ var errorHandler = {
     },
 
     /**
-     * Throw an error in this ontext
+     * Throw an error in this context
      * @param {String} name - the context name
      * @param {Error} err - the error with a message
+     * @returns {boolean}
      */
-    throw: function throwError(name, err) {
-        var context = this.getContext(name);
+    throw(name, err) {
+        const context = this.getContext(name);
         if (context) {
             if (_.isString(err)) {
                 err = new Error(err);
@@ -104,7 +105,7 @@ var errorHandler = {
      * Reset an error context
      * @param {String} name - the context name
      */
-    reset: function reset(name) {
+    reset(name) {
         if (this._contexts[name]) {
             this._contexts = _.omit(this._contexts, name);
         }

--- a/src/core/format.js
+++ b/src/core/format.js
@@ -21,7 +21,7 @@
  */
 import _ from 'lodash';
 
-var pattern = /(%[sdj])/g;
+const pattern = /(%[sdj])/g;
 
 /**
  * Enables you to format strings/message, using the pattern:
@@ -35,13 +35,12 @@ var pattern = /(%[sdj])/g;
  * @param {...String|Number|Object} [replacements] -  the replacements arguments in the order defined in the message
  * @returns {String} the formatted message
  */
-export default function(message) {
-    var replacements = Array.prototype.slice.call(arguments, 1);
+export default function (message, ...replacements) {
     return _.reduce(
         message.match(pattern),
-        function(acc, match, index) {
-            var replacement = '';
-            if (undefined !== replacements[index]) {
+        function (acc, match, index) {
+            let replacement = '';
+            if ('undefined' !== typeof replacements[index]) {
                 switch (match) {
                     case '%d':
                         replacement = Number(replacements[index]);
@@ -49,7 +48,9 @@ export default function(message) {
                     case '%j':
                         try {
                             replacement = JSON.stringify(replacements[index]).replace(/"/g, '');
-                        } catch (e) {}
+                        } catch (e) {
+                            // no fallback
+                        }
                         break;
                     default:
                         replacement = replacements[index];

--- a/src/core/history.js
+++ b/src/core/history.js
@@ -24,37 +24,37 @@
  */
 import $ from 'jquery';
 
-var ns = 'history';
+const ns = 'history';
 
 /**
  * Browser history management
  * @exports core/history
  */
-var history = {
+const history = {
     /**
      * Some browsers have the backspace button configured to run window.history.back(); we will fix this awefull behavior.
      * The strategy is to prevent backspace everywhere except in text and editable elements.
      */
-    fixBrokenBrowsers: function fixBrokenBrowsers() {
+    fixBrokenBrowsers() {
         //to be completed if needed
-        var enabledSelector = ['input', 'textarea', '[contenteditable=true]'].join(',');
+        const enabledSelector = ['input', 'textarea', '[contenteditable=true]'].join(',');
 
-        var preventBackSpace = function preventBackSpace(e) {
+        function preventBackSpace(e) {
             return e.keyCode !== 8;
-        };
-        var preventBackSpacePropag = function preventBackSpacePropag(e) {
+        }
+        function preventBackSpacePropag(e) {
             if (e.keyCode === 8 && !e.target.readonly && !e.target.disbaled) {
                 e.stopPropagation();
             }
             return true;
-        };
-        $(document).off('.' + ns);
-        $(document).off('.' + ns, enabledSelector);
+        }
+        $(document).off(`.${ns}`);
+        $(document).off(`.${ns}`, enabledSelector);
 
-        $(document).on('keydown.' + ns, preventBackSpace);
-        $(document).on('keypress.' + ns, preventBackSpace);
-        $(document).on('keydown.' + ns, enabledSelector, preventBackSpacePropag);
-        $(document).on('keypress.' + ns, enabledSelector, preventBackSpacePropag);
+        $(document).on(`keydown.${ns}`, preventBackSpace);
+        $(document).on(`keypress.${ns}`, preventBackSpace);
+        $(document).on(`keydown.${ns}`, enabledSelector, preventBackSpacePropag);
+        $(document).on(`keypress.${ns}`, enabledSelector, preventBackSpacePropag);
     }
 };
 

--- a/src/core/historyRouter.js
+++ b/src/core/historyRouter.js
@@ -27,8 +27,8 @@ import eventifier from 'core/eventifier';
 import statifier from 'core/statifier';
 import Promise from 'core/promise';
 
-var historyRouter;
-var location = (window.history.location || window.location) + '';
+let historyRouter;
+const location = `${window.history.location || window.location}`;
 
 /**
  * Create an history router
@@ -41,7 +41,7 @@ var location = (window.history.location || window.location) + '';
  * @returns {historyRouter} the router (same instance)
  */
 function historyRouterFactory() {
-    var pendingPromise;
+    let pendingPromise;
 
     if (historyRouter) {
         return historyRouter;
@@ -59,7 +59,7 @@ function historyRouterFactory() {
              * @param {String} url
              * @returns {Promise}
              */
-            redirect: function redirect(url) {
+            redirect(url) {
                 return this.pushState(url);
             },
 
@@ -70,9 +70,9 @@ function historyRouterFactory() {
              * @param {String} url
              * @returns {Promise}
              */
-            forward: function forward(url) {
-                var state = _.isString(url) ? { url: url } : url;
-                window.history.replaceState(state, '', window.location + '');
+            forward(url) {
+                const state = _.isString(url) ? { url: url } : url;
+                window.history.replaceState(state, '', `${window.location}`);
                 return this.dispatch(state, false);
             },
 
@@ -81,7 +81,7 @@ function historyRouterFactory() {
              * @param {String} url
              * @returns {Promise}
              */
-            replace: function replace(url) {
+            replace(url) {
                 return this.dispatch(url, true);
             },
 
@@ -95,9 +95,8 @@ function historyRouterFactory() {
              * @fires historyRouter#dispatching before dispatch
              * @fires historyRouter#dispatched  once dispatch succeed
              */
-            dispatch: function dispatch(state, replace) {
-                var self = this;
-                function doDispatch() {
+            dispatch(state, replace) {
+                const doDispatch = () => {
                     if (_.isString(state)) {
                         state = { url: state };
                     }
@@ -109,22 +108,22 @@ function historyRouterFactory() {
                      * @event historyRouter#dispatching
                      * @param {String} url
                      */
-                    self.setState('dispatching').trigger('dispatching', state.url);
+                    this.setState('dispatching').trigger('dispatching', state.url);
 
                     if (replace === true) {
                         window.history.replaceState(state, '', state.url);
                     }
 
-                    return router.dispatch(state.url).then(function() {
+                    return router.dispatch(state.url).then(() => {
                         /**
                          * @event historyRouter#dispatched
                          * @param {String} url
                          */
-                        self.trigger('dispatched', state.url).setState('dispatching', false);
+                        this.trigger('dispatched', state.url).setState('dispatching', false);
 
                         return state.url;
                     });
-                }
+                };
 
                 if (pendingPromise) {
                     pendingPromise = pendingPromise.then(doDispatch).catch(doDispatch);
@@ -141,7 +140,7 @@ function historyRouterFactory() {
              * @param {String} state.url - if the state is an object, then it must have an URL to dispatch
              * @returns {Promise}
              */
-            pushState: function pushState(state) {
+            pushState(state) {
                 if (_.isString(state)) {
                     state = { url: state };
                 }
@@ -155,12 +154,12 @@ function historyRouterFactory() {
     window.history.replaceState({ url: location }, '', location);
 
     //back & forward button, and push state
-    $(window).on('popstate', function() {
+    $(window).on('popstate', function () {
         historyRouter.dispatch(window.history.state);
     });
 
     //listen for dispatch event in order to push a state
-    historyRouter.on('dispatch', function(state) {
+    historyRouter.on('dispatch', function (state) {
         if (state) {
             this.pushState(state);
         }

--- a/src/core/logger.js
+++ b/src/core/logger.js
@@ -34,7 +34,7 @@ import loggerFactory from 'core/logger/api';
  * The default configuration if nothing
  * is found on the module config
  */
-var defaultConfig = {
+const defaultConfig = {
     level: loggerFactory.levels.warn,
     loggers: {
         'core/logger/console': {
@@ -44,23 +44,22 @@ var defaultConfig = {
 };
 
 //the logger providers are configured through the AMD module config
-var config = _.defaults(module.config() || {}, defaultConfig);
-var logger = loggerFactory('core/logger');
+const config = _.defaults(module.config() || {}, defaultConfig);
+const logger = loggerFactory('core/logger');
 
 loggerFactory.setDefaultLevel(config.level);
 loggerFactory.load(config.loggers);
 
 /**
  * Catch uncaught errors
- * @param msg - error message
- * @param url - current url
- * @param line - line number
- * @param col - column number
- * @param error - error object (not all browsers support).
+ * @param {string} msg - error message
+ * @param {string} url - current url
+ * @param {number} line - line number
+ * @param {number} col - column number
  * @return {boolean}
  */
-window.onerror = function(msg, url, line, col, error) {
-    logger.error("Caught[via window.onerror]: '" + msg + "' from " + url + ':' + line + ':' + col);
+window.onerror = function onError(msg, url, line, col) {
+    logger.error(`Caught[via window.onerror]: '${msg}' from ${url}:${line}:${col}`);
 };
 
 /**

--- a/src/core/logger/api.js
+++ b/src/core/logger/api.js
@@ -40,9 +40,9 @@ import moduleLoader from 'core/moduleLoader';
 /**
  * The default level
  */
-var defaultLevel = 'info';
+let defaultLevel = 'info';
 
-var levels = {
+const levels = {
     fatal: 60, // The service/app is going to stop or become unusable now. An operator should definitely look into this soon.
     error: 50, // Fatal for a particular request, but the service/app continues servicing other requests. An operator should look at this soon(ish).
     warn: 40, // A note on something that should probably be looked at by an operator eventually.
@@ -54,12 +54,12 @@ var levels = {
 /**
  * Major version of the node-bunyan package (for compat)
  */
-var bunyanVersion = 0;
+const bunyanVersion = 0;
 
 /**
  * Where messages dwells
  */
-var logQueue = [];
+let logQueue = [];
 
 /**
  * Get the actual level as a string,
@@ -67,19 +67,19 @@ var logQueue = [];
  * @param {String|Number} [level] - the level
  * @returns {String} the level
  */
-var getLevel = function getLevel(level) {
+function getLevel(level) {
     if (typeof level === 'undefined' || (_.isString(level) && !_.has(levels, level))) {
         return defaultLevel;
     }
     if (_.isNumber(level)) {
         return (
-            _.findKey(levels, function(l) {
+            _.findKey(levels, function (l) {
                 return l === level;
             }) || defaultLevel
         );
     }
     return level;
-};
+}
 
 /**
  * Get the actual level as a number,
@@ -87,7 +87,7 @@ var getLevel = function getLevel(level) {
  * @param {String|Number} [level] - the level
  * @returns {Number} the level
  */
-var getLevelNum = function getLevelNum(level) {
+function getLevelNum(level) {
     if (_.isString(level) && _.has(levels, level)) {
         return levels[level];
     }
@@ -95,17 +95,17 @@ var getLevelNum = function getLevelNum(level) {
         return level;
     }
     return levels[defaultLevel];
-};
+}
 
 /**
  * Check whether the given level is above the minimum level threshold
- * @param {String|Number} minlevel- the minimum level
+ * @param {String|Number} minLevel - the minimum level
  * @param {String|Number} [level] - the level to check
  * @returns {Boolean}
  */
-var checkMinLevel = function checkMinLevel(minLevel, level) {
+function checkMinLevel(minLevel, level) {
     return getLevelNum(level) >= getLevelNum(minLevel);
-};
+}
 
 /**
  * Creates a logger instance
@@ -116,10 +116,7 @@ var checkMinLevel = function checkMinLevel(minLevel, level) {
  *
  * @returns {logger} a new logger instance
  */
-var loggerFactory = function loggerFactory(name, minLevel, fields) {
-    var baseRecord;
-    var logger;
-
+function loggerFactory(name, minLevel, fields) {
     if (!_.isString(name) || _.isEmpty(name)) {
         throw new TypeError('A logger needs a name');
     }
@@ -129,7 +126,7 @@ var loggerFactory = function loggerFactory(name, minLevel, fields) {
         minLevel = defaultLevel;
     }
 
-    baseRecord = _.defaults(fields || {}, {
+    const baseRecord = _.defaults(fields || {}, {
         name: name,
         pid: 1, // only for compat
         hostname: navigator.userAgent
@@ -140,22 +137,19 @@ var loggerFactory = function loggerFactory(name, minLevel, fields) {
      *
      * @typedef logger
      */
-    logger = {
-
+    const logger = {
         /**
          * Log messages by delegating to the provider
          *
          * @param {String|Number} level - the log level
-         * @param {Object} [recordFields] - fields to add to the log record
+         * @param {Object|string} [recordFields] - fields to add to the log record
          * @param {String|Error} message - the message to log
          * @param {...String} [rest] - rest parameters if the message is formatted
          * @returns {logger} chains
          */
-        log: function log(level, recordFields, message) {
-            var record;
-            var err;
-            var rest = [];
-            var time = new Date().toISOString();
+        log(level, recordFields, message, ...rest) {
+            let err;
+            const time = new Date().toISOString();
 
             //without providers or not the level, we don't log.
             if (loggerFactory.providers === false || !checkMinLevel(minLevel || defaultLevel, level)) {
@@ -163,14 +157,14 @@ var loggerFactory = function loggerFactory(name, minLevel, fields) {
             }
 
             if (_.isString(recordFields) || recordFields instanceof Error) {
+                if ('undefined' !== typeof message) {
+                    rest = [message, ...rest];
+                }
                 message = recordFields;
                 recordFields = {};
-                rest = [].slice.call(arguments, 2);
-            } else {
-                rest = [].slice.call(arguments, 3);
             }
 
-            record = {
+            const record = {
                 level: getLevel(level),
                 v: bunyanVersion,
                 time: time
@@ -187,7 +181,7 @@ var loggerFactory = function loggerFactory(name, minLevel, fields) {
                 record.msg = err.message;
                 record.err = err;
             } else {
-                record.msg = format.apply(null, [message].concat(rest));
+                record.msg = format(message, ...rest);
             }
 
             _.merge(record, baseRecord, recordFields);
@@ -201,10 +195,10 @@ var loggerFactory = function loggerFactory(name, minLevel, fields) {
 
         /**
          * Get/set the default level of the logger
-         * @param {String|Number} [level] - set the default level
+         * @param {String|Number} [value] - set the default level
          * @returns {String|logger} the default level as a getter or chains as a setter
          */
-        level: function(value) {
+        level(value) {
             if (typeof value !== 'undefined') {
                 //update the partial function
                 minLevel = getLevelNum(value);
@@ -218,9 +212,9 @@ var loggerFactory = function loggerFactory(name, minLevel, fields) {
          * same config + child fields
          *
          * @param {Object} [childFields] - specialized child fields
-         * @return {logger} the child logger
+         * @returns {logger} the child logger
          */
-        child: function child(childFields) {
+        child(childFields) {
             return loggerFactory(name, minLevel, _.defaults(childFields, baseRecord));
         }
     };
@@ -234,7 +228,7 @@ var loggerFactory = function loggerFactory(name, minLevel, fields) {
         },
         logger
     );
-};
+}
 
 /**
  * Exposes the levels
@@ -257,30 +251,37 @@ loggerFactory.load = function load(providerConfigs) {
     this.providers = [];
 
     //we can load the loggers dynamically
-    const modules = Object.keys(providerConfigs || {})
-        .map( module => ({
-            module,
-            category: 'logger'
-        }));
+    const modules = Object.keys(providerConfigs || {}).map(module => ({
+        module,
+        category: 'logger'
+    }));
 
-    return moduleLoader()
-        .addList(modules)
-        .load()
-        .then( loadedProviders => {
-            loadedProviders.forEach( (provider, moduleKey) => {
-                const providerConfig = modules[moduleKey] && modules[moduleKey].module && providerConfigs[modules[moduleKey].module];
-                this.register(provider, providerConfig);
-            });
-        })
-        //flush messages that arrived before the providers are there
-        .then( () => this.flush());
+    return (
+        moduleLoader()
+            .addList(modules)
+            .load()
+            .then(loadedProviders => {
+                loadedProviders.forEach((provider, moduleKey) => {
+                    const providerConfig =
+                        modules[moduleKey] && modules[moduleKey].module && providerConfigs[modules[moduleKey].module];
+                    this.register(provider, providerConfig);
+                });
+            })
+            //flush messages that arrived before the providers are there
+            .then(() => this.flush())
+    );
 };
 
 /**
  * A logger provider provides with a way to log
  * @typedef {Object} loggerProvider
  * @property {Function} log - called with the message in parameter
- * @param {Object} providerConfig - provider's config
+ */
+
+/**
+ * Registers a logger provider.
+ * @param {loggerProvider} provider
+ * @param {object} providerConfig - provider's config
  * @throws TypeError
  */
 loggerFactory.register = function register(provider, providerConfig) {
@@ -301,9 +302,9 @@ loggerFactory.register = function register(provider, providerConfig) {
  */
 loggerFactory.flush = function flush() {
     if (_.isArray(this.providers) && this.providers.length > 0) {
-        _.forEach(logQueue, function(message) {
+        _.forEach(logQueue, function (message) {
             //forward to the providers
-            _.forEach(loggerFactory.providers, function(provider) {
+            _.forEach(loggerFactory.providers, function (provider) {
                 provider.log(message);
             });
         });

--- a/src/core/logger/console.js
+++ b/src/core/logger/console.js
@@ -24,10 +24,10 @@
  */
 import _ from 'lodash';
 
-var config = {
+let config = {
     level: 'info'
 };
-var mapping = {
+const mapping = {
     trace: 'debug',
     debug: 'debug',
     info: 'info',
@@ -38,23 +38,23 @@ var mapping = {
 
 /**
  * Initialize the logger API with the console provider
- * @returns {logger} the logger
+ * @type {logger} the logger
  */
 export default {
-    setConfig: function setConfig(newConfig) {
+    setConfig(newConfig) {
         config = _.defaults(newConfig || {}, config);
     },
-    log: function log(record) {
-        var level = record.level;
+    log(record) {
+        const level = record.level;
         if (this.checkMinLevel(config.level, level)) {
             if (_.isFunction(window.console[mapping[level]])) {
                 if (record.err) {
-                    window.console[mapping[level]].call(window.console, record.name, record.msg, record.err, record);
+                    window.console[mapping[level]](record.name, record.msg, record.err, record);
                 } else {
-                    window.console[mapping[level]].call(window.console, record.name, record.msg, record);
+                    window.console[mapping[level]](record.name, record.msg, record);
                 }
             } else {
-                window.console.log('[' + level.toUpperCase() + ']', record.name, record.msg, record);
+                window.console.log(`[${level.toUpperCase()}]`, record.name, record.msg, record);
             }
         }
     }

--- a/src/core/logger/http.js
+++ b/src/core/logger/http.js
@@ -24,21 +24,19 @@
  */
 import _ from 'lodash';
 import $ from 'jquery';
-import url from 'util/url';
+import urlHelper from 'util/url';
 
-var defaultConfig = {
-    url: url.route('log', 'Log', 'tao'),
+const defaultConfig = {
+    url: urlHelper.route('log', 'Log', 'tao'),
     level: 'warning',
     delay: 500 //milliseconds of delay to flush
 };
-var config;
-var logQueue = [];
-var debouncedFlush;
+let config = Object.assign({}, defaultConfig);
+let logQueue = [];
 
 /**
  * Push log message into log queue
  * @param {Object} message - log message
- * @returns {Promise} resolves when the message is stored
  */
 function push(message) {
     logQueue.push(message);
@@ -46,10 +44,9 @@ function push(message) {
 
 /**
  * Flush the log messages store and retrieve the data
- * @returns {Promise} resolves with the flushed data
  */
 function flush() {
-    var messages = logQueue;
+    const messages = logQueue;
     logQueue = [];
     send(messages);
 }
@@ -66,32 +63,32 @@ function send(messages) {
         data: { messages: JSON.stringify(messages) },
         dataType: 'json',
         global: false,
-        error: function() {
-            _.forEach(flush, function(message) {
+        error() {
+            _.forEach(flush, function (message) {
                 push(message);
             });
         }
     });
 }
 
-debouncedFlush = _.debounce(flush, defaultConfig.delay);
+let debouncedFlush = _.debounce(flush, defaultConfig.delay);
 
 /**
- * @returns {logger} the logger
+ * @type {logger} the logger
  */
 export default {
-    setConfig: function setConfig(newConfig) {
+    setConfig(newConfig) {
         config = _.defaults(newConfig || {}, defaultConfig);
         if (_.isArray(config.url)) {
-            config.url = url.route.apply(url, config.url);
+            config.url = urlHelper.route(...config.url);
         }
         debouncedFlush = _.debounce(flush, config.delay);
     },
     /**
      * log message
-     * @param {Object} record - See core/logger/api::log() method
+     * @param {Object} message - See core/logger/api::log() method
      */
-    log: function log(message) {
+    log(message) {
         if (this.checkMinLevel(config.level, message.level)) {
             push(message);
             debouncedFlush();

--- a/src/core/mimetype.js
+++ b/src/core/mimetype.js
@@ -27,7 +27,7 @@ import extensions from 'core/mimetype/extensions.json';
  * Helps you to retrieve file type and categories based on a file mime type
  * @exports core/mimetype
  */
-var mimetypeHelper = {
+const mimetypeHelper = {
     /**
      * Gets the MIME type of a resource.
      *
@@ -38,20 +38,20 @@ var mimetypeHelper = {
      *                                the second is the MIME type if the request succeed.
      * @returns {mimetype}
      */
-    getResourceType: function getResourceType(url, callback) {
+    getResourceType(url, callback) {
         $.ajax({
             type: 'HEAD',
             async: true,
             url: url,
-            success: function onSuccess(message, text, jqXHR) {
-                var mime = jqXHR.getResponseHeader('Content-Type');
+            success(message, text, jqXHR) {
+                const mime = jqXHR.getResponseHeader('Content-Type');
                 if (callback) {
                     callback(null, mime);
                 }
             },
 
-            error: function onError(jqXHR) {
-                var error = jqXHR.status || 404;
+            error(jqXHR) {
+                const error = jqXHR.status || 404;
                 if (callback) {
                     callback(error);
                 }
@@ -67,10 +67,9 @@ var mimetypeHelper = {
      * @param {String} [file.name] - the file name
      * @returns {String} the type
      */
-    getFileType: function getFileType(file) {
-        var type;
-        var mime = file.mime;
-        var ext;
+    getFileType(file) {
+        let type;
+        const mime = file.mime;
 
         if (mime) {
             //lookup for exact mime
@@ -88,7 +87,7 @@ var mimetypeHelper = {
 
         //try by extension
         if (!type) {
-            ext = getFileExtension(file.name);
+            const ext = getFileExtension(file.name);
             if (ext) {
                 type = _.findKey(categories, {
                     extensions: [ext]
@@ -102,15 +101,15 @@ var mimetypeHelper = {
     /**
      * Check if a given mime type matches some filters
      * @param {String} type - the mime type
-     * @param {String[]} filters - the validTypes
+     * @param {String[]} validTypes - the validTypes
      * @returns {String} category
      */
-    match: function match(type, validTypes) {
+    match(type, validTypes) {
         // Under rare circumstances a browser may report the mime type
         // with quotes (e.g. "application/foo" instead of application/foo)
-        var checkType = type.replace(/^["']+|['"]+$/g, '');
+        const checkType = type.replace(/^["']+|['"]+$/g, '');
 
-        var starType = checkType.replace(/\/.*$/, '/*');
+        const starType = checkType.replace(/\/.*$/, '/*');
 
         return _.contains(validTypes, checkType) || _.contains(validTypes, starType);
     },
@@ -120,7 +119,7 @@ var mimetypeHelper = {
      * @param {String} type
      * @returns {String} category
      */
-    getCategory: function getCategory(type) {
+    getCategory(type) {
         if (categories[type]) {
             return categories[type].category;
         }
@@ -135,18 +134,17 @@ var mimetypeHelper = {
      * @param {File} file
      * @returns {String} the mime type
      */
-    getMimeType: function getMimeType(file) {
-        var ext,
-            type = file.type,
-            category = mimetypeHelper.getFileType({
-                name: file.name,
-                mime: type
-            });
+    getMimeType(file) {
+        const type = file.type;
+        const category = mimetypeHelper.getFileType({
+            name: file.name,
+            mime: type
+        });
 
         if (type && !type.match(/invalid/) && category !== 'generic') {
             return type;
         } else {
-            ext = getFileExtension(file.name);
+            const ext = getFileExtension(file.name);
             if (ext && extensions[ext]) {
                 return extensions[ext];
             }
@@ -162,7 +160,7 @@ var mimetypeHelper = {
  * @returns {String}
  */
 function getFileExtension(fileName) {
-    var extMatch = fileName.match(/\.([0-9a-z]+)(?:[\?#]|$)/i);
+    const extMatch = fileName.match(/\.([0-9a-z]+)(?:[?#]|$)/i);
     if (extMatch && extMatch.length > 1) {
         return extMatch[1];
     }

--- a/src/core/mouseEvent.js
+++ b/src/core/mouseEvent.js
@@ -98,7 +98,7 @@ if (document.dispatchEvent) {
 } else if (document.fireEvent) {
     dispatchEvent = function dispatchEventUsingFireEvent(element, eventName, event) {
         if (element) {
-            element.fireEvent('on' + eventName, event);
+            element.fireEvent(`on${eventName}`, event);
             return true;
         }
         return false;

--- a/src/core/plugin.js
+++ b/src/core/plugin.js
@@ -69,8 +69,6 @@ import Promise from 'core/promise';
  * @returns {Function} - the generated plugin factory
  */
 function pluginFactory(provider, defaults) {
-    var pluginName;
-
     if (
         !_.isPlainObject(provider) ||
         !_.isString(provider.name) ||
@@ -80,7 +78,7 @@ function pluginFactory(provider, defaults) {
         throw new TypeError('A plugin should be defined at least by a name property and an init method');
     }
 
-    pluginName = provider.name;
+    const pluginName = provider.name;
 
     defaults = defaults || {};
 
@@ -93,11 +91,11 @@ function pluginFactory(provider, defaults) {
      * @returns {plugin} the plugin instance
      */
     return function instanciatePlugin(host, areaBroker, config) {
-        var plugin, delegate;
+        let delegate;
 
-        var states = {};
+        let states = {};
 
-        var pluginContent = {};
+        let pluginContent = {};
 
         //basic checking for the host
         if (!_.isObject(host) || !_.isFunction(host.on) || !_.isFunction(host.trigger)) {
@@ -110,17 +108,13 @@ function pluginFactory(provider, defaults) {
          * The plugin instance.
          * @typedef {plugin}
          */
-        plugin = {
+        const plugin = {
             /**
              * Called when the host is installing the plugins
              * @returns {Promise} to resolve async delegation
              */
-            install: function install() {
-                var self = this;
-
-                return delegate('install').then(function() {
-                    self.trigger('install');
-                });
+            install() {
+                return delegate('install').then(() => this.trigger('install'));
             },
 
             /**
@@ -128,58 +122,43 @@ function pluginFactory(provider, defaults) {
              * @param {Object|*} [content] the plugin content
              * @returns {Promise} to resolve async delegation
              */
-            init: function init(content) {
-                var self = this;
+            init(content) {
                 states = {};
 
                 if (content) {
                     pluginContent = content;
                 }
 
-                return delegate('init', content).then(function() {
-                    self.setState('init', true).trigger('init');
-                });
+                return delegate('init', content).then(() => this.setState('init', true).trigger('init'));
             },
 
             /**
              * Called when the host is rendering
              * @returns {Promise} to resolve async delegation
              */
-            render: function render() {
-                var self = this;
-
-                return delegate('render').then(function() {
-                    self.setState('ready', true)
-                        .trigger('render')
-                        .trigger('ready');
-                });
+            render() {
+                return delegate('render').then(() => this.setState('ready', true).trigger('render').trigger('ready'));
             },
 
             /**
              * Called when the host is finishing
              * @returns {Promise} to resolve async delegation
              */
-            finish: function finish() {
-                var self = this;
-
-                return delegate('finish').then(function() {
-                    self.setState('finish', true).trigger('finish');
-                });
+            finish() {
+                return delegate('finish').then(() => this.setState('finish', true).trigger('finish'));
             },
 
             /**
              * Called when the host is destroying
              * @returns {Promise} to resolve async delegation
              */
-            destroy: function destroy() {
-                var self = this;
-
-                return delegate('destroy').then(function() {
+            destroy() {
+                return delegate('destroy').then(() => {
                     config = {};
                     states = {};
 
-                    self.setState('init', false);
-                    self.trigger('destroy');
+                    this.setState('init', false);
+                    this.trigger('destroy');
                 });
             },
 
@@ -192,9 +171,8 @@ function pluginFactory(provider, defaults) {
              * @param {...} args - additional args are given to the event
              * @returns {plugin} chains
              */
-            trigger: function trigger(name) {
-                var args = [].slice.call(arguments, 1);
-                host.trigger.apply(host, ['plugin-' + name + '.' + pluginName, plugin].concat(args));
+            trigger(name, ...args) {
+                host.trigger(`plugin-${name}.${pluginName}`, plugin, ...args);
                 return this;
             },
 
@@ -202,7 +180,7 @@ function pluginFactory(provider, defaults) {
              * Get the plugin host
              * @returns {host} the plugins's host
              */
-            getHost: function getHost() {
+            getHost() {
                 return host;
             },
 
@@ -210,7 +188,7 @@ function pluginFactory(provider, defaults) {
              * Get the host's areaBroker
              * @returns {areaBroker} the areaBroker
              */
-            getAreaBroker: function getAreaBroker() {
+            getAreaBroker() {
                 return areaBroker;
             },
 
@@ -218,7 +196,7 @@ function pluginFactory(provider, defaults) {
              * Get the config
              * @returns {Object} config
              */
-            getConfig: function getConfig() {
+            getConfig() {
                 return config;
             },
 
@@ -228,7 +206,7 @@ function pluginFactory(provider, defaults) {
              * @param {*} [value] - the config value if name is an entry
              * @returns {plugin} chains
              */
-            setConfig: function setConfig(name, value) {
+            setConfig(name, value) {
                 if (_.isPlainObject(name)) {
                     config = _.defaults(name, config);
                 } else {
@@ -243,7 +221,7 @@ function pluginFactory(provider, defaults) {
              * @param {String} name - the state name
              * @returns {Boolean} if active, false if not set
              */
-            getState: function getState(name) {
+            getState(name) {
                 return !!states[name];
             },
 
@@ -255,7 +233,7 @@ function pluginFactory(provider, defaults) {
              * @returns {plugin} chains
              * @throws {TypeError} if the state name is not a valid string
              */
-            setState: function setState(name, active) {
+            setState(name, active) {
                 if (!_.isString(name) || _.isEmpty(name)) {
                     throw new TypeError('The state must have a name');
                 }
@@ -269,7 +247,7 @@ function pluginFactory(provider, defaults) {
              *
              * @returns {Object|*} the content
              */
-            getContent: function getContent() {
+            getContent() {
                 return pluginContent;
             },
 
@@ -279,7 +257,7 @@ function pluginFactory(provider, defaults) {
              * @param {Object|*} [content] - the plugin content
              * @returns {plugin} chains
              */
-            setContent: function setContent(content) {
+            setContent(content) {
                 pluginContent = content;
 
                 return this;
@@ -290,7 +268,7 @@ function pluginFactory(provider, defaults) {
              *
              * @returns {String} the name
              */
-            getName: function getName() {
+            getName() {
                 return pluginName;
             },
 
@@ -298,48 +276,32 @@ function pluginFactory(provider, defaults) {
              * Shows the component related to this plugin
              * @returns {Promise} to resolve async delegation
              */
-            show: function show() {
-                var self = this;
-
-                return delegate('show').then(function() {
-                    self.setState('visible', true).trigger('show');
-                });
+            show() {
+                return delegate('show').then(() => this.setState('visible', true).trigger('show'));
             },
 
             /**
              * Hides the component related to this plugin
              * @returns {Promise} to resolve async delegation
              */
-            hide: function hide() {
-                var self = this;
-
-                return delegate('hide').then(function() {
-                    self.setState('visible', false).trigger('hide');
-                });
+            hide() {
+                return delegate('hide').then(() => this.setState('visible', false).trigger('hide'));
             },
 
             /**
              * Enables the plugin
              * @returns {Promise} to resolve async delegation
              */
-            enable: function enable() {
-                var self = this;
-
-                return delegate('enable').then(function() {
-                    self.setState('enabled', true).trigger('enable');
-                });
+            enable() {
+                return delegate('enable').then(() => this.setState('enabled', true).trigger('enable'));
             },
 
             /**
              * Disables the plugin
              * @returns {Promise} to resolve async delegation
              */
-            disable: function disable() {
-                var self = this;
-
-                return delegate('disable').then(function() {
-                    self.setState('enabled', false).trigger('disable');
-                });
+            disable() {
+                return delegate('disable').then(() => this.setState('enabled', false).trigger('disable'));
             }
         };
 
@@ -352,14 +314,14 @@ function pluginFactory(provider, defaults) {
          */
         delegate = delegator(plugin, provider, {
             eventifier: false,
-            wrapper: function pluginWrapper(response) {
+            wrapper(response) {
                 return Promise.resolve(response);
             }
         });
 
         //add a convenience method that alias getHost using the hostName
         if (_.isString(defaults.hostName) && !_.isEmpty(defaults.hostName)) {
-            plugin['get' + defaults.hostName.charAt(0).toUpperCase() + defaults.hostName.slice(1)] = plugin.getHost;
+            plugin[`get${defaults.hostName.charAt(0).toUpperCase()}${defaults.hostName.slice(1)}`] = plugin.getHost;
         }
 
         return plugin;

--- a/src/core/polling.js
+++ b/src/core/polling.js
@@ -123,7 +123,7 @@ import eventifier from 'core/eventifier';
  * @type {Number}
  * @private
  */
-var _defaultInterval = 60 * 1000;
+const _defaultInterval = 60 * 1000;
 
 /**
  * Create a polling manager for a particular action
@@ -133,86 +133,36 @@ var _defaultInterval = 60 * 1000;
  * @param {Number|String} [config.max] - Set a max number of iterations, after what the polling is stopped.
  * @param {Boolean} [config.autoStart] - Whether or not the polling should start immediately
  * @param {Object} [config.context] - An optional context to apply on each action call
+ * @param {number} pollingInterval - The minimal time between two iterations (to be set when the first parameter is a function)
  * @returns {polling}
  */
-var pollingFactory = function pollingFactory(config) {
-    var timer, promise, interval, max, iter, action, context, autoStart;
-    var state = {};
-
-    /**
-     * Fires a new timer
-     */
-    var startTimer = function startTimer() {
-        timer = setTimeout(iteration, interval);
-        state.stopped = false;
-        state.pending = true;
-    };
-
-    /**
-     * Stops the current timer
-     */
-    var stopTimer = function stopTimer() {
-        clearTimeout(timer);
-        timer = null;
-        state.stopped = true;
-        state.pending = false;
-    };
-
-    /**
-     * Runs an iteration of the polling loop
-     */
-    var iteration = function iteration() {
-        // prevent more iterations than needed to be ran
-        if (max && iter >= max) {
-            // breaks the polling
-            polling.stop();
-            return;
-        }
-
-        // count the iteration
-        iter = (iter || 0) + 1;
-        state.processing = true;
-        state.pending = false;
-
-        /**
-         * Notifies the action is about to be called
-         * @event polling#call
-         */
-        polling.trigger('call');
-
-        // process the action in the right context
-        action.call(context, polling);
-
-        // next iteration in synchronous mode
-        if (!promise && !state.stopped) {
-            state.processing = false;
-            startTimer();
-        }
-    };
+function pollingFactory(config, pollingInterval = _defaultInterval) {
+    let timer, promise, interval, max, iter, action, context, autoStart;
+    const state = {};
 
     /**
      * Defines the polling manager
      * @type {Object}
      */
-    var polling = {
+    const polling = {
         /**
          * Gets the current action into asynchronous mode.
          * The next iteration won't be executed until the resolve method has been called.
          * However if the reject method is called, the polling is then stopped!
          * @returns {Object} Returns a promise resolver that provides resolve() and reject() methods
          */
-        async: function async() {
-            var resolver = {};
+        async() {
+            const resolver = {};
 
             // create a promise and extract the control callbacks
-            promise = new Promise(function(resolve, reject) {
+            promise = new Promise(function (resolve, reject) {
                 resolver.resolve = resolve;
                 resolver.reject = reject;
             });
 
             // directly install the pending actions
             promise
-                .then(function() {
+                .then(function () {
                     promise = null;
                     state.processing = false;
 
@@ -227,7 +177,7 @@ var pollingFactory = function pollingFactory(config) {
                      */
                     polling.trigger('resolved');
                 })
-                .catch(function() {
+                .catch(function () {
                     promise = null;
                     state.processing = false;
 
@@ -258,7 +208,7 @@ var pollingFactory = function pollingFactory(config) {
          * If the polling has been stopped, start it again.
          * @returns {polling}
          */
-        next: function next() {
+        next() {
             var _next;
 
             // reset the counter if the polling is stopped
@@ -299,7 +249,7 @@ var pollingFactory = function pollingFactory(config) {
          * Starts the polling if it is not currently running
          * @returns {polling}
          */
-        start: function start() {
+        start() {
             if (!timer) {
                 iter = 0;
                 startTimer();
@@ -317,7 +267,7 @@ var pollingFactory = function pollingFactory(config) {
          * Stops the polling if it is currently running
          * @returns {polling}
          */
-        stop: function stop() {
+        stop() {
             stopTimer();
 
             /**
@@ -334,7 +284,7 @@ var pollingFactory = function pollingFactory(config) {
          * @param {Number|String} value
          * @returns {polling}
          */
-        setInterval: function setInterval(value) {
+        setInterval(value) {
             interval = Math.abs(parseInt(value, 10) || _defaultInterval);
 
             /**
@@ -351,7 +301,7 @@ var pollingFactory = function pollingFactory(config) {
          * Gets the minimum time interval between two actions
          * @returns {Number}
          */
-        getInterval: function getInterval() {
+        getInterval() {
             return interval;
         },
 
@@ -360,7 +310,7 @@ var pollingFactory = function pollingFactory(config) {
          * @param {Function} fn
          * @returns {polling}
          */
-        setAction: function setAction(fn) {
+        setAction(fn) {
             action = fn;
 
             /**
@@ -377,7 +327,7 @@ var pollingFactory = function pollingFactory(config) {
          * Gets the polling action
          * @returns {Function}
          */
-        getAction: function getAction() {
+        getAction() {
             return action;
         },
 
@@ -386,7 +336,7 @@ var pollingFactory = function pollingFactory(config) {
          * @param {Object} ctx
          * @returns {polling}
          */
-        setContext: function setContext(ctx) {
+        setContext(ctx) {
             context = ctx || this;
 
             /**
@@ -403,7 +353,7 @@ var pollingFactory = function pollingFactory(config) {
          * Gets the context applied on each action call
          * @returns {Object}
          */
-        getContext: function getContext() {
+        getContext() {
             return context;
         },
 
@@ -412,7 +362,7 @@ var pollingFactory = function pollingFactory(config) {
          * @param {Number} value
          * @returns {polling}
          */
-        setMax: function setMax(value) {
+        setMax(value) {
             max = Math.abs(parseInt(value, 10) || 0);
             return this;
         },
@@ -421,7 +371,7 @@ var pollingFactory = function pollingFactory(config) {
          * Gets the max number of polling occurrences
          * @returns {Number}
          */
-        getMax: function getMax() {
+        getMax() {
             return max;
         },
 
@@ -429,7 +379,7 @@ var pollingFactory = function pollingFactory(config) {
          * Gets the number of ran iterations
          * @returns {Number}
          */
-        getIteration: function getIteration() {
+        getIteration() {
             return iter || 0;
         },
 
@@ -445,6 +395,57 @@ var pollingFactory = function pollingFactory(config) {
             return !!state[stateName];
         }
     };
+
+    /**
+     * Fires a new timer
+     */
+    function startTimer() {
+        timer = setTimeout(iteration, interval);
+        state.stopped = false;
+        state.pending = true;
+    }
+
+    /**
+     * Stops the current timer
+     */
+    function stopTimer() {
+        clearTimeout(timer);
+        timer = null;
+        state.stopped = true;
+        state.pending = false;
+    }
+
+    /**
+     * Runs an iteration of the polling loop
+     */
+    function iteration() {
+        // prevent more iterations than needed to be ran
+        if (max && iter >= max) {
+            // breaks the polling
+            polling.stop();
+            return;
+        }
+
+        // count the iteration
+        iter = (iter || 0) + 1;
+        state.processing = true;
+        state.pending = false;
+
+        /**
+         * Notifies the action is about to be called
+         * @event polling#call
+         */
+        polling.trigger('call');
+
+        // process the action in the right context
+        action.call(context, polling);
+
+        // next iteration in synchronous mode
+        if (!promise && !state.stopped) {
+            state.processing = false;
+            startTimer();
+        }
+    }
 
     eventifier(polling);
 
@@ -465,7 +466,7 @@ var pollingFactory = function pollingFactory(config) {
     // loads the config
     if (_.isObject(config)) {
         polling.setAction(config.action);
-        polling.setInterval(config.interval || arguments[1]);
+        polling.setInterval(config.interval || pollingInterval);
         polling.setContext(config.context);
         polling.setMax(config.max);
         autoStart = !!config.autoStart;
@@ -476,6 +477,6 @@ var pollingFactory = function pollingFactory(config) {
     }
 
     return polling;
-};
+}
 
 export default pollingFactory;

--- a/src/core/promiseQueue.js
+++ b/src/core/promiseQueue.js
@@ -49,15 +49,15 @@ import uuid from 'lib/uuid';
  */
 export default function promiseQueueFactory() {
     //where we keep the pending promises
-    var queue = {};
+    let queue = {};
 
-    var getId = function getId() {
-        var id = 'promise-' + uuid(6);
+    function getId() {
+        const id = `promise-${uuid(6)}`;
         if (typeof queue[id] === 'undefined') {
             return id;
         }
         return getId();
-    };
+    }
 
     /**
      * @typedef {promiseQueue}
@@ -66,9 +66,9 @@ export default function promiseQueueFactory() {
         /**
          * Just add another promise to the queue
          * @param {Promise} promise
-         * @return {promiseQueue} chains
+         * @returns {promiseQueue} chains
          */
-        add: function add(promise) {
+        add(promise) {
             queue[getId()] = promise;
             return this;
         },
@@ -77,15 +77,15 @@ export default function promiseQueueFactory() {
          * Get the queue values
          * @returns {Promise[]} the array of promises in the queue
          */
-        getValues: function getValues() {
+        getValues() {
             return _.values(queue);
         },
 
         /**
          * Empty the queue
-         * @return {promiseQueue} chains
+         * @returns {promiseQueue} chains
          */
-        clear: function clear() {
+        clear() {
             queue = {};
             return this;
         },
@@ -95,17 +95,17 @@ export default function promiseQueueFactory() {
          * @param {Function} promiseFn - a function that returns a promise
          * @returns {Promise}
          */
-        serie: function serie(promiseFn) {
-            var id = getId();
+        serie(promiseFn) {
+            const id = getId();
 
             //the actual queue to execute before running the given promise
-            var currentQueue = this.getValues();
+            const currentQueue = this.getValues();
 
             //use an emitter to notify the promise fulfillment, internally.
-            var emitter = eventifier();
+            const emitter = eventifier();
 
             //add a waiting promise into the queue (for others who are calling the queue)
-            queue[id] = new Promise(function(resolve) {
+            queue[id] = new Promise(function (resolve) {
                 emitter.on('fulfilled', resolve);
             });
 
@@ -113,17 +113,17 @@ export default function promiseQueueFactory() {
             //then run the given promise
             //and resolve the waiting promise (for others)
             return Promise.all(currentQueue)
-                .then(function() {
+                .then(function () {
                     if (_.isFunction(promiseFn)) {
                         return promiseFn();
                     }
                 })
-                .then(function(data) {
+                .then(function (data) {
                     emitter.trigger('fulfilled');
                     delete queue[id];
                     return data;
                 })
-                .catch(function(err) {
+                .catch(function (err) {
                     queue = {};
                     throw err;
                 });

--- a/src/core/providerLoader.js
+++ b/src/core/providerLoader.js
@@ -27,7 +27,7 @@ import moduleLoaderFactory from 'core/moduleLoader';
 
 /**
  * Checks a provider object
- * @param provider
+ * @param {object} provider
  * @returns {Boolean}
  */
 function validateProvider(provider) {
@@ -53,7 +53,7 @@ export default function providerLoader(requiredProviders) {
          * @param {String} [category] - to get the providers for a given category, if not set, we get everything
          * @returns {Function[]} the providers
          */
-        getProviders: function getProviders(category) {
+        getProviders(category) {
             return this.getModules(category);
         }
     });

--- a/src/core/providerRegistry.js
+++ b/src/core/providerRegistry.js
@@ -33,7 +33,7 @@ import _ from 'lodash';
  * @returns {Object} the target itself
  */
 function providerRegistry(target, validator) {
-    var _providers = {};
+    let _providers = {};
     target = target || {};
 
     /**
@@ -50,7 +50,7 @@ function providerRegistry(target, validator) {
      * @throws TypeError when a wrong provider is given or an empty name.
      */
     function registerProvider(name, provider) {
-        var valid = true;
+        let valid = true;
 
         //type checking
         if (!_.isString(name) || name.length <= 0) {
@@ -76,7 +76,7 @@ function providerRegistry(target, validator) {
      * @returns {Object} provider
      */
     function getProvider(providerName) {
-        var provider;
+        let provider;
 
         //check a provider is available
         if (!_providers || _.size(_providers) === 0) {
@@ -101,7 +101,7 @@ function providerRegistry(target, validator) {
 
     /**
      * Expose the list of registered providers
-     * @return {String[]} the list of provider names
+     * @returns {String[]} the list of provider names
      */
     function getAvailableProviders() {
         return _.keys(_providers);

--- a/src/core/request.js
+++ b/src/core/request.js
@@ -263,11 +263,11 @@ export default function request(options) {
 
                     const jwtTokenHandler = options.jwtTokenHandler;
                     /**
-                         * if access token expired then
-                         * get new token
-                         * update header with new token
-                         * retry request
-                         *  */
+                     * if access token expired then
+                     * get new token
+                     * update header with new token
+                     * retry request
+                     *  */
                     if (xhr.status === 401 && !isAccessTokenRefreshTried && jwtTokenHandler) {
                         isAccessTokenRefreshTried = true;
                         jwtTokenHandler

--- a/src/core/router.js
+++ b/src/core/router.js
@@ -35,7 +35,7 @@ import UrlParser from 'util/urlParser';
 import loggerFactory from 'core/logger';
 import Promise from 'core/promise';
 
-var logger = loggerFactory('router');
+const logger = loggerFactory('router');
 
 /**
  * The router helps you to execute a controller when an URL maps a defined route.
@@ -46,33 +46,28 @@ var logger = loggerFactory('router');
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  * @exports router
  */
-var router = {
+const router = {
     /**
      * Routing dispatching: execute the controller for the given URL.
      * If more than one URL is provided, we try to dispatch until a valid routing if found
      * (used mainly for forward/redirects).
      *
-     * @param {Array|String} url - the urls to try to dispatch
+     * @param {Array|String} urls - the urls to try to dispatch
      * @param {Function} cb - a callback executed once dispatched
+     * @returns {Promise}
      */
-    dispatch: function dispatch(urls, cb) {
-        var self = this;
-
+    dispatch(urls, cb) {
         if (!_.isArray(urls)) {
             urls = [urls];
         }
 
-        return Promise.all(
-            urls.map(function(url) {
-                return self.dispatchUrl(url);
-            })
-        )
-            .then(function() {
+        return Promise.all(urls.map(url => this.dispatchUrl(url)))
+            .then(function () {
                 if (_.isFunction(cb)) {
                     cb();
                 }
             })
-            .catch(function(err) {
+            .catch(function (err) {
                 logger.error(err);
             });
     },
@@ -82,14 +77,12 @@ var router = {
      * @param {String} url - the URL to parse
      * @returns {Object} the route structure
      */
-    parseMvcUrl: function parseMvcUrl(url) {
-        var route = null;
-        var parser;
-        var paths;
+    parseMvcUrl(url) {
+        let route = null;
 
         if (_.isString(url) && !_.isEmpty(url)) {
-            parser = new UrlParser(url);
-            paths = parser.getPaths();
+            const parser = new UrlParser(url);
+            const paths = parser.getPaths();
             if (paths.length >= 3) {
                 route = {
                     action: paths[paths.length - 1],
@@ -108,15 +101,15 @@ var router = {
      * @param {String} route.extension
      * @returns {Promise} once loaded
      */
-    loadRouteBundle: function loadRouteBundle(route) {
+    loadRouteBundle(route) {
         //only for bundle mode and route which are not TAO (self contained)
         if (route && route.extension && context.bundle && route.extension !== 'tao') {
-            return new Promise(function(resolve) {
-                var routeBundle = route.extension + '/loader/' + route.extension + '.min';
+            return new Promise(function (resolve) {
+                const routeBundle = `${route.extension}/loader/${route.extension}.min`;
 
-                window.require([routeBundle], resolve, function(err) {
+                window.require([routeBundle], resolve, function (err) {
                     //do not break in case of error, module loading will take over
-                    logger.warn('Unable to load ' + routeBundle + ' : ' + err.message);
+                    logger.warn(`Unable to load ${routeBundle} : ${err.message}`);
 
                     resolve();
                 });
@@ -132,11 +125,11 @@ var router = {
      * @param {String} route.extension
      * @returns {Promise<Object>} resolves with the routes data
      */
-    loadRoute: function loadRoute(route) {
+    loadRoute(route) {
         if (route && route.extension) {
-            return new Promise(function(resolve, reject) {
-                var routeModule =
-                    route.extension === 'tao' ? 'controller/routes' : route.extension + '/controller/routes';
+            return new Promise(function (resolve, reject) {
+                const routeModule =
+                    route.extension === 'tao' ? 'controller/routes' : `${route.extension}/controller/routes`;
 
                 //loads the routing for the current extensino
                 window.require([routeModule], resolve, reject);
@@ -153,31 +146,26 @@ var router = {
      *  - load the route's controllers
      *  - execute the start method of those controllers
      * @param {String} url - the
+     * @returns {Promise}
      */
-    dispatchUrl: function dispatchUrl(url) {
-        var self = this;
-
+    dispatchUrl(url) {
         //parse the URL
-        var route = this.parseMvcUrl(url);
+        const route = this.parseMvcUrl(url);
 
-        logger.debug('Dispatch URL ' + url);
+        logger.debug(`Dispatch URL ${url}`);
 
         return this.loadRouteBundle(route)
-            .then(function() {
-                return self.loadRoute(route);
-            })
-            .then(function(routes) {
-                var moduleRoutes;
-                var dependencies = [];
-                var styles = [];
-                var moduleConfig = {};
-                var action;
-                var mapStyle = function mapStyle(style) {
-                    return 'css!' + route.extension + 'Css/' + style;
-                };
+            .then(() => this.loadRoute(route))
+            .then(function (routes) {
+                let dependencies = [];
+                let styles = [];
+                const moduleConfig = {};
+                function mapStyle(style) {
+                    return `css!${route.extension}Css/${style}`;
+                }
                 if (routes && routes[route.module]) {
                     //get the dependencies for the current context
-                    moduleRoutes = routes[route.module];
+                    const moduleRoutes = routes[route.module];
 
                     //resolve controller dependencies
                     if (moduleRoutes.deps) {
@@ -190,7 +178,7 @@ var router = {
 
                     //resolve actions dependencies
                     if ((moduleRoutes.actions && moduleRoutes.actions[route.action]) || moduleRoutes[route.action]) {
-                        action = moduleRoutes.actions[route.action] || moduleRoutes[route.action];
+                        const action = moduleRoutes.actions[route.action] || moduleRoutes[route.action];
                         if (_.isString(action) || _.isArray(action)) {
                             dependencies = dependencies.concat(action);
                         }
@@ -204,13 +192,13 @@ var router = {
                     }
 
                     //alias controller/ to extension/controller
-                    dependencies = _.map(dependencies, function(dep) {
-                        return /^controller/.test(dep) && route.extension !== 'tao' ? route.extension + '/' + dep : dep;
+                    dependencies = _.map(dependencies, function (dep) {
+                        return /^controller/.test(dep) && route.extension !== 'tao' ? `${route.extension}/${dep}` : dep;
                     });
 
                     //URL parameters are given by default to the required module (through module.confid())
                     if (!_.isEmpty(route.params)) {
-                        _.forEach(dependencies, function(dependency) {
+                        _.forEach(dependencies, function (dependency) {
                             //inject parameters using the curent requirejs contex. This rely on a private api...
                             moduleConfig[dependency] = _.merge(
                                 _.clone(window.requirejs.s.contexts._.config.config[dependency] || {}),
@@ -222,22 +210,22 @@ var router = {
                 }
                 return dependencies;
             })
-            .then(function(dependencies) {
+            .then(function (dependencies) {
                 if (dependencies && dependencies.length) {
-                    logger.debug('Load controllers : ' + dependencies.join(', '));
+                    logger.debug(`Load controllers : ${dependencies.join(', ')}`);
 
                     //loads module and action's dependencies and start the controllers.
-                    return new Promise(function(resolve, reject) {
+                    return new Promise(function (resolve, reject) {
                         window.require(
                             dependencies,
-                            function() {
-                                _.forEach(arguments, function(dependency) {
+                            function (...args) {
+                                _.forEach(args, function (dependency) {
                                     if (dependency && _.isFunction(dependency.start)) {
                                         dependency.start();
                                     }
                                 });
 
-                                logger.debug(arguments.length + ' controllers started');
+                                logger.debug(`${args.length} controllers started`);
                                 resolve();
                             },
                             reject

--- a/src/core/statifier.js
+++ b/src/core/statifier.js
@@ -75,14 +75,14 @@ import _ from 'lodash';
  * @returns {Object} the target for convenience
  */
 function statifierFactory(target) {
-    var states = {};
-    var statesApi = {
+    let states = {};
+    const statesApi = {
         /**
          * Tells if the state is set
          * @param {String} name
          * @returns {Boolean}
          */
-        getState: function getState(name) {
+        getState(name) {
             return !!states[name];
         },
 
@@ -99,7 +99,7 @@ function statifierFactory(target) {
          * @param {Boolean} [value]
          * @returns {statesApi}
          */
-        setState: function setState(name, value) {
+        setState(name, value) {
             if (typeof value === 'undefined') {
                 value = true;
             }
@@ -111,7 +111,7 @@ function statifierFactory(target) {
          * Cleans up all states
          * @returns {statesApi}
          */
-        clearStates: function clearStates() {
+        clearStates() {
             states = {};
             return this;
         },
@@ -120,10 +120,10 @@ function statifierFactory(target) {
          * Returns all current states set
          * @returns {Array}
          */
-        getStates: function getStates() {
+        getStates() {
             return _.reduce(
                 states,
-                function(result, state, key) {
+                function (result, state, key) {
                     if (state) {
                         result.push(key);
                     }
@@ -138,9 +138,8 @@ function statifierFactory(target) {
 
     _(statesApi)
         .functions()
-        .forEach(function(method) {
-            target[method] = function delegate() {
-                var args = [].slice.call(arguments);
+        .forEach(function (method) {
+            target[method] = function delegate(...args) {
                 return statesApi[method].apply(target, args);
             };
         });


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1166

### Summary

Fix the ESLint error in the source code for `tao-core`.

**Note:** as the changes are pretty heavy, I split them all into several pull requests.

### Details

This pull request only targets the `core/*` part of the library.
The full picture can be seen from the main branch which contains all the fixes: https://github.com/oat-sa/tao-core-sdk-fe.git#fix/ADF-1166/eslint-errors

What has been made:
- fix errors that can be automated using `eslint --fix`, then adjust the changes in case by case (mostly string literals)
- fix the wrong annotations (missing/wrong return or param definition)
- fix the more complex cases with some refactoring (rest operator instead of `.apply()`)
- replace `var` by `const` or `let` (but not in all places, only in the touched files when it was not adding too much noise)
- apply object shorthand instead of duplicated function names
- apply arrow functions here and there when it helped, but not systematically to reduce the noise

### How to test
- checkout and install the source code `npm i`
- run the linter: `npm run lint:src`, errors and warnings coming from the `core` folder should have gone.
- run the unit tests: `npm run test core`
- install with other repositories, using the following scheme: `"@oat-sa/tao-core-sdk": "https://github.com/oat-sa/tao-core-sdk-fe.git#fix/ADF-1166/eslint-errors",`, then checking the unit tests and playing with TAO