### PR TITLE
fix: replaced - and _ characters in jwt

### DIFF
--- a/src/core/jwt/jwtToken.js
+++ b/src/core/jwt/jwtToken.js
@@ -30,7 +30,11 @@
  */
 export function parseJwtPayload(token) {
     try {
-        return JSON.parse(atob(token.split('.')[1]));
+        let base64Payload = token.split('.')[1];
+        base64Payload = base64Payload.replace(/-/g, '+'); // replace - with +
+        base64Payload = base64Payload.replace(/_/g, '/'); // replace _ with /
+
+        return JSON.parse(atob(base64Payload));
     } catch (e) {
         return null;
     }

--- a/test/core/jwt/jwtToken/test.js
+++ b/test/core/jwt/jwtToken/test.js
@@ -48,6 +48,14 @@ define(['core/jwt/jwtToken'], jwtToken => {
         assert.equal(parseJwtPayload(), null, 'missing token returns null');
     });
 
+    QUnit.test('parses payload object from full token with unsupported characters', assert => {
+        assert.expect(2);
+        const token = 'eyJhbGciOiJIUzI1NiJ9.eyJmb28iOiI_In0.qXbg9lEnmvDekuDfNqiAdqYb3Yx1iTLw7RyUGoz5I9w';
+        const result = parseJwtPayload(token);
+        assert.ok(typeof result === 'object', 'parsed payload is an object');
+        assert.equal(result.foo, '?');
+    });
+
     QUnit.module('getJwtTTL');
 
     const time1 = 1620651921250;


### PR DESCRIPTION
`atob` doesn't support the following special characters: `-` and `_`.

`-` must be replaced with `+` and `_` must be replaced with `/` characters.