### PR TITLE
Fix/tr 6116/parse float thousands separator fix

### DIFF
--- a/src/util/locale.js
+++ b/src/util/locale.js
@@ -83,7 +83,9 @@ export default {
 
         // discard all thousand separators:
         if (thousandsSeparator.length) {
-            numStr = numStr.replace(new RegExp(`\\${thousandsSeparator}`, 'g'), '');
+            // This regex finds thousands separators between groups of three digits
+            const thousandsRegex = new RegExp(`(?<=\\d)(?<!\\.\\d{0,2})\\${thousandsSeparator}(?=\\d{3}(\\D|$))`, 'g');
+            numStr = numStr.replace(thousandsRegex, '');
         }
 
         // standardise the decimal separator as '.':

--- a/test/util/locale/test.js
+++ b/test/util/locale/test.js
@@ -250,5 +250,18 @@ define([
         assert.equal(locale.parseFloat('34,1'), 34.0, 'float with thousands separator in decimal part should be parsed as integer 34');
         assert.equal(locale.parseFloat('3,123'), 3123.0, 'integer part with thousands separator should be parsed correctly as 3123');
         assert.equal(locale.parseFloat('23,123'), 23123.0, 'integer part with thousands separator should be parsed correctly as 23123');
+
+        assert.equal(locale.parseFloat('1,000'), 1000.0, 'integer with one thousands separator');
+        assert.equal(locale.parseFloat('1,000,000'), 1000000.0, 'integer with multiple valid thousands separators');
+        assert.equal(locale.parseFloat('1,00,000'), 1.0, 'integer with invalid thousands separators');
+        assert.equal(locale.parseFloat('1,000.123'), 1000.123, 'float with one thousands separator');
+        assert.equal(locale.parseFloat('1,000,000.123'), 1000000.123, 'float with multiple valid thousands separators');
+        assert.equal(locale.parseFloat('1,00,000.123'), 1.0, 'float with invalid thousands separators');
+        assert.equal(locale.parseFloat('1,000.1,23'), 1000.1, 'float with invalid thousands separator in the decimal part');
+
+        assert.equal(locale.parseFloat('1000,'), 1000.0, 'trailing thousands separator should be ignored');
+        assert.equal(locale.parseFloat('1,,000'), 1.0, 'double thousands separator should be invalid');
+        assert.equal(locale.parseFloat('1,000,000.0001'), 1000000.0001, 'float with multiple valid thousands separators and small decimal part');
+        assert.equal(locale.parseFloat('1,000,000,000.0001'), 1000000000.0001, 'float with many valid thousands separators and small decimal part');
     });
 });

--- a/test/util/locale/test.js
+++ b/test/util/locale/test.js
@@ -239,4 +239,16 @@ define([
             })
             .then(ready);
     });
+
+    QUnit.test('parseFloat with thousands separator in decimal part', assert => {
+        locale.setConfig({
+            decimalSeparator: '.',
+            thousandsSeparator: ','
+        });
+
+        assert.equal(locale.parseFloat('3,14'), 3.0, 'float with thousands separator in decimal part should be parsed as integer 3');
+        assert.equal(locale.parseFloat('34,1'), 34.0, 'float with thousands separator in decimal part should be parsed as integer 34');
+        assert.equal(locale.parseFloat('3,123'), 3123.0, 'integer part with thousands separator should be parsed correctly as 3123');
+        assert.equal(locale.parseFloat('23,123'), 23123.0, 'integer part with thousands separator should be parsed correctly as 23123');
+    });
 });


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-6116

In `locale.js`, the `thousandsSeparator` was only replacing the value with an empty string, which caused a bug where the number 3,14 was converted to 314. The expectation is that the number after the `thousandsSeparator` will be ignored and send as 3.

To achieve that, I prepared a regex that transforms only groups of 3 digits after the `thousandsSeparator` to a number and ignores less and more than 3 digits.
Examples:
3,14 => 3
3,1 => 3
3,123 => 3123
23,123 => 23123
23,1234 =>23