### PR TITLE
Fix/ADF-1166/ESlint errors in tests of core

### DIFF
--- a/test/core/asyncProcess/test.js
+++ b/test/core/asyncProcess/test.js
@@ -18,57 +18,54 @@
 /**
  * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
  */
-define(['lodash', 'core/promise', 'core/asyncProcess'], function(_, Promise, asyncProcessFactory) {
+define(['lodash', 'core/promise', 'core/asyncProcess'], function (_, Promise, asyncProcessFactory) {
     'use strict';
 
     QUnit.module('asyncProcess');
 
-    QUnit.test('factory', function(assert) {
+    QUnit.test('factory', function (assert) {
         assert.expect(3);
         assert.ok(typeof asyncProcessFactory === 'function', 'the module exposes a function');
         assert.ok(typeof asyncProcessFactory() === 'object', 'the factory produces an object');
-        assert.ok(
-            asyncProcessFactory() !== asyncProcessFactory(),
+        assert.notEqual(
+            asyncProcessFactory(),
+            asyncProcessFactory(),
             'the factory produces a different object at each call'
         );
     });
 
-    var asyncProcessApi = [
+    const asyncProcessApi = [
         { name: 'isRunning', title: 'isRunning' },
         { name: 'start', title: 'start' },
         { name: 'addStep', title: 'addStep' },
         { name: 'done', title: 'done' }
     ];
 
-    QUnit.cases.init(asyncProcessApi).test('asyncProcess API ', function(data, assert) {
+    QUnit.cases.init(asyncProcessApi).test('asyncProcess API ', function (data, assert) {
         assert.expect(1);
 
-        var asyncProcess = asyncProcessFactory();
+        const asyncProcess = asyncProcessFactory();
 
-        assert.equal(
-            typeof asyncProcess[data.name],
-            'function',
-            'The asyncProcess expose a "' + data.name + '" function'
-        );
+        assert.equal(typeof asyncProcess[data.name], 'function', `The asyncProcess expose a "${data.name}" function`);
     });
 
-    QUnit.test('simple process', function(assert) {
-        var ready = assert.async(4);
+    QUnit.test('simple process', function (assert) {
+        const ready = assert.async(4);
 
         assert.expect(11);
 
-        var asyncProcess = asyncProcessFactory();
+        const asyncProcess = asyncProcessFactory();
 
         asyncProcess
-            .on('start', function() {
+            .on('start', function () {
                 assert.ok(true, 'The process is started');
                 ready();
             })
-            .on('resolve', function() {
+            .on('resolve', function () {
                 assert.ok(true, 'The process is finished and the resolve event has been triggered');
                 ready();
             })
-            .on('reject', function() {
+            .on('reject', function () {
                 assert.ok(false, 'The process is finished and the reject event has been triggered');
                 ready();
             });
@@ -81,7 +78,7 @@ define(['lodash', 'core/promise', 'core/asyncProcess'], function(_, Promise, asy
 
         assert.equal(asyncProcess.isRunning(), true, 'There is a running process at this time');
 
-        var p = asyncProcess.done(function(err) {
+        const p = asyncProcess.done(function (err) {
             assert.ok(!err, 'No error is reported by the handler');
             assert.equal(asyncProcess.isRunning(), false, 'The process is now finished');
             ready();
@@ -90,31 +87,31 @@ define(['lodash', 'core/promise', 'core/asyncProcess'], function(_, Promise, asy
         assert.ok('object' === typeof p, 'The done method returns an object');
         assert.ok('function' === typeof p.then && 'function' === typeof p.catch, 'The done method returns a promise');
 
-        p.then(function() {
+        p.then(function () {
             assert.ok(true, 'The promise is resolved');
             ready();
-        }).catch(function() {
+        }).catch(function () {
             assert.ok(false, 'The promise must not be rejected');
             ready();
         });
     });
 
-    QUnit.test('deferred process', function(assert) {
-        var ready = assert.async(4);
+    QUnit.test('deferred process', function (assert) {
+        const ready = assert.async(4);
         assert.expect(13);
 
-        var asyncProcess = asyncProcessFactory();
+        const asyncProcess = asyncProcessFactory();
 
         asyncProcess
-            .on('start', function() {
+            .on('start', function () {
                 assert.ok(true, 'The process is started');
                 ready();
             })
-            .on('resolve', function() {
+            .on('resolve', function () {
                 assert.ok(true, 'The process is finished and the resolve event has been triggered');
                 ready();
             })
-            .on('reject', function() {
+            .on('reject', function () {
                 assert.ok(false, 'The process is finished and the reject event has been triggered');
                 ready();
             });
@@ -123,8 +120,8 @@ define(['lodash', 'core/promise', 'core/asyncProcess'], function(_, Promise, asy
             assert.ok(true, 'The process main has been called');
             assert.ok(asyncProcess.isRunning(), 'The process is running');
 
-            setTimeout(function() {
-                var p = asyncProcess.done(function(err) {
+            setTimeout(function () {
+                const p = asyncProcess.done(function (err) {
                     assert.ok(!err, 'No error is reported by the handler');
                     assert.equal(asyncProcess.isRunning(), false, 'The process is now finished');
                     ready();
@@ -136,10 +133,10 @@ define(['lodash', 'core/promise', 'core/asyncProcess'], function(_, Promise, asy
                     'The done method returns a promise'
                 );
 
-                p.then(function() {
+                p.then(function () {
                     assert.ok(true, 'The promise is resolved');
                     ready();
-                }).catch(function() {
+                }).catch(function () {
                     assert.ok(false, 'The promise must not be rejected');
                     ready();
                 });
@@ -159,22 +156,22 @@ define(['lodash', 'core/promise', 'core/asyncProcess'], function(_, Promise, asy
         assert.equal(asyncProcess.isRunning(), true, 'There is a running process at this time');
     });
 
-    QUnit.test('process with steps', function(assert) {
-        var ready = assert.async(6);
+    QUnit.test('process with steps', function (assert) {
+        const ready = assert.async(6);
         assert.expect(24);
 
-        var asyncProcess = asyncProcessFactory();
+        const asyncProcess = asyncProcessFactory();
 
         asyncProcess
-            .on('start', function() {
+            .on('start', function () {
                 assert.ok(true, 'The process is started');
                 ready();
             })
-            .on('step', function() {
+            .on('step', function () {
                 assert.ok(true, 'A step has been added');
                 ready();
             })
-            .on('resolve', function(data) {
+            .on('resolve', function (data) {
                 assert.ok(true, 'The process is finished and the resolve event has been triggered');
 
                 assert.ok(_.isArray(data), 'The resolved data has been provided');
@@ -182,7 +179,7 @@ define(['lodash', 'core/promise', 'core/asyncProcess'], function(_, Promise, asy
                 assert.ok(_.indexOf(data, 2) !== -1, 'The data contains the second resolved step');
                 ready();
             })
-            .on('reject', function() {
+            .on('reject', function () {
                 assert.ok(false, 'The process is finished and the reject event has been triggered');
                 ready();
             });
@@ -192,23 +189,23 @@ define(['lodash', 'core/promise', 'core/asyncProcess'], function(_, Promise, asy
             assert.ok(asyncProcess.isRunning(), 'The process is running');
 
             asyncProcess.addStep(
-                new Promise(function(resolve) {
-                    setTimeout(function() {
+                new Promise(function (resolve) {
+                    setTimeout(function () {
                         resolve(1);
                     }, 300);
                 })
             );
 
             asyncProcess.addStep(
-                new Promise(function(resolve) {
-                    setTimeout(function() {
+                new Promise(function (resolve) {
+                    setTimeout(function () {
                         resolve(2);
                     }, 400);
                 })
             );
 
-            setTimeout(function() {
-                var p = asyncProcess.done(function(err, data) {
+            setTimeout(function () {
+                const p = asyncProcess.done(function (err, data) {
                     assert.ok(!err, 'No error is reported by the handler');
                     assert.equal(asyncProcess.isRunning(), false, 'The process is now finished');
 
@@ -225,7 +222,7 @@ define(['lodash', 'core/promise', 'core/asyncProcess'], function(_, Promise, asy
                     'The done method returns a promise'
                 );
 
-                p.then(function(data) {
+                p.then(function (data) {
                     assert.ok(true, 'The promise is resolved');
 
                     assert.ok(_.isArray(data), 'The resolved data has been provided');
@@ -233,7 +230,7 @@ define(['lodash', 'core/promise', 'core/asyncProcess'], function(_, Promise, asy
                     assert.ok(_.indexOf(data, 2) !== -1, 'The data contains the second resolved step');
 
                     ready();
-                }).catch(function() {
+                }).catch(function () {
                     assert.ok(false, 'The promise must not be rejected');
                     ready();
                 });
@@ -253,22 +250,22 @@ define(['lodash', 'core/promise', 'core/asyncProcess'], function(_, Promise, asy
         assert.equal(asyncProcess.isRunning(), true, 'There is a running process at this time');
     });
 
-    QUnit.test('process with errors', function(assert) {
-        var ready = assert.async(4);
+    QUnit.test('process with errors', function (assert) {
+        const ready = assert.async(4);
         assert.expect(14);
 
-        var asyncProcess = asyncProcessFactory();
+        const asyncProcess = asyncProcessFactory();
 
         asyncProcess
-            .on('start', function() {
+            .on('start', function () {
                 assert.ok(true, 'The process is started');
                 ready();
             })
-            .on('resolve', function() {
+            .on('resolve', function () {
                 assert.ok(false, 'The process is finished and the resolve event has been triggered');
                 ready();
             })
-            .on('reject', function(err) {
+            .on('reject', function (err) {
                 assert.ok(true, 'The process is finished and the reject event has been triggered');
                 assert.equal(err, 'oups', 'An error is reported by the handler');
                 ready();
@@ -279,23 +276,23 @@ define(['lodash', 'core/promise', 'core/asyncProcess'], function(_, Promise, asy
             assert.ok(asyncProcess.isRunning(), 'The process is running');
 
             asyncProcess.addStep(
-                new Promise(function(resolve, reject) {
-                    setTimeout(function() {
+                new Promise(function (resolve, reject) {
+                    setTimeout(function () {
                         reject('oups');
                     }, 300);
                 })
             );
 
             asyncProcess.addStep(
-                new Promise(function(resolve) {
-                    setTimeout(function() {
+                new Promise(function (resolve) {
+                    setTimeout(function () {
                         resolve(2);
                     }, 400);
                 })
             );
 
-            setTimeout(function() {
-                var p = asyncProcess.done(function(err) {
+            setTimeout(function () {
+                const p = asyncProcess.done(function (err) {
                     assert.equal(err, 'oups', 'An error is reported by the handler');
                     assert.equal(asyncProcess.isRunning(), false, 'The process is now finished');
 
@@ -308,10 +305,10 @@ define(['lodash', 'core/promise', 'core/asyncProcess'], function(_, Promise, asy
                     'The done method returns a promise'
                 );
 
-                p.then(function() {
+                p.then(function () {
                     assert.ok(false, 'The promise must be rejected!');
                     ready();
-                }).catch(function(err) {
+                }).catch(function (err) {
                     assert.equal(err, 'oups', 'An error is reported by the handler');
                     ready();
                 });

--- a/test/core/cachedStore/storeMock.js
+++ b/test/core/cachedStore/storeMock.js
@@ -68,7 +68,8 @@ define(['core/promise'], function(Promise) {
                             return Promise.reject(new Error('Cannot access storage!'));
                         }
 
-                        _stores[name] = data = {};
+                        data = {};
+                        _stores[name] = data;
                         return Promise.resolve(true);
                     },
                     removeStore: function removeStore() {

--- a/test/core/cachedStore/test.js
+++ b/test/core/cachedStore/test.js
@@ -30,10 +30,10 @@ define(['core/store', 'core/cachedStore'], function(store, cachedStore) {
     });
 
     QUnit.test('factory', function(assert) {
-        var ready = assert.async();
+        const ready = assert.async();
         assert.expect(3);
 
-        var name = 'test1';
+        const name = 'test1';
 
         cachedStore(name).then(function(storage1) {
             assert.equal(typeof storage1, 'object', 'An instance of the cachedStore accessor has been created');
@@ -52,14 +52,14 @@ define(['core/store', 'core/cachedStore'], function(store, cachedStore) {
     });
 
     QUnit.test('data', function(assert) {
-        var ready = assert.async();
+        const ready = assert.async();
         assert.expect(11);
 
-        var name = 'test2';
-        var expectedName1 = 'foo';
-        var expectedName2 = 'bob';
-        var expectedValue1 = 'bar';
-        var expectedValue2 = 'fake';
+        const name = 'test2';
+        const expectedName1 = 'foo';
+        const expectedName2 = 'bob';
+        const expectedValue1 = 'bar';
+        const expectedValue2 = 'fake';
 
         cachedStore(name).then(function(storage) {
             assert.equal(typeof storage, 'object', 'An instance of the cachedStore accessor has been created');
@@ -70,29 +70,25 @@ define(['core/store', 'core/cachedStore'], function(store, cachedStore) {
                 storage.setItem(expectedName2, expectedValue2).then(function() {
                     assert.ok(true, 'The value2 has been set');
 
-                    var value1 = storage.getItem(expectedName1);
+                    const value1 = storage.getItem(expectedName1);
                     assert.equal(value1, expectedValue1, 'The got value1 is correct');
 
-                    var value2 = storage.getItem(expectedName2);
+                    const value2 = storage.getItem(expectedName2);
                     assert.equal(value2, expectedValue2, 'The got value2 is correct');
 
                     storage.removeItem(expectedName1).then(function() {
                         assert.ok(true, 'The value1 has been removed');
 
-                        var value1 = storage.getItem(expectedName1);
-                        assert.equal(value1, undefined, 'The value1 is erased');
+                        assert.equal(storage.getItem(expectedName1), void 0, 'The value1 is erased');
 
-                        var value2 = storage.getItem(expectedName2);
-                        assert.equal(value2, expectedValue2, 'The value2 is still there');
+                        assert.equal(storage.getItem(expectedName2), expectedValue2, 'The value2 is still there');
 
                         storage.clear().then(function() {
                             assert.ok(true, 'The data is erased');
 
-                            var value1 = storage.getItem(expectedName1);
-                            assert.equal(value1, undefined, 'The value1 is erased');
+                            assert.equal(storage.getItem(expectedName1), void 0, 'The value1 is erased');
 
-                            var value2 = storage.getItem(expectedName2);
-                            assert.equal(value2, undefined, 'The value2 is erased');
+                            assert.equal(storage.getItem(expectedName2), void 0, 'The value2 is erased');
 
                             ready();
                         });
@@ -103,12 +99,12 @@ define(['core/store', 'core/cachedStore'], function(store, cachedStore) {
     });
 
     QUnit.test('persistence', function(assert) {
-        var ready = assert.async();
+        const ready = assert.async();
         assert.expect(6);
 
-        var name = 'test3';
-        var expectedName = 'foo';
-        var expectedValue = 'bar';
+        const name = 'test3';
+        const expectedName = 'foo';
+        const expectedValue = 'bar';
 
         cachedStore(name).then(function(storage1) {
             assert.equal(typeof storage1, 'object', 'An instance of the cachedStore accessor has been created');
@@ -123,8 +119,7 @@ define(['core/store', 'core/cachedStore'], function(store, cachedStore) {
                         'Another instance of the cachedStore accessor has been created'
                     );
 
-                    var value = storage2.getItem(expectedName);
-                    assert.equal(value, expectedValue, 'The got value is correct');
+                    assert.equal(storage2.getItem(expectedName), expectedValue, 'The got value is correct');
 
                     storage2.removeStore().then(function() {
                         cachedStore(name).then(function(storage3) {
@@ -134,7 +129,7 @@ define(['core/store', 'core/cachedStore'], function(store, cachedStore) {
                                 'Another instance of the cachedStore accessor has been created'
                             );
 
-                            var value = storage3.getItem(expectedName);
+                            const value = storage3.getItem(expectedName);
                             assert.equal(typeof value, 'undefined', 'The got value is correct');
 
                             ready();

--- a/test/core/communicator/poll/test.js
+++ b/test/core/communicator/poll/test.js
@@ -58,7 +58,7 @@ define(['jquery', 'lodash', 'core/communicator', 'core/communicator/poll', 'jque
         assert.equal(
             typeof poll[data.name],
             'function',
-            'The communicator/poll api exposes a "' + data.name + '" function'
+            `The communicator/poll api exposes a "${data.name}" function`
         );
     });
 

--- a/test/core/communicator/request/test.js
+++ b/test/core/communicator/request/test.js
@@ -44,19 +44,19 @@ define(['jquery', 'core/communicator', 'core/communicator/request'], function($,
             assert.equal(
                 typeof requestProvider[data.name],
                 'function',
-                'The communicator/request api exposes a "' + data.name + '" function'
+                `The communicator/request api exposes a "${data.name}" function`
             );
         });
 
     QUnit.module('provider');
 
     QUnit.test('missing configuration', function(assert) {
-        var ready = assert.async();
+        const ready = assert.async();
         assert.expect(1);
 
         communicator.registerProvider('request', requestProvider);
 
-        var instance = communicator('request');
+        const instance = communicator('request');
 
         instance.init().catch(function() {
             assert.ok(true, 'The provider needs the a service config');
@@ -65,12 +65,12 @@ define(['jquery', 'core/communicator', 'core/communicator/request'], function($,
     });
 
     QUnit.test('lifecyle', function(assert) {
-        var ready = assert.async();
+        const ready = assert.async();
         assert.expect(8);
 
         communicator.registerProvider('request', requestProvider);
 
-        var instance = communicator('request', { service: 'service.url' })
+        const instance = communicator('request', { service: 'service.url' })
             .on('init', function() {
                 assert.ok(true, 'The communicator has fired the "init" event');
             })
@@ -117,12 +117,12 @@ define(['jquery', 'core/communicator', 'core/communicator/request'], function($,
     });
 
     QUnit.test('send', function(assert) {
-        var ready = assert.async();
+        const ready = assert.async();
         assert.expect(2);
 
         communicator.registerProvider('request', requestProvider);
 
-        var instance = communicator('request', {
+        const instance = communicator('request', {
             service: '/test/core/communicator/request/messages.json'
         }).on('receive', function(data) {
             assert.equal(typeof data, 'object', 'We got a response');

--- a/test/core/communicator/test.js
+++ b/test/core/communicator/test.js
@@ -22,10 +22,10 @@ define(['lodash', 'core/promise', 'core/communicator'], function(_, Promise, com
     'use strict';
 
     QUnit.module('communicator factory', {
-        beforeEach: function(assert) {
+        beforeEach: function() {
             communicator.registerProvider('mock', { init: _.noop });
         },
-        afterEach: function(assert) {
+        afterEach: function() {
             communicator.clearProviders();
         }
     });
@@ -51,7 +51,7 @@ define(['lodash', 'core/promise', 'core/communicator'], function(_, Promise, com
         );
     });
 
-    var communicatorApi = [
+    const communicatorApi = [
         { name: 'init', title: 'init' },
         { name: 'destroy', title: 'destroy' },
 
@@ -72,25 +72,25 @@ define(['lodash', 'core/promise', 'core/communicator'], function(_, Promise, com
     ];
 
     QUnit.cases.init(communicatorApi).test('api', function(data, assert) {
-        var instance = communicator('mock');
+        const instance = communicator('mock');
         assert.equal(
             typeof instance[data.name],
             'function',
-            'The communicator instance exposes a "' + data.name + '" function'
+            `The communicator instance exposes a "${data.name}" function`
         );
     });
 
     QUnit.module('provider', {
-        beforeEach: function(assert) {
+        beforeEach: function() {
             communicator.clearProviders();
         }
     });
 
     QUnit.test('init()', function(assert) {
-        var ready = assert.async();
+        const ready = assert.async();
         assert.expect(5);
 
-        var expectedContextValue = 'yo!';
+        const expectedContextValue = 'yo!';
 
         communicator.registerProvider('foo', {
             init: function() {
@@ -99,7 +99,7 @@ define(['lodash', 'core/promise', 'core/communicator'], function(_, Promise, com
             }
         });
 
-        var instance = communicator('foo')
+        const instance = communicator('foo')
             .on('init', function() {
                 assert.ok(true, 'The communicator has fired the "init" event');
             })
@@ -122,10 +122,10 @@ define(['lodash', 'core/promise', 'core/communicator'], function(_, Promise, com
     });
 
     QUnit.test('destroy()', function(assert) {
-        var ready = assert.async();
+        const ready = assert.async();
         assert.expect(5);
 
-        var expectedContextValue = 'yo!';
+        const expectedContextValue = 'yo!';
 
         communicator.registerProvider('foo', {
             init: function() {
@@ -139,7 +139,7 @@ define(['lodash', 'core/promise', 'core/communicator'], function(_, Promise, com
             }
         });
 
-        var instance = communicator('foo')
+        const instance = communicator('foo')
             .on('destroy', function() {
                 assert.ok(true, 'The communicator has fired the "destroy" event');
             })
@@ -158,10 +158,10 @@ define(['lodash', 'core/promise', 'core/communicator'], function(_, Promise, com
     });
 
     QUnit.test('open()', function(assert) {
-        var ready = assert.async();
+        const ready = assert.async();
         assert.expect(6);
 
-        var expectedContextValue = 'yo!';
+        const expectedContextValue = 'yo!';
 
         communicator.registerProvider('foo', {
             init: function() {
@@ -175,7 +175,7 @@ define(['lodash', 'core/promise', 'core/communicator'], function(_, Promise, com
             }
         });
 
-        var instance = communicator('foo')
+        const instance = communicator('foo')
             .on('open', function() {
                 assert.ok(true, 'The communicator has fired the "open" event');
             })
@@ -200,10 +200,10 @@ define(['lodash', 'core/promise', 'core/communicator'], function(_, Promise, com
     });
 
     QUnit.test('close()', function(assert) {
-        var ready = assert.async();
+        const ready = assert.async();
         assert.expect(15);
 
-        var expectedContextValue = 'yo!';
+        const expectedContextValue = 'yo!';
 
         communicator.registerProvider('foo', {
             init: function() {
@@ -225,7 +225,7 @@ define(['lodash', 'core/promise', 'core/communicator'], function(_, Promise, com
             }
         });
 
-        var instance = communicator('foo')
+        const instance = communicator('foo')
             .on('close', function() {
                 assert.ok(true, 'The communicator has fired the "close" event');
             })
@@ -260,10 +260,10 @@ define(['lodash', 'core/promise', 'core/communicator'], function(_, Promise, com
     });
 
     QUnit.test('send()', function(assert) {
-        var ready = assert.async();
-        var expectedChannel = 'foo';
-        var expectedMessage = 'bar';
-        var expectedResponse = 'ok';
+        const ready = assert.async();
+        const expectedChannel = 'foo';
+        const expectedMessage = 'bar';
+        const expectedResponse = 'ok';
 
         assert.expect(15);
 
@@ -284,7 +284,7 @@ define(['lodash', 'core/promise', 'core/communicator'], function(_, Promise, com
             }
         });
 
-        var instance = communicator('foo')
+        const instance = communicator('foo')
             .on('send', function(promise, channel, message) {
                 assert.ok(true, 'The communicator has fired the "send" event');
                 assert.ok(promise instanceof Promise, 'The promise is provided');
@@ -318,14 +318,14 @@ define(['lodash', 'core/promise', 'core/communicator'], function(_, Promise, com
     });
 
     QUnit.test('channel()', function(assert) {
-        var ready = assert.async();
-        var expectedMessage = 'Hello';
+        const ready = assert.async();
+        const expectedMessage = 'Hello';
 
         assert.expect(4);
 
         communicator.registerProvider('foo', { init: _.noop });
 
-        var instance = communicator('foo');
+        const instance = communicator('foo');
 
         assert.throws(function() {
             instance.channel(null, _.noop);
@@ -345,30 +345,30 @@ define(['lodash', 'core/promise', 'core/communicator'], function(_, Promise, com
     });
 
     QUnit.test('getConfig()', function(assert) {
-        var ready = assert.async();
+        const ready = assert.async();
         assert.expect(1);
 
-        var config = {
+        const config = {
             timeout: 15000,
             moo: 'norz'
         };
 
         communicator.registerProvider('foo', {
             init: function() {
-                var myConfig = this.getConfig();
+                const myConfig = this.getConfig();
                 assert.deepEqual(myConfig, config, 'The retrieved config is the right one');
                 return Promise.resolve();
             }
         });
 
-        var instance = communicator('foo', config);
+        const instance = communicator('foo', config);
         instance.init().then(function() {
             ready();
         });
     });
 
     QUnit.test('setState()', function(assert) {
-        var ready = assert.async();
+        const ready = assert.async();
         assert.expect(4);
 
         communicator.registerProvider('foo', {
@@ -377,7 +377,7 @@ define(['lodash', 'core/promise', 'core/communicator'], function(_, Promise, com
             }
         });
 
-        var instance = communicator('foo');
+        const instance = communicator('foo');
         instance.init().then(function() {
             assert.ok(!instance.getState('foo'), 'The state "foo" is not set');
 

--- a/test/core/connectivity/test.js
+++ b/test/core/connectivity/test.js
@@ -45,15 +45,15 @@ define(['core/connectivity'], function(connectivity) {
             assert.equal(
                 typeof connectivity[data.title],
                 'function',
-                'The tokenHandler instanceexposes a "' + data.name + '" function'
+                `The tokenHandler instanceexposes a "${data.name}" function`
             );
         });
 
     QUnit.module('Behavior', {
-        beforeEach: function setup(assert) {
+        beforeEach: function setup() {
             connectivity.setOnline();
         },
-        afterEach: function teardown(assert) {
+        afterEach: function teardown() {
             connectivity.off('online offline change');
         }
     });

--- a/test/core/dataProvider/proxy/ajax/test.js
+++ b/test/core/dataProvider/proxy/ajax/test.js
@@ -56,7 +56,7 @@ define([
         assert.equal(
             typeof ajaxProvider[data.title],
             'function',
-            'The proxy/ajax provider exposes a "' + data.title + '" function'
+            `The proxy/ajax provider exposes a "${data.title}" function`
         );
     });
 
@@ -110,6 +110,7 @@ define([
             })
             .catch(function(err) {
                 assert.ok(false, 'The promise should not be rejected');
+                // eslint-disable-next-line
                 console.error(err);
                 ready();
             });
@@ -186,6 +187,7 @@ define([
             })
             .catch(function(err) {
                 assert.ok(false, 'The promise should not be rejected');
+                // eslint-disable-next-line
                 console.error(err);
                 ready();
             });
@@ -256,6 +258,7 @@ define([
             })
             .catch(function(err) {
                 assert.ok(false, 'The promise should not be rejected');
+                // eslint-disable-next-line
                 console.error(err);
                 ready();
             });
@@ -355,6 +358,7 @@ define([
             })
             .catch(function(err) {
                 assert.ok(false, 'The promise should not be rejected');
+                // eslint-disable-next-line
                 console.error(err);
                 ready();
             });
@@ -425,6 +429,7 @@ define([
             })
             .catch(function(err) {
                 assert.ok(false, 'The promise should not be rejected');
+                // eslint-disable-next-line
                 console.error(err);
                 ready();
             });
@@ -521,6 +526,7 @@ define([
             })
             .catch(function(err) {
                 assert.ok(false, 'The promise should not be rejected');
+                // eslint-disable-next-line
                 console.error(err);
                 ready();
             });

--- a/test/core/dataProvider/proxy/api/test.js
+++ b/test/core/dataProvider/proxy/api/test.js
@@ -47,7 +47,7 @@ define(['lodash', 'core/promise', 'core/dataProvider/proxy'], function(_, Promis
     ];
 
     QUnit.module('proxyFactory', {
-        beforeEach: function(assert) {
+        beforeEach: function() {
             proxyFactory.clearProviders();
         }
     });
@@ -85,7 +85,7 @@ define(['lodash', 'core/promise', 'core/dataProvider/proxy'], function(_, Promis
         assert.equal(
             typeof instance[data.title],
             'function',
-            'The proxyFactory instance exposes a "' + data.title + '" function'
+            `The proxyFactory instance exposes a "${data.title}" function`
         );
     });
 
@@ -141,6 +141,7 @@ define(['lodash', 'core/promise', 'core/dataProvider/proxy'], function(_, Promis
             })
             .catch(function(err) {
                 assert.ok(false, 'The promise should not be rejected');
+                // eslint-disable-next-line
                 console.error(err);
                 ready();
             });
@@ -188,6 +189,7 @@ define(['lodash', 'core/promise', 'core/dataProvider/proxy'], function(_, Promis
             })
             .catch(function(err) {
                 assert.ok(false, 'The promise should not be rejected');
+                // eslint-disable-next-line
                 console.error(err);
                 ready();
             });
@@ -257,6 +259,7 @@ define(['lodash', 'core/promise', 'core/dataProvider/proxy'], function(_, Promis
             })
             .catch(function(err) {
                 assert.ok(false, 'The promise should not be rejected');
+                // eslint-disable-next-line
                 console.error(err);
                 ready();
             });
@@ -323,6 +326,7 @@ define(['lodash', 'core/promise', 'core/dataProvider/proxy'], function(_, Promis
             })
             .catch(function(err) {
                 assert.ok(false, 'The promise should not be rejected');
+                // eslint-disable-next-line
                 console.error(err);
                 ready();
             });
@@ -392,6 +396,7 @@ define(['lodash', 'core/promise', 'core/dataProvider/proxy'], function(_, Promis
             })
             .catch(function(err) {
                 assert.ok(false, 'The promise should not be rejected');
+                // eslint-disable-next-line
                 console.error(err);
                 ready();
             });
@@ -461,6 +466,7 @@ define(['lodash', 'core/promise', 'core/dataProvider/proxy'], function(_, Promis
             })
             .catch(function(err) {
                 assert.ok(false, 'The promise should not be rejected');
+                // eslint-disable-next-line
                 console.error(err);
                 ready();
             });
@@ -529,6 +535,7 @@ define(['lodash', 'core/promise', 'core/dataProvider/proxy'], function(_, Promis
             })
             .catch(function(err) {
                 assert.ok(false, 'The promise should not be rejected');
+                // eslint-disable-next-line
                 console.error(err);
                 ready();
             });
@@ -661,6 +668,7 @@ define(['lodash', 'core/promise', 'core/dataProvider/proxy'], function(_, Promis
             })
             .catch(function(err) {
                 assert.ok(false, 'The promise should not be rejected');
+                // eslint-disable-next-line
                 console.error(err);
                 ready();
             });
@@ -750,6 +758,7 @@ define(['lodash', 'core/promise', 'core/dataProvider/proxy'], function(_, Promis
             })
             .catch(function(err) {
                 assert.ok(false, 'The promise should not be rejected');
+                // eslint-disable-next-line
                 console.error(err);
                 ready();
             });

--- a/test/core/dataProvider/request/test.js
+++ b/test/core/dataProvider/request/test.js
@@ -128,13 +128,13 @@ define(['jquery', 'lodash', 'core/dataProvider/request', 'core/promise'], functi
                                 }
                                 response[0].data.requestHeaders = options.headers;
                             }
-                            cb.apply(null, response);
+                            cb(...response);
                         }
                         return this;
                     },
                     fail: function(cb) {
                         if (errors[options.url]) {
-                            cb.apply(null, errors[options.url]);
+                            cb(...errors[options.url]);
                         }
                         return this;
                     }

--- a/test/core/databinder/test.js
+++ b/test/core/databinder/test.js
@@ -27,7 +27,7 @@ define(['jquery', 'core/databinder'], function($, DataBinder) {
     var model;
 
     QUnit.module('2 ways data binding', {
-        beforeEach: function(assert) {
+        beforeEach: function() {
             model = {
                 title: 'testTitle',
                 testParts: [
@@ -113,7 +113,7 @@ define(['jquery', 'core/databinder'], function($, DataBinder) {
 
         $title.trigger('delete');
 
-        assert.strictEqual(model.title, undefined, 'model title has been removed');
+        assert.strictEqual(model.title, void 0, 'model title has been removed');
     });
 
     QUnit.test('Array assignment', function(assert) {
@@ -175,7 +175,6 @@ define(['jquery', 'core/databinder'], function($, DataBinder) {
         var $sectionParts = $('ul', $container);
         var $firstPart;
         var $thirdPart;
-        var index;
 
         assert.expect(7);
 
@@ -216,7 +215,7 @@ define(['jquery', 'core/databinder'], function($, DataBinder) {
             .find('[data-bind="href"]')
             .text('toto')
             .trigger('change');
-        index = $sectionParts.find('li:nth-child(2)').attr('data-bind-index');
+
         assert.equal(
             model.testParts[0].assessmentSections[0].sectionParts[1].href,
             'toto',

--- a/test/core/delegator/test.js
+++ b/test/core/delegator/test.js
@@ -117,9 +117,9 @@ define(['core/delegator'], function(delegator) {
     QUnit.test('delegate event disabled', function(assert) {
         var delegate;
         var api = {
-            action: function() {
+            action: function(...args) {
                 assert.ok(true, 'Action called from the api');
-                return delegate('action', arguments);
+                return delegate('action', args);
             },
 
             trigger: function() {

--- a/test/core/encoder/str2array/test.js
+++ b/test/core/encoder/str2array/test.js
@@ -12,7 +12,7 @@ define(['core/encoder/str2array'], function(str2array) {
 
     QUnit.module('encoder');
 
-    var encodeData = [
+    const encodeData = [
         { title: 'empty array', input: [], output: '' },
         { title: 'string', input: 'foo', output: 'foo' },
         { title: 'string array', input: ['bar', 'foo'], output: 'bar,foo' },
@@ -26,7 +26,7 @@ define(['core/encoder/str2array'], function(str2array) {
 
     QUnit.module('decoder');
 
-    var decodeData = [
+    const decodeData = [
         { title: 'empty string', input: '', output: [] },
         { title: 'blank string', input: ' ', output: [] },
         { title: 'number', input: 12, output: [] },

--- a/test/core/errorHandler/test.js
+++ b/test/core/errorHandler/test.js
@@ -8,7 +8,7 @@ define(['core/errorHandler'], function(errorHandler) {
     });
 
     QUnit.module('Error', {
-        afterEach: function(assert) {
+        afterEach: function() {
             errorHandler._contexts = {};
         }
     });

--- a/test/core/eventifier/test.js
+++ b/test/core/eventifier/test.js
@@ -366,7 +366,7 @@ define(['lodash', 'core/eventifier', 'core/promise', 'test/core/logger/testLogge
     });
 
     QUnit.module('before', {
-        beforeEach: function setup(assert) {
+        beforeEach: function setup() {
             testLogger.reset();
         }
     });
@@ -668,9 +668,8 @@ define(['lodash', 'core/eventifier', 'core/promise', 'test/core/logger/testLogge
 
     QUnit.test('events context (multi)', function(assert) {
         var emitter = eventifier();
-
-        assert.expect(80);
         var ready = assert.async(8);
+        assert.expect(80);
 
         emitter
             .on('ev1', function() {
@@ -779,7 +778,7 @@ define(['lodash', 'core/eventifier', 'core/promise', 'test/core/logger/testLogge
     });
 
     QUnit.module('on/between', {
-        beforeEach: function setup(assert) {
+        beforeEach: function setup() {
             testLogger.reset();
         }
     });
@@ -924,7 +923,7 @@ define(['lodash', 'core/eventifier', 'core/promise', 'test/core/logger/testLogge
     });
 
     QUnit.module('after', {
-        beforeEach: function setup(assert) {
+        beforeEach: function setup() {
             testLogger.reset();
         }
     });
@@ -1075,7 +1074,7 @@ define(['lodash', 'core/eventifier', 'core/promise', 'test/core/logger/testLogge
     });
 
     QUnit.module('stopEvent', {
-        beforeEach: function setup(assert) {
+        beforeEach: function setup() {
             testLogger.reset();
         }
     });
@@ -1435,7 +1434,7 @@ define(['lodash', 'core/eventifier', 'core/promise', 'test/core/logger/testLogge
     });
 
     QUnit.module('spread', {
-        beforeEach: function setup(assert) {
+        beforeEach: function setup() {
             testLogger.reset();
         }
     });
@@ -1601,7 +1600,7 @@ define(['lodash', 'core/eventifier', 'core/promise', 'test/core/logger/testLogge
     });
 
     QUnit.module('error and rejection', {
-        beforeEach: function setup(assert) {
+        beforeEach: function setup() {
             testLogger.reset();
         }
     });

--- a/test/core/fetchRequest/test.js
+++ b/test/core/fetchRequest/test.js
@@ -183,8 +183,8 @@ define([
         );
 
         request('/foo').catch(error => {
-            error.response.json().then(error => {
-                assert.equal(error.errorMessage, 'Cannot trigger ABC');
+            error.response.json().then(err => {
+                assert.equal(err.errorMessage, 'Cannot trigger ABC');
                 done();
             });
         });

--- a/test/core/historyRouter/test.js
+++ b/test/core/historyRouter/test.js
@@ -21,13 +21,13 @@
 define(['core/historyRouter', 'test/core/historyRouter/mock/controller'], function(historyRouterFactory, controller) {
     'use strict';
 
-    var location = window.history.location || window.location;
-    var port = location.port;
-    var protocol = location.protocol;
-    var domain = protocol + '//' + location.hostname;
-    var testerUrl = location.href;
+    const location = window.history.location || window.location;
+    const port = location.port;
+    const protocol = location.protocol;
+    let domain = `${protocol}//${location.hostname}`;
+    const testerUrl = location.href;
 
-    var historyRouterApi = [
+    const historyRouterApi = [
         { title: 'redirect' },
         { title: 'forward' },
         { title: 'replace' },
@@ -35,7 +35,7 @@ define(['core/historyRouter', 'test/core/historyRouter/mock/controller'], functi
         { title: 'pushState' }
     ];
 
-    var errorsProvider = [
+    const errorsProvider = [
         {
             title: 'Null',
             state: null
@@ -54,39 +54,37 @@ define(['core/historyRouter', 'test/core/historyRouter/mock/controller'], functi
         }
     ];
 
-    var pagesProvider;
-
     if (port && (('http:' === protocol && '80' !== port) || ('https:' === protocol && '443' !== port))) {
-        domain += ':' + port;
+        domain += `:${port}`;
     }
 
-    pagesProvider = [
+    const pagesProvider = [
         {
             title: 'Index page',
             state: '/tao/Test/index',
-            expected: domain + '/tao/Test/index'
+            expected: `${domain}/tao/Test/index`
         },
         {
             title: 'User page',
             state: {
                 url: '/tao/Test/user?id=foo#bar'
             },
-            expected: domain + '/tao/Test/user?id=foo#bar'
+            expected: `${domain}/tao/Test/user?id=foo#bar`
         },
         {
             title: 'Delivery page',
             state: {
                 url: '/tao/Test/delivery?delivery=bar'
             },
-            expected: domain + '/tao/Test/delivery?delivery=bar'
+            expected: `${domain}/tao/Test/delivery?delivery=bar`
         }
     ];
 
     QUnit.module('API', {
-        beforeEach: function(assert) {
+        beforeEach: function() {
             controller.removeAllListeners();
         },
-        afterEach: function(assert) {
+        afterEach: function() {
             window.history.replaceState(null, '', testerUrl);
         }
     });
@@ -104,27 +102,27 @@ define(['core/historyRouter', 'test/core/historyRouter/mock/controller'], functi
     });
 
     QUnit.cases.init(historyRouterApi).test('instance API ', function(data, assert) {
-        var instance = historyRouterFactory();
+        const instance = historyRouterFactory();
         assert.expect(1);
         assert.equal(
             typeof instance[data.title],
             'function',
-            'The historyRouter instance exposes a "' + data.title + '" function'
+            `The historyRouter instance exposes a "${data.title}" function`
         );
     });
 
     QUnit.module('States', {
-        beforeEach: function(assert) {
+        beforeEach: function() {
             controller.removeAllListeners();
         },
-        afterEach: function(assert) {
+        afterEach: function() {
             window.history.replaceState(null, '', testerUrl);
         }
     });
 
     QUnit.cases.init(pagesProvider).test('pushState', function(data, assert) {
-        var ready = assert.async();
-        var instance = historyRouterFactory();
+        const ready = assert.async();
+        const instance = historyRouterFactory();
 
         assert.expect(1);
 
@@ -141,8 +139,8 @@ define(['core/historyRouter', 'test/core/historyRouter/mock/controller'], functi
     });
 
     QUnit.cases.init(pagesProvider).test('replace', function(data, assert) {
-        var instance = historyRouterFactory();
-        var ready = assert.async();
+        const instance = historyRouterFactory();
+        const ready = assert.async();
 
         assert.expect(1);
 
@@ -159,8 +157,8 @@ define(['core/historyRouter', 'test/core/historyRouter/mock/controller'], functi
     });
 
     QUnit.test('forward', function(assert) {
-        var ready = assert.async();
-        var instance = historyRouterFactory();
+        const ready = assert.async();
+        const instance = historyRouterFactory();
 
         assert.expect(2);
 
@@ -181,10 +179,10 @@ define(['core/historyRouter', 'test/core/historyRouter/mock/controller'], functi
     });
 
     QUnit.test('redirect', function(assert) {
-        var ready = assert.async();
-        var instance = historyRouterFactory();
-        var url1 = domain + '/tao/Test/user';
-        var url2 = domain + '/tao/Test/delivery';
+        const ready = assert.async();
+        const instance = historyRouterFactory();
+        const url1 = `${domain}/tao/Test/user`;
+        const url2 = `${domain}/tao/Test/delivery`;
 
         assert.expect(3);
 
@@ -211,10 +209,10 @@ define(['core/historyRouter', 'test/core/historyRouter/mock/controller'], functi
     });
 
     QUnit.test('dispatch', function(assert) {
-        var ready = assert.async();
-        var instance = historyRouterFactory();
-        var url1 = domain + '/tao/Test/user';
-        var url2 = domain + '/tao/Test/delivery';
+        const ready = assert.async();
+        const instance = historyRouterFactory();
+        const url1 = `${domain}/tao/Test/user`;
+        const url2 = `${domain}/tao/Test/delivery`;
 
         assert.expect(3);
 
@@ -241,8 +239,8 @@ define(['core/historyRouter', 'test/core/historyRouter/mock/controller'], functi
     });
 
     QUnit.cases.init(errorsProvider).test('dispatch', function(data, assert) {
-        var instance = historyRouterFactory();
-        var ready = assert.async();
+        const instance = historyRouterFactory();
+        const ready = assert.async();
 
         assert.expect(1);
 

--- a/test/core/logger/api/test.js
+++ b/test/core/logger/api/test.js
@@ -120,7 +120,7 @@ define(['core/logger/api'], function(loggerFactory) {
     });
 
     QUnit.module('providers', {
-        beforeEach: function(assert) {
+        beforeEach: function() {
             loggerFactory.providers = false;
         }
     });
@@ -169,7 +169,7 @@ define(['core/logger/api'], function(loggerFactory) {
     });
 
     QUnit.module('logger behavior', {
-        beforeEach: function(assert) {
+        beforeEach: function() {
             loggerFactory.providers = [];
         }
     });
@@ -239,7 +239,7 @@ define(['core/logger/api'], function(loggerFactory) {
             });
 
             logger = loggerFactory(data.name);
-            logger[data.level].apply(logger, data.args);
+            logger[data.level](...data.args);
         });
 
     QUnit.test('minimum level', function(assert) {

--- a/test/core/logger/console/test.js
+++ b/test/core/logger/console/test.js
@@ -25,11 +25,11 @@ define(['core/logger/console'], function(consoleLogger) {
     'use strict';
 
     //Keep a ref of the global functions
-    var cerr = window.console.error;
-    var cwarn = window.console.warn;
-    var cinfo = window.console.info;
-    var clog = window.console.log;
-    var cdebug = window.console.debug;
+    const cerr = window.console.error;
+    const cwarn = window.console.warn;
+    const cinfo = window.console.info;
+    const clog = window.console.log;
+    const cdebug = window.console.debug;
 
     //Mock checkMinLevel function which should be propogated by core/logger/api module
     consoleLogger.checkMinLevel = function() {
@@ -57,7 +57,7 @@ define(['core/logger/console'], function(consoleLogger) {
     });
 
     QUnit.test('trace log', function(assert) {
-        var ready = assert.async();
+        const ready = assert.async();
         assert.expect(4);
 
         window.console.debug = function(name, message, record) {
@@ -76,9 +76,9 @@ define(['core/logger/console'], function(consoleLogger) {
     });
 
     QUnit.test('debug log', function(assert) {
-        var ready = assert.async();
+        const ready = assert.async();
 
-        var field = {
+        const field = {
             array: ['a', 'b', 'c'],
             obj: {
                 prop: true,
@@ -106,7 +106,7 @@ define(['core/logger/console'], function(consoleLogger) {
     });
 
     QUnit.test('info log', function(assert) {
-        var ready = assert.async();
+        const ready = assert.async();
         assert.expect(5);
 
         window.console.info = function(name, message, record) {
@@ -127,7 +127,7 @@ define(['core/logger/console'], function(consoleLogger) {
     });
 
     QUnit.test('warn log', function(assert) {
-        var ready = assert.async();
+        const ready = assert.async();
         assert.expect(4);
 
         window.console.warn = function(name, message, record) {
@@ -146,7 +146,7 @@ define(['core/logger/console'], function(consoleLogger) {
     });
 
     QUnit.test('error log', function(assert) {
-        var ready = assert.async();
+        const ready = assert.async();
         assert.expect(5);
 
         window.console.error = function(name, message, err, record) {
@@ -167,7 +167,7 @@ define(['core/logger/console'], function(consoleLogger) {
     });
 
     QUnit.test('fatal log', function(assert) {
-        var ready = assert.async();
+        const ready = assert.async();
         assert.expect(5);
 
         window.console.error = function(name, message, err, record) {
@@ -188,14 +188,14 @@ define(['core/logger/console'], function(consoleLogger) {
     });
 
     QUnit.module('fallback logging', {
-        beforeEach: function(assert) {
-            window.console.error = undefined;
-            window.console.warn = undefined;
-            window.console.info = undefined;
-            window.console.log = undefined;
-            window.console.debug = undefined;
+        beforeEach: function() {
+            window.console.error = void 0;
+            window.console.warn = void 0;
+            window.console.info = void 0;
+            window.console.log = void 0;
+            window.console.debug = void 0;
         },
-        afterEach: function(assert) {
+        afterEach: function() {
             window.console.error = cerr;
             window.console.warn = cwarn;
             window.console.info = cinfo;
@@ -205,7 +205,7 @@ define(['core/logger/console'], function(consoleLogger) {
     });
 
     QUnit.test('no native warn', function(assert) {
-        var ready = assert.async();
+        const ready = assert.async();
         assert.expect(5);
 
         window.console.log = function(level, name, message, record) {
@@ -225,7 +225,7 @@ define(['core/logger/console'], function(consoleLogger) {
     });
 
     QUnit.test('no native debug', function(assert) {
-        var ready = assert.async();
+        const ready = assert.async();
         assert.expect(5);
 
         window.console.log = function(level, name, message, record) {

--- a/test/core/middleware/test.js
+++ b/test/core/middleware/test.js
@@ -51,7 +51,7 @@ define(['core/middleware'], function(middlewaresHandlerFactory) {
         assert.equal(
             typeof instance[data.title],
             'function',
-            'The middlewaresHandlerFactory instance exposes a "' + data.title + '" function'
+            `The middlewaresHandlerFactory instance exposes a "${data.title}" function`
         );
     });
 
@@ -103,6 +103,7 @@ define(['core/middleware'], function(middlewaresHandlerFactory) {
             })
             .catch(function(err) {
                 assert.ok(false, 'The promise should not be rejected');
+                // eslint-disable-next-line
                 console.error(err);
                 ready();
             });

--- a/test/core/plugin/test.js
+++ b/test/core/plugin/test.js
@@ -25,17 +25,17 @@
 define(['lodash', 'core/plugin', 'core/eventifier'], function(_, pluginFactory, eventifier) {
     'use strict';
 
-    var mockProvider = {
+    const mockProvider = {
         name: 'foo',
         init: _.noop
     };
 
-    var defaultConfig = {
+    const defaultConfig = {
         a: false,
         b: 10
     };
 
-    var mockHost = {
+    const mockHost = {
         on: _.noop,
         trigger: _.noop
     };
@@ -98,7 +98,7 @@ define(['lodash', 'core/plugin', 'core/eventifier'], function(_, pluginFactory, 
     QUnit.test('instantiation', function(assert) {
         assert.expect(21);
 
-        var myPlugin = pluginFactory(mockProvider, defaultConfig);
+        const myPlugin = pluginFactory(mockProvider, defaultConfig);
 
         assert.throws(
             function() {
@@ -123,7 +123,7 @@ define(['lodash', 'core/plugin', 'core/eventifier'], function(_, pluginFactory, 
             'My plugin factory provides different object on each call'
         );
 
-        var plugin = myPlugin(mockHost);
+        const plugin = myPlugin(mockHost);
         assert.equal(typeof plugin.init, 'function', 'The plugin instance has also the default function init');
         assert.equal(
             typeof plugin.getAreaBroker,
@@ -166,22 +166,22 @@ define(['lodash', 'core/plugin', 'core/eventifier'], function(_, pluginFactory, 
     QUnit.test('config', function(assert) {
         assert.expect(8);
 
-        var myPlugin = pluginFactory(mockProvider, defaultConfig);
-        var myAreaBroker = {};
-        var instanceConfig = { c: 'c' };
-        var plugin = myPlugin(mockHost, myAreaBroker, instanceConfig);
+        const myPlugin = pluginFactory(mockProvider, defaultConfig);
+        const myAreaBroker = {};
+        const instanceConfig = { c: 'c' };
+        const plugin = myPlugin(mockHost, myAreaBroker, instanceConfig);
 
         assert.equal(typeof plugin, 'object', 'My plugin factory produce a plugin instance object');
 
-        var config1 = plugin.getConfig();
+        const config1 = plugin.getConfig();
         assert.equal(config1.a, defaultConfig.a, 'instance1 inherits the default config "a"');
         assert.equal(config1.b, defaultConfig.b, 'instance1 inherit the default config "b"');
         assert.equal(config1.c, instanceConfig.c, 'instance1 inherit the default config "c"');
 
-        var areaBroker = plugin.getAreaBroker();
+        const areaBroker = plugin.getAreaBroker();
         assert.equal(areaBroker, myAreaBroker, 'instance1 inherit the provided areaBroker');
 
-        var config2 = {
+        const config2 = {
             a: true,
             b: 999
         };
@@ -197,14 +197,14 @@ define(['lodash', 'core/plugin', 'core/eventifier'], function(_, pluginFactory, 
     QUnit.test('methods', function(assert) {
         assert.expect(13);
 
-        var samplePluginImpl = {
+        const samplePluginImpl = {
             name: 'samplePluginImpl',
             install: function() {
                 assert.ok(true, 'called install');
                 assert.equal(this.getHost(), mockHost, 'instance1 has a host when install() is called');
             },
             init: function() {
-                var config = this.getConfig();
+                const config = this.getConfig();
                 assert.ok(true, 'called init');
 
                 assert.equal(config.a, defaultConfig.a, 'instance1 inherits the default config');
@@ -233,11 +233,11 @@ define(['lodash', 'core/plugin', 'core/eventifier'], function(_, pluginFactory, 
             }
         };
 
-        var myPlugin = pluginFactory(samplePluginImpl, defaultConfig);
+        const myPlugin = pluginFactory(samplePluginImpl, defaultConfig);
 
         assert.equal(typeof myPlugin(mockHost), 'object', 'My plugin factory produce a plugin instance object');
 
-        var instance1 = myPlugin(mockHost);
+        const instance1 = myPlugin(mockHost);
         instance1.install();
         instance1.init();
         instance1.render();
@@ -250,14 +250,14 @@ define(['lodash', 'core/plugin', 'core/eventifier'], function(_, pluginFactory, 
     });
 
     QUnit.test('state', function(assert) {
-        var ready = assert.async();
+        const ready = assert.async();
         assert.expect(14);
 
-        var myPlugin = pluginFactory(mockProvider);
+        const myPlugin = pluginFactory(mockProvider);
 
         assert.equal(typeof myPlugin(mockHost), 'object', 'My plugin factory produce a plugin instance object');
 
-        var instance1 = myPlugin(mockHost);
+        const instance1 = myPlugin(mockHost);
 
         assert.throws(
             function() {
@@ -310,10 +310,10 @@ define(['lodash', 'core/plugin', 'core/eventifier'], function(_, pluginFactory, 
     QUnit.test('host name alias', function(assert) {
         assert.expect(3);
 
-        var myPlugin = pluginFactory(mockProvider, {
+        const myPlugin = pluginFactory(mockProvider, {
             hostName: 'fooStopper'
         });
-        var plugin = myPlugin(mockHost);
+        const plugin = myPlugin(mockHost);
 
         assert.equal(typeof plugin, 'object', 'My plugin factory produce a plugin instance object');
         assert.equal(typeof plugin.getFooStopper, 'function', 'Getter with alias has been created');
@@ -322,8 +322,8 @@ define(['lodash', 'core/plugin', 'core/eventifier'], function(_, pluginFactory, 
 
     QUnit.test('host binding', function(assert) {
         assert.expect(4);
-        var value1 = 'xxx';
-        var host = {
+        const value1 = 'xxx';
+        const host = {
             prop1: 123,
             method1: function() {
                 return value1;
@@ -332,7 +332,7 @@ define(['lodash', 'core/plugin', 'core/eventifier'], function(_, pluginFactory, 
             trigger: _.noop
         };
 
-        var samplePluginImpl = {
+        const samplePluginImpl = {
             name: 'hostPlugin',
             init: function() {
                 assert.ok(true, 'called init');
@@ -342,49 +342,49 @@ define(['lodash', 'core/plugin', 'core/eventifier'], function(_, pluginFactory, 
             }
         };
 
-        var myPlugin = pluginFactory(samplePluginImpl);
+        const myPlugin = pluginFactory(samplePluginImpl);
 
-        var instance1 = myPlugin(host);
+        const instance1 = myPlugin(host);
         instance1.init();
         assert.strictEqual(instance1.getHost(), host, 'root component is set');
     });
 
     QUnit.test('root component event', function(assert) {
-        var ready = assert.async();
+        const ready = assert.async();
         assert.expect(6);
 
-        var eventParams = ['ABC', true, 12345];
-        var myPlugin = pluginFactory({
+        const eventParams = ['ABC', true, 12345];
+        const myPlugin = pluginFactory({
             name: 'pluginA',
             init: function() {
                 this.trigger('someEvent', eventParams[0], eventParams[1], eventParams[2]);
             }
         });
 
-        var host = eventifier()
-            .on('plugin-init.pluginA', function(plugin) {
-                assert.ok(true, 'root component knows knows that pluginA has been initialized');
-                assert.deepEqual(plugin, instance1, 'The given plugin instance is correct');
-                ready();
-            })
-            .on('plugin-someEvent.pluginA', function(plugin, arg1, arg2, arg3) {
-                assert.ok(true, 'someEvent triggered and forwarded to root component');
-                assert.strictEqual(eventParams[0], arg1, 'event param ok');
-                assert.strictEqual(eventParams[1], arg2, 'event param ok');
-                assert.strictEqual(eventParams[2], arg3, 'event param ok');
-            });
-
-        var instance1 = myPlugin(host);
+        const instance1 = myPlugin(
+            eventifier()
+                .on('plugin-init.pluginA', function (plugin) {
+                    assert.ok(true, 'root component knows knows that pluginA has been initialized');
+                    assert.deepEqual(plugin, instance1, 'The given plugin instance is correct');
+                    ready();
+                })
+                .on('plugin-someEvent.pluginA', function (plugin, arg1, arg2, arg3) {
+                    assert.ok(true, 'someEvent triggered and forwarded to root component');
+                    assert.strictEqual(eventParams[0], arg1, 'event param ok');
+                    assert.strictEqual(eventParams[1], arg2, 'event param ok');
+                    assert.strictEqual(eventParams[2], arg3, 'event param ok');
+                })
+        );
         instance1.init();
     });
 
     QUnit.test('get plugin name', function(assert) {
-        var ready = assert.async();
+        const ready = assert.async();
         assert.expect(3);
 
-        var name = 'foo-plugin';
+        const name = 'foo-plugin';
 
-        var samplePluginImpl = {
+        const samplePluginImpl = {
             name: name,
             init: function() {
                 assert.ok(true, 'called init');
@@ -393,22 +393,22 @@ define(['lodash', 'core/plugin', 'core/eventifier'], function(_, pluginFactory, 
             }
         };
 
-        var myPlugin = pluginFactory(samplePluginImpl);
+        const myPlugin = pluginFactory(samplePluginImpl);
 
-        var instance1 = myPlugin(mockHost);
+        const instance1 = myPlugin(mockHost);
         assert.equal(instance1.getName(), name, 'The name matches');
         instance1.init();
     });
 
     QUnit.test('plugin content', function(assert) {
-        var ready = assert.async();
+        const ready = assert.async();
         assert.expect(4);
 
-        var name = 'foo-plugin';
-        var content1 = { foo: 'bar' };
-        var content2 = { foo: 'moo' };
+        const name = 'foo-plugin';
+        const content1 = { foo: 'bar' };
+        const content2 = { foo: 'moo' };
 
-        var myPlugin = pluginFactory({
+        const myPlugin = pluginFactory({
             name: name,
             init: function(data) {
                 assert.deepEqual(data, content1, 'The given content is correct');
@@ -416,7 +416,7 @@ define(['lodash', 'core/plugin', 'core/eventifier'], function(_, pluginFactory, 
             }
         });
 
-        var instance1 = myPlugin(mockHost);
+        const instance1 = myPlugin(mockHost);
         instance1.init(content1).then(function() {
             assert.deepEqual(instance1.setContent(content2), instance1, 'The method set content chains');
             assert.deepEqual(instance1.getContent(), content2, 'The given content is up to date');

--- a/test/core/polling/test.js
+++ b/test/core/polling/test.js
@@ -30,7 +30,7 @@ define(['jquery', 'lodash', 'core/polling'], function($, _, polling) {
         assert.notStrictEqual(polling(), polling(), 'The polling factory provides a different object on each call');
     });
 
-    var testReviewApi = [
+    const testReviewApi = [
         { name: 'async', title: 'async' },
         { name: 'next', title: 'next' },
         { name: 'start', title: 'start' },
@@ -48,21 +48,21 @@ define(['jquery', 'lodash', 'core/polling'], function($, _, polling) {
     ];
 
     QUnit.cases.init(testReviewApi).test('instance API ', function(data, assert) {
-        var instance = polling();
+        const instance = polling();
         assert.expect(1);
         assert.equal(
             typeof instance[data.name],
             'function',
-            'The polling instance exposes a "' + data.title + '" function'
+            `The polling instance exposes a "${data.title}" function`
         );
     });
 
     QUnit.test('API', function(assert) {
-        var instance = polling();
-        var action = function() {};
-        var interval = 250;
-        var context = {};
-        var max = 3;
+        const instance = polling();
+        const action = function() {};
+        const interval = 250;
+        const context = {};
+        const max = 3;
 
         assert.expect(18);
 
@@ -92,7 +92,7 @@ define(['jquery', 'lodash', 'core/polling'], function($, _, polling) {
         );
         assert.equal(instance.getAction(), action, 'The polling instance has set the right action callback');
 
-        var instance2 = polling(action);
+        const instance2 = polling(action);
         assert.equal(instance2.getInterval(), 60000, 'The polling instance has set a default value for the interval');
         assert.equal(
             instance2.getContext(),
@@ -101,7 +101,7 @@ define(['jquery', 'lodash', 'core/polling'], function($, _, polling) {
         );
         assert.equal(instance2.getAction(), action, 'The polling instance has set the right action callback');
 
-        var instance3 = polling({
+        const instance3 = polling({
             action: action,
             interval: interval,
             context: context,
@@ -126,26 +126,26 @@ define(['jquery', 'lodash', 'core/polling'], function($, _, polling) {
     });
 
     QUnit.test('events', function(assert) {
-        var ready10 = assert.async();
-        var ready9 = assert.async();
-        var ready8 = assert.async();
-        var ready7 = assert.async(3);
-        var ready6 = assert.async();
-        var ready5 = assert.async(2);
-        var ready4 = assert.async(3);
-        var ready3 = assert.async(2);
-        var ready2 = assert.async();
-        var ready1 = assert.async(4);
-        var ready = assert.async();
-        var instance = polling();
+        const ready10 = assert.async();
+        const ready9 = assert.async();
+        const ready8 = assert.async();
+        const ready7 = assert.async(3);
+        const ready6 = assert.async();
+        const ready5 = assert.async(2);
+        const ready4 = assert.async(3);
+        const ready3 = assert.async(2);
+        const ready2 = assert.async();
+        const ready1 = assert.async(4);
+        const ready = assert.async();
+        const instance = polling();
 
-        var interval = 50;
-        var context = {
+        const interval = 50;
+        const context = {
             step: 0
         };
 
-        var action = function() {
-            var async;
+        const action = function() {
+            let async;
 
             assert.equal(instance.is('processing'), true, 'The instance must be in state processing');
 
@@ -185,7 +185,7 @@ define(['jquery', 'lodash', 'core/polling'], function($, _, polling) {
         instance.on('call', function() {
             assert.ok(
                 true,
-                'The polling instance triggers event when the action is called [step ' + context.step + ']'
+                `The polling instance triggers event when the action is called [step ${context.step}]`
             );
             ready1();
         });
@@ -195,9 +195,7 @@ define(['jquery', 'lodash', 'core/polling'], function($, _, polling) {
             assert.equal(instance.is('pending'), true, 'The instance must be in state pending');
             assert.ok(
                 true,
-                'The polling instance triggers event when the action is validated in async mode [step ' +
-                    context.step +
-                    ']'
+                `The polling instance triggers event when the action is validated in async mode [step ${context.step}]`
             );
             ready2();
         });
@@ -209,9 +207,7 @@ define(['jquery', 'lodash', 'core/polling'], function($, _, polling) {
             }
             assert.ok(
                 true,
-                'The polling instance triggers event when the action is canceled in async mode [step ' +
-                    context.step +
-                    ']'
+                `The polling instance triggers event when the action is canceled in async mode [step ${context.step}]`
             );
             ready3();
         });
@@ -219,7 +215,7 @@ define(['jquery', 'lodash', 'core/polling'], function($, _, polling) {
         instance.on('async', function(cb) {
             assert.ok(
                 true,
-                'The polling instance triggers event when the action is set to async mode [step ' + context.step + ']'
+                `The polling instance triggers event when the action is set to async mode [step ${context.step}]`
             );
             assert.equal(typeof cb, 'object', 'The first parameter of the async event is the resolve object');
             assert.ok(cb.resolve, 'The first parameter of the async event has a resolve method');
@@ -231,9 +227,7 @@ define(['jquery', 'lodash', 'core/polling'], function($, _, polling) {
             assert.equal(instance.is('stopped'), false, 'The instance must not be in state stopped');
             assert.ok(
                 true,
-                'The polling instance triggers event when the action is triggered immediately [step ' +
-                    context.step +
-                    ']'
+                `The polling instance triggers event when the action is triggered immediately [step ${context.step}]`
             );
             ready5();
         });
@@ -243,7 +237,7 @@ define(['jquery', 'lodash', 'core/polling'], function($, _, polling) {
             assert.equal(instance.is('stopped'), false, 'The instance must not be in state stopped');
             assert.ok(
                 true,
-                'The polling instance triggers event when the polling is started [step ' + context.step + ']'
+                `The polling instance triggers event when the polling is started [step ${context.step}]`
             );
             ready6();
         });
@@ -253,7 +247,7 @@ define(['jquery', 'lodash', 'core/polling'], function($, _, polling) {
             assert.equal(instance.is('stopped'), true, 'The instance must be in state stopped');
             assert.ok(
                 true,
-                'The polling instance triggers event when the polling is stopped [step ' + context.step + ']'
+                `The polling instance triggers event when the polling is stopped [step ${context.step}]`
             );
             ready7();
 
@@ -291,19 +285,19 @@ define(['jquery', 'lodash', 'core/polling'], function($, _, polling) {
     });
 
     QUnit.test('limit', function(assert) {
-        var ready1 = assert.async();
-        var ready = assert.async(3);
-        var instance = polling();
-        var max = 3;
-        var interval = 50;
-        var context = {
+        const ready1 = assert.async();
+        const ready = assert.async(3);
+        const instance = polling();
+        const max = 3;
+        const interval = 50;
+        const context = {
             step: 0
         };
 
-        var action = function() {
+        const action = function() {
             this.step++;
-            assert.equal(instance.getIteration(), this.step, 'The iteration is counted #' + this.step);
-            assert.ok(instance.getIteration() <= max, 'The number of iterations is under the max #' + this.step);
+            assert.equal(instance.getIteration(), this.step, `The iteration is counted #${  this.step}`);
+            assert.ok(instance.getIteration() <= max, `The number of iterations is under the max #${  this.step}`);
             ready();
         };
 
@@ -322,7 +316,7 @@ define(['jquery', 'lodash', 'core/polling'], function($, _, polling) {
 
         assert.equal(instance.getMax(), max, 'The mex number of iteration is correct');
 
-        var instance2 = polling({
+        const instance2 = polling({
             action: _.noop,
             max: 2
         });
@@ -333,8 +327,8 @@ define(['jquery', 'lodash', 'core/polling'], function($, _, polling) {
     });
 
     QUnit.test('autoStart', function(assert) {
-        var ready = assert.async();
-        var instance = polling({
+        const ready = assert.async();
+        const instance = polling({
             action: function() {
                 assert.ok(true, 'The instance has auto started the polling');
             },
@@ -352,10 +346,11 @@ define(['jquery', 'lodash', 'core/polling'], function($, _, polling) {
     });
 
     QUnit.test('next pending', function(assert) {
-        var ready = assert.async();
-        var instance = polling({
+        const ready = assert.async();
+        let count = 0;
+        const instance = polling({
             action: function() {
-                var async = this.async();
+                const async = this.async();
 
                 assert.ok(true, 'The next() method has force an iteration');
                 count++;
@@ -371,7 +366,6 @@ define(['jquery', 'lodash', 'core/polling'], function($, _, polling) {
             },
             interval: 200
         });
-        var count = 0;
 
         assert.expect(4);
 

--- a/test/core/providerRegistry/test.js
+++ b/test/core/providerRegistry/test.js
@@ -50,7 +50,7 @@ define(['core/providerRegistry'], function(providerRegistry) {
             assert.equal(
                 typeof registry[data.name],
                 'function',
-                'The providerRegistry helper has injected the "' + data.name + '" API'
+                `The providerRegistry helper has injected the "${data.name}" API`
             );
         });
 
@@ -65,7 +65,7 @@ define(['core/providerRegistry'], function(providerRegistry) {
             assert.expect(1);
             assert.throws(function() {
                 providerRegistry().registerProvider(data.name, data.provider);
-            }, 'registerProvider must throw error when ' + data.title);
+            }, `registerProvider must throw error when ${data.title}`);
         });
 
     QUnit.test('registerProvider validator', function(assert) {

--- a/test/core/request/test.js
+++ b/test/core/request/test.js
@@ -755,7 +755,7 @@ define(['jquery', 'lodash', 'core/request', 'core/tokenHandler', 'core/jwt/jwtTo
             assert.equal(data.refreshToken, refreshToken, 'refresh token is sent to the api');
             return JSON.stringify({ accessToken: expiredAccessToken });
         });
-        
+
         $.mockjax([
             {
                 url: /^\/\/endpoint$/,

--- a/test/core/router/test.js
+++ b/test/core/router/test.js
@@ -44,11 +44,11 @@ define(['core/router', 'context'], function(router, context) {
             }
         ])
         .test('router has the method ', function(data, assert) {
-            assert.equal(typeof router[data.title], 'function', 'The router object expose the method ' + data.title);
+            assert.equal(typeof router[data.title], 'function', `The router object expose the method ${data.title}`);
         });
 
     QUnit.module('Parse URl', {
-        beforeEach: function setup(assert) {
+        beforeEach: function setup() {
             context.bundle = false;
         }
     });

--- a/test/core/statifier/test.js
+++ b/test/core/statifier/test.js
@@ -40,7 +40,7 @@ define(['core/statifier'], function(statifier) {
         assert.equal(
             typeof statifier()[data.title],
             'function',
-            'The statifier instance exposes a "' + data.title + '" function'
+            `The statifier instance exposes a "${data.title}" function`
         );
     });
 

--- a/test/core/store/indexeddb/test.js
+++ b/test/core/store/indexeddb/test.js
@@ -32,7 +32,7 @@ define(['core/store/indexeddb', 'core/promise'], function(indexedDbBackend, Prom
             testDbs.forEach(function(dbName) {
                 req = idb.deleteDatabase(dbName);
                 req.onerror = function(event) {
-                    window.console.error('Error deleting test database ' + dbName, event);
+                    window.console.error(`Error deleting test database ${dbName}`, event);
                 };
             });
         }

--- a/test/core/store/store/test.js
+++ b/test/core/store/store/test.js
@@ -241,7 +241,7 @@ define(['core/store', 'core/promise'], function(store, Promise) {
     });
 
     QUnit.module('CRUD', {
-        beforeEach: function(assert) {
+        beforeEach: function() {
             mockedData = {};
         }
     });

--- a/test/core/timer/test.js
+++ b/test/core/timer/test.js
@@ -33,7 +33,7 @@ define(['lodash', 'core/timer'], function(_, timerFactory) {
         );
     });
 
-    var timerApi = [
+    const timerApi = [
         { name: 'start', title: 'start' },
         { name: 'stop', title: 'stop' },
         { name: 'pause', title: 'pause' },
@@ -46,18 +46,18 @@ define(['lodash', 'core/timer'], function(_, timerFactory) {
     ];
 
     QUnit.cases.init(timerApi).test('instance API ', function(data, assert) {
-        var instance = timerFactory();
+        const instance = timerFactory();
         assert.equal(
             typeof instance[data.name],
             'function',
-            'The timer instance exposes a "' + data.name + '" function'
+            `The timer instance exposes a "${data.name}" function`
         );
     });
 
-    var timerOptions = [
+    const timerOptions = [
         {
             title: 'config: default',
-            config: undefined,
+            config: void 0,
             started: true,
             running: true
         },
@@ -90,31 +90,31 @@ define(['lodash', 'core/timer'], function(_, timerFactory) {
     ];
 
     QUnit.cases.init(timerOptions).test('timer.start ', function(data, assert) {
-        var expectedDuration = data.duration || 0;
-        var timer = timerFactory(data.config);
+        const expectedDuration = data.duration || 0;
+        const timer = timerFactory(data.config);
         assert.equal(
             Math.floor(timer.getDuration()),
             expectedDuration,
-            'The duration must be initialized with the right value (' + expectedDuration + ')'
+            `The duration must be initialized with the right value (${expectedDuration})`
         );
-        assert.equal(timer.is('started'), data.started, 'The timer started state must be ' + data.started);
-        assert.equal(timer.is('running'), data.running, 'The timer running state must be ' + data.running);
+        assert.equal(timer.is('started'), data.started, `The timer started state must be ${data.started}`);
+        assert.equal(timer.is('running'), data.running, `The timer running state must be ${data.running}`);
 
         timer.start(data.duration);
         assert.equal(
             Math.floor(timer.getDuration()),
             expectedDuration,
-            'The duration must be initialized with the right value (' + expectedDuration + ')'
+            `The duration must be initialized with the right value (${expectedDuration})`
         );
         assert.equal(timer.is('started'), true, 'The timer must be started');
         assert.equal(timer.is('running'), true, 'The timer must be running');
     });
 
     QUnit.cases.init(timerOptions).test('timer.stop ', function(data, assert) {
-        var timer = timerFactory(data.config);
+        const timer = timerFactory(data.config);
 
-        assert.equal(timer.is('started'), data.started, 'The timer started state must be ' + data.started);
-        assert.equal(timer.is('running'), data.running, 'The timer running state must be ' + data.running);
+        assert.equal(timer.is('started'), data.started, `The timer started state must be ${data.started}`);
+        assert.equal(timer.is('running'), data.running, `The timer running state must be ${data.running}`);
 
         timer.stop();
         assert.equal(timer.is('started'), false, 'The timer must be stopped');
@@ -130,24 +130,24 @@ define(['lodash', 'core/timer'], function(_, timerFactory) {
     });
 
     QUnit.cases.init(timerOptions).test('timer.pause ', function(data, assert) {
-        var timer = timerFactory(data.config);
+        const timer = timerFactory(data.config);
 
-        assert.equal(timer.is('started'), data.started, 'The timer started state must be ' + data.started);
-        assert.equal(timer.is('running'), data.running, 'The timer running state must be ' + data.running);
+        assert.equal(timer.is('started'), data.started, `The timer started state must be ${data.started}`);
+        assert.equal(timer.is('running'), data.running, `The timer running state must be ${data.running}`);
 
         timer.pause();
-        assert.equal(timer.is('started'), data.started, 'The timer started state must be ' + data.started);
+        assert.equal(timer.is('started'), data.started, `The timer started state must be ${data.started}`);
         assert.equal(timer.is('running'), false, 'The timer must not be running');
     });
 
     QUnit.cases.init(timerOptions).test('timer.resume ', function(data, assert) {
-        var timer = timerFactory(data.config);
+        const timer = timerFactory(data.config);
 
-        assert.equal(timer.is('started'), data.started, 'The timer started state must be ' + data.started);
-        assert.equal(timer.is('running'), data.running, 'The timer running state must be ' + data.running);
+        assert.equal(timer.is('started'), data.started, `The timer started state must be ${data.started}`);
+        assert.equal(timer.is('running'), data.running, `The timer running state must be ${data.running}`);
 
         timer.pause();
-        assert.equal(timer.is('started'), data.started, 'The timer started state must be ' + data.started);
+        assert.equal(timer.is('started'), data.started, `The timer started state must be ${data.started}`);
         assert.equal(timer.is('running'), false, 'The timer must not be running');
 
         timer.resume();
@@ -156,25 +156,25 @@ define(['lodash', 'core/timer'], function(_, timerFactory) {
     });
 
     QUnit.cases.init(timerOptions).test('timer.tick ', function(data, assert) {
-        var ready = assert.async();
+        const ready = assert.async();
         assert.expect(6);
 
-        var delay = 200;
-        var timer = timerFactory(data.config);
+        let delay = 200;
+        const timer = timerFactory(data.config);
 
-        assert.equal(timer.is('started'), data.started, 'The timer started state must be ' + data.started);
-        assert.equal(timer.is('running'), data.running, 'The timer running state must be ' + data.running);
+        assert.equal(timer.is('started'), data.started, `The timer started state must be ${data.started}`);
+        assert.equal(timer.is('running'), data.running, `The timer running state must be ${data.running}`);
 
         if (!timer.is('started')) {
             timer.start(data.duration);
         }
 
         setTimeout(function() {
-            assert.ok(timer.tick() >= delay - 1, 'The timer must return the right tick interval (>=' + delay + ')');
+            assert.ok(timer.tick() >= delay - 1, `The timer must return the right tick interval (>=${delay})`);
 
             delay = 100;
             setTimeout(function() {
-                assert.ok(timer.tick() >= delay - 1, 'The timer must return the right tick interval (>=' + delay + ')');
+                assert.ok(timer.tick() >= delay - 1, `The timer must return the right tick interval (>=${delay})`);
 
                 timer.pause();
                 delay = 150;
@@ -184,10 +184,10 @@ define(['lodash', 'core/timer'], function(_, timerFactory) {
                     timer.resume();
                     delay = 200;
                     setTimeout(function() {
-                        var tick = timer.tick();
+                        const tick = timer.tick();
                         assert.ok(
                             tick >= delay - 1,
-                            'The timer must return the right tick interval ( ' + tick + '>=' + delay + ') once resumed'
+                            `The timer must return the right tick interval ( ${  tick  }>=${delay}) once resumed`
                         );
                         ready();
                     }, delay);
@@ -197,18 +197,18 @@ define(['lodash', 'core/timer'], function(_, timerFactory) {
     });
 
     QUnit.cases.init(timerOptions).test('timer.getDuration ', function(data, assert) {
-        var ready = assert.async();
-        var delay = 200;
-        var expectedDuration = data.duration || 0;
-        var timer = timerFactory(data.config);
+        const ready = assert.async();
+        const delay = 200;
+        let expectedDuration = data.duration || 0;
+        const timer = timerFactory(data.config);
 
         assert.equal(
             Math.floor(timer.getDuration()),
             expectedDuration,
-            'The duration must be initialized with the right value (' + expectedDuration + ')'
+            `The duration must be initialized with the right value (${expectedDuration})`
         );
-        assert.equal(timer.is('started'), data.started, 'The timer started state must be ' + data.started);
-        assert.equal(timer.is('running'), data.running, 'The timer running state must be ' + data.running);
+        assert.equal(timer.is('started'), data.started, `The timer started state must be ${data.started}`);
+        assert.equal(timer.is('running'), data.running, `The timer running state must be ${data.running}`);
 
         if (!timer.is('started')) {
             timer.start(data.duration);
@@ -218,7 +218,7 @@ define(['lodash', 'core/timer'], function(_, timerFactory) {
             expectedDuration += delay;
             assert.ok(
                 timer.getDuration() >= expectedDuration - 1,
-                'The timer must return the right duration (>=' + expectedDuration + ')'
+                `The timer must return the right duration (>=${expectedDuration})`
             );
 
             timer.pause();
@@ -228,7 +228,7 @@ define(['lodash', 'core/timer'], function(_, timerFactory) {
                 assert.equal(
                     timer.getDuration(),
                     expectedDuration,
-                    'The timer must return the right duration (=' + expectedDuration + ')'
+                    `The timer must return the right duration (=${expectedDuration})`
                 );
 
                 timer.resume();
@@ -237,14 +237,14 @@ define(['lodash', 'core/timer'], function(_, timerFactory) {
                     expectedDuration += delay;
                     assert.ok(
                         timer.getDuration() >= expectedDuration - 1,
-                        'The timer must return the right duration (>=' + expectedDuration + ')'
+                        `The timer must return the right duration (>=${expectedDuration})`
                     );
 
                     setTimeout(function() {
                         expectedDuration += delay;
                         assert.ok(
                             timer.getDuration() >= expectedDuration - 1,
-                            'The timer must return the right duration (>=' + expectedDuration + ')'
+                            `The timer must return the right duration (>=${expectedDuration})`
                         );
 
                         timer.stop();
@@ -254,7 +254,7 @@ define(['lodash', 'core/timer'], function(_, timerFactory) {
                             assert.equal(
                                 timer.getDuration(),
                                 expectedDuration,
-                                'The timer must return the right duration (=' + expectedDuration + ')'
+                                `The timer must return the right duration (=${expectedDuration})`
                             );
                             ready();
                         }, delay);
@@ -265,19 +265,19 @@ define(['lodash', 'core/timer'], function(_, timerFactory) {
     });
 
     QUnit.cases.init(timerOptions).test('timer.add ', function(data, assert) {
-        var ready = assert.async();
-        var delay = 200;
-        var expectedDuration = data.duration || 0;
-        var timer = timerFactory(data.config);
-        var extra = 300;
+        const ready = assert.async();
+        const delay = 200;
+        let expectedDuration = data.duration || 0;
+        const timer = timerFactory(data.config);
+        const extra = 300;
 
         assert.equal(
             Math.floor(timer.getDuration()),
             expectedDuration,
-            'The duration must be initialized with the right value (' + expectedDuration + ')'
+            `The duration must be initialized with the right value (${expectedDuration})`
         );
-        assert.equal(timer.is('started'), data.started, 'The timer started state must be ' + data.started);
-        assert.equal(timer.is('running'), data.running, 'The timer running state must be ' + data.running);
+        assert.equal(timer.is('started'), data.started, `The timer started state must be ${  data.started}`);
+        assert.equal(timer.is('running'), data.running, `The timer running state must be ${  data.running}`);
 
         if (!timer.is('started')) {
             timer.start(data.duration);
@@ -288,7 +288,7 @@ define(['lodash', 'core/timer'], function(_, timerFactory) {
             timer.add(extra);
             assert.ok(
                 timer.getDuration() >= expectedDuration - 1,
-                'The timer must return the right duration (>=' + expectedDuration + ')'
+                `The timer must return the right duration (>=${expectedDuration})`
             );
 
             timer.pause();
@@ -298,7 +298,7 @@ define(['lodash', 'core/timer'], function(_, timerFactory) {
                 assert.equal(
                     timer.getDuration(),
                     expectedDuration,
-                    'The timer must return the right duration (=' + expectedDuration + ')'
+                    `The timer must return the right duration (=${expectedDuration})`
                 );
 
                 timer.resume();
@@ -308,7 +308,7 @@ define(['lodash', 'core/timer'], function(_, timerFactory) {
                     timer.add(extra);
                     assert.ok(
                         timer.getDuration() >= expectedDuration - 1,
-                        'The timer must return the right duration (>=' + expectedDuration + ')'
+                        `The timer must return the right duration (>=${expectedDuration})`
                     );
 
                     setTimeout(function() {
@@ -316,7 +316,7 @@ define(['lodash', 'core/timer'], function(_, timerFactory) {
                         timer.add(extra);
                         assert.ok(
                             timer.getDuration() >= expectedDuration - 1,
-                            'The timer must return the right duration (>=' + expectedDuration + ')'
+                            `The timer must return the right duration (>=${expectedDuration})`
                         );
 
                         timer.stop();
@@ -326,7 +326,7 @@ define(['lodash', 'core/timer'], function(_, timerFactory) {
                             assert.equal(
                                 timer.getDuration(),
                                 expectedDuration,
-                                'The timer must return the right duration (=' + expectedDuration + ')'
+                                `The timer must return the right duration (=${expectedDuration})`
                             );
                             ready();
                         }, delay);
@@ -337,19 +337,19 @@ define(['lodash', 'core/timer'], function(_, timerFactory) {
     });
 
     QUnit.cases.init(timerOptions).test('timer.sub ', function(data, assert) {
-        var ready = assert.async();
-        var delay = 200;
-        var expectedDuration = data.duration || 0;
-        var timer = timerFactory(data.config);
-        var extra = 50;
+        const ready = assert.async();
+        const delay = 200;
+        let expectedDuration = data.duration || 0;
+        const timer = timerFactory(data.config);
+        const extra = 50;
 
         assert.equal(
             Math.floor(timer.getDuration()),
             expectedDuration,
-            'The duration must be initialized with the right value (' + expectedDuration + ')'
+            `The duration must be initialized with the right value (${expectedDuration})`
         );
-        assert.equal(timer.is('started'), data.started, 'The timer started state must be ' + data.started);
-        assert.equal(timer.is('running'), data.running, 'The timer running state must be ' + data.running);
+        assert.equal(timer.is('started'), data.started, `The timer started state must be ${data.started}`);
+        assert.equal(timer.is('running'), data.running, `The timer running state must be ${data.running}`);
 
         if (!timer.is('started')) {
             timer.start(data.duration);
@@ -360,7 +360,7 @@ define(['lodash', 'core/timer'], function(_, timerFactory) {
             timer.sub(extra);
             assert.ok(
                 timer.getDuration() >= expectedDuration - 1,
-                'The timer must return the right duration (>=' + expectedDuration + ')'
+                `The timer must return the right duration (>=${expectedDuration})`
             );
 
             timer.pause();
@@ -370,7 +370,7 @@ define(['lodash', 'core/timer'], function(_, timerFactory) {
                 assert.equal(
                     timer.getDuration(),
                     expectedDuration,
-                    'The timer must return the right duration (=' + expectedDuration + ')'
+                    `The timer must return the right duration (=${expectedDuration})`
                 );
 
                 timer.resume();
@@ -380,7 +380,7 @@ define(['lodash', 'core/timer'], function(_, timerFactory) {
                     timer.sub(extra);
                     assert.ok(
                         timer.getDuration() >= expectedDuration - 1,
-                        'The timer must return the right duration (>=' + expectedDuration + ')'
+                        `The timer must return the right duration (>=${expectedDuration})`
                     );
 
                     setTimeout(function() {
@@ -388,7 +388,7 @@ define(['lodash', 'core/timer'], function(_, timerFactory) {
                         timer.sub(extra);
                         assert.ok(
                             timer.getDuration() >= expectedDuration - 1,
-                            'The timer must return the right duration (>=' + expectedDuration + ')'
+                            `The timer must return the right duration (>=${expectedDuration})`
                         );
 
                         timer.stop();
@@ -398,7 +398,7 @@ define(['lodash', 'core/timer'], function(_, timerFactory) {
                             assert.equal(
                                 timer.getDuration(),
                                 expectedDuration,
-                                'The timer must return the right duration (=' + expectedDuration + ')'
+                                `The timer must return the right duration (=${expectedDuration})`
                             );
                             ready();
                         }, delay);

--- a/test/core/tokenHandler/test.js
+++ b/test/core/tokenHandler/test.js
@@ -49,16 +49,16 @@ define(['core/promise', 'core/tokenHandler', 'jquery.mockjax'], function(Promise
         assert.equal(
             typeof instance[data.name],
             'function',
-            'The tokenHandler instance exposes a "' + data.name + '" function'
+            `The tokenHandler instance exposes a "${data.name}" function`
         );
     });
 
     QUnit.module('behaviour', {
         beforeEach: function() {
-            this.cachedModuleConfig = requirejs.s.contexts._.config.config['core/tokenHandler'];
+            this.cachedModuleConfig = window.requirejs.s.contexts._.config.config['core/tokenHandler'];
         },
         afterEach: function() {
-            requirejs.s.contexts._.config.config['core/tokenHandler'] = this.cachedModuleConfig;
+            window.requirejs.s.contexts._.config.config['core/tokenHandler'] = this.cachedModuleConfig;
         }
     });
 
@@ -133,7 +133,7 @@ define(['core/promise', 'core/tokenHandler', 'jquery.mockjax'], function(Promise
         assert.expect(2);
 
         if (data.moduleOptions) {
-            requirejs.s.contexts._.config.config['core/tokenHandler'] = data.moduleOptions;
+            window.requirejs.s.contexts._.config.config['core/tokenHandler'] = data.moduleOptions;
         }
         tokenHandler = tokenHandlerFactory(data.options);
 


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1166

### Summary

Fix the ESLint error in the unit tests for `tao-core`.

**Note:** as the changes are pretty heavy, I split them all into several pull requests.

### Details

This pull request only targets the `core/*` part of the library.
The full picture can be seen from the main branch which contains all the fixes: https://github.com/oat-sa/tao-core-sdk-fe.git#fix/ADF-1166/eslint-errors

What has been made:
- fix errors that can be automated using `eslint --fix`, then adjust the changes in case by case (mostly string literals)
- fix the wrong annotations (missing/wrong return or param definition)
- fix the more complex cases with some refactoring (rest operator instead of `.apply()`)
- replace `var` by `const` or `let` (but not in all places, only in the touched files when it was not adding too much noise)
- apply object shorthand instead of duplicated function names
- apply arrow functions here and there when it helped, but not systematically to reduce the noise

### How to test
- checkout and install the source code `npm i`
- run the linter: `npm run lint:test`, errors and warnings coming from the `core` folder should have gone.
- run the unit tests: `npm run test core`
- install with other repositories, using the following scheme: `"@oat-sa/tao-core-sdk": "https://github.com/oat-sa/tao-core-sdk-fe.git#fix/ADF-1166/eslint-errors",`, then checking the unit tests and playing with TAO