### PR TITLE
chore: removed hardcoded mime extensions

### DIFF
--- a/src/core/mimetype/definitions.js
+++ b/src/core/mimetype/definitions.js
@@ -183,7 +183,7 @@ export default {
             },
             {
                 mime: 'text/x-c',
-                label: __('C++ file (.cpp)'),
+                label: __('C++ file'),
                 equivalent: ['.cpp'],
                 extensionsLabels: ['.cpp']
             },
@@ -195,7 +195,7 @@ export default {
             },
             {
                 mime: 'text/pascal',
-                label: __('Pascal file (.pas)'),
+                label: __('Pascal file'),
                 equivalent: ['.pas'],
                 extensionsLabels: ['.pas']
             },


### PR DESCRIPTION
**Related to:** https://oat-sa.atlassian.net/browse/AUT-4106

**Description:**
Some mime types have the extension hardcoded in the label. There is no need now that the extension has been added to the list

**Changes:**

- Removed hardcoded extensions in mime labels

**How to check:**
- Code available to check in [unit13](https://tenant01-oat-unit13.dev.gcp-eu.taocloud.org/login)
- Check in the companion PR https://github.com/oat-sa/extension-tao-itemqti/pull/2690
<img width="230" alt="image" src="https://github.com/user-attachments/assets/7d5a745b-1305-4921-91e8-203a412758e3" />
