### PR TITLE
Fix/ADF-1166/Broken Glob pattern in Windows

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -29,7 +29,8 @@ const { srcDir, outputDir } = require('./path');
 
 const isDev = process.env.NODE_ENV === 'development';
 
-const inputs = glob.sync(path.join(srcDir, '**', '*.js'));
+const globPath = p => p.replace(/\\/g, '/');
+const inputs = glob.sync(globPath(path.join(srcDir, '**', '*.js')));
 
 const localExternals = inputs.map(input => (
     path

--- a/package-lock.json
+++ b/package-lock.json
@@ -1414,8 +1414,9 @@
       "dev": true
     },
     "@oat-sa/tao-core-libs": {
-      "version": "git+https://github.com/oat-sa/tao-core-libs-fe.git#6240314dccdb1ce20b367489457884db208e8c9f",
-      "from": "git+https://github.com/oat-sa/tao-core-libs-fe.git#fix/ADF-1166/broken-glob-pattern",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-libs/-/tao-core-libs-0.5.1.tgz",
+      "integrity": "sha512-1fAwH0INmP/Xmqn/lvD5Amcpncm8KSMk1IOS2/SZehkspQQnTq4zCOiUwBKttGr18nzzflySX3CUVY4xMuA/LA==",
       "dev": true
     },
     "@oat-sa/tao-qunit-testrunner": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1414,9 +1414,8 @@
       "dev": true
     },
     "@oat-sa/tao-core-libs": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-libs/-/tao-core-libs-0.4.8.tgz",
-      "integrity": "sha512-/JtoZmzMXvpNvd1wEa4nVL9xo59dhVHQUvm7Dsmf+yH1sv4ktl9ovcJK8XVWilB7JbELqM5YxbMKlGgK4DiWSw==",
+      "version": "git+https://github.com/oat-sa/tao-core-libs-fe.git#6240314dccdb1ce20b367489457884db208e8c9f",
+      "from": "git+https://github.com/oat-sa/tao-core-libs-fe.git#fix/ADF-1166/broken-glob-pattern",
       "dev": true
     },
     "@oat-sa/tao-qunit-testrunner": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@oat-sa/eslint-config-tao": "^1.1.1",
     "@oat-sa/expr-eval": "^1.3.1",
     "@oat-sa/prettier-config": "^0.1.1",
-    "@oat-sa/tao-core-libs": "https://github.com/oat-sa/tao-core-libs-fe.git#fix/ADF-1166/broken-glob-pattern",
+    "@oat-sa/tao-core-libs": "^0.5.1",
     "@oat-sa/tao-qunit-testrunner": "1.0.3",
     "async": "^0.2.10",
     "decimal.js": "10.1.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@oat-sa/eslint-config-tao": "^1.1.1",
     "@oat-sa/expr-eval": "^1.3.1",
     "@oat-sa/prettier-config": "^0.1.1",
-    "@oat-sa/tao-core-libs": "^0.4.8",
+    "@oat-sa/tao-core-libs": "https://github.com/oat-sa/tao-core-libs-fe.git#fix/ADF-1166/broken-glob-pattern",
     "@oat-sa/tao-qunit-testrunner": "1.0.3",
     "async": "^0.2.10",
     "decimal.js": "10.1.1",


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1166

### Dependencies

- [x] https://github.com/oat-sa/tao-core-libs-fe/pull/64

### Summary

Make sure to use forward-slash only in glob pattern.

### Details

Recently the dependencies were updated for fixing a few issues.
However, it also introduced a breaking change with Windows users as `node-glob` now reserves the back-slashes for escaping only.

See: https://github.com/isaacs/node-glob/blob/main/changelog.md#80

### How to test
- checkout the branch
- install it: `npm i`
- it should work seamlessly under Windows as well as in other systems