### PR TITLE
fix: SOLAR-1440 decode jwt token properly when it has non-ASCII characters

### DIFF
--- a/src/core/jwt/jwtToken.js
+++ b/src/core/jwt/jwtToken.js
@@ -27,8 +27,8 @@
  * Parse a base64 encoded string to utf8
  * It can help decode non-ASCII characters
  * @see https://oat-sa.atlassian.net/browse/SOLAR-1440?focusedCommentId=304145
- * If a jwt token contains non-ASCII characters, the function atob() will not work. This can
- * happen if the user is allowed to enter a custom name for any of it's fields like working profiles names, or ORG ids.
+ * If a jwt token contains non-ASCII characters, the function atob() will not be enough on its own. This can
+ * happen if the user is allowed to enter a custom name for any of the token fields like working profile names, or ORG ids.
  * @param {String} base64 - base64 encoded string
  * @returns {String} utf8 decoded string
  */

--- a/src/core/jwt/jwtToken.js
+++ b/src/core/jwt/jwtToken.js
@@ -24,6 +24,22 @@
  */
 
 /**
+ * Parse a base64 encoded string to utf8
+ * It can help decode non-ASCII characters
+ * @see https://oat-sa.atlassian.net/browse/SOLAR-1440?focusedCommentId=304145
+ * If a jwt token contains non-ASCII characters, the function atob() will not work. This can
+ * happen if the user is allowed to enter a custom name for any of it's fields like working profiles names, or ORG ids.
+ * @param {String} base64 - base64 encoded string
+ * @returns {String} utf8 decoded string
+ */
+function base64ToUtf8(base64) {
+    const binaryStr = atob(base64);
+    const bytes = Uint8Array.from(binaryStr, char => char.charCodeAt(0));
+    const decoder = new TextDecoder();
+    return decoder.decode(bytes);
+}
+
+/**
  * Decodes the payload (middle section) of a JWT token
  * @param {String} token - JWT token, 'xxxxx.yyyyy.zzzzz' format
  * @returns {Object} JWT payload
@@ -34,7 +50,7 @@ export function parseJwtPayload(token) {
         base64Payload = base64Payload.replace(/-/g, '+'); // replace - with +
         base64Payload = base64Payload.replace(/_/g, '/'); // replace _ with /
 
-        return JSON.parse(atob(base64Payload));
+        return JSON.parse(base64ToUtf8(base64Payload));
     } catch (e) {
         return null;
     }

--- a/test/core/jwt/jwtToken/test.js
+++ b/test/core/jwt/jwtToken/test.js
@@ -48,7 +48,7 @@ define(['core/jwt/jwtToken'], jwtToken => {
             'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpw7FlIEpXVCBCdWlsZGVyIOKdpO-4j_CflKUiLCJpYXQiOjE2MjA2NTM1NDgsImV4cCI6MTYyMDY1NDc2MiwiYXVkIjoid3d3LsSZeMOlbXBsZS5jb20iLCJzdWIiOiIifQ.g9h9kvy39vauIwM4S2i8jSuG0uRIVq0XpH9glMPoxN8';
         const result = parseJwtPayload(token);
         assert.ok(typeof result === 'object', 'parsed payload is an object');
-        assert.equal(result.iss, 'Onliñe JWT Builder ❤️🔥', 'iat correctly parsed');
+        // assert.equal(result.iss, 'Onliñe JWT Builder ❤️🔥', 'iat correctly parsed');
         assert.equal(result.iat, 1620653548, 'iat correctly parsed');
         assert.equal(result.exp, 1620654762, 'exp correctly parsed');
         assert.equal(result.aud, 'www.ęxåmple.com', 'aud correctly parsed');

--- a/test/core/jwt/jwtToken/test.js
+++ b/test/core/jwt/jwtToken/test.js
@@ -43,7 +43,7 @@ define(['core/jwt/jwtToken'], jwtToken => {
     });
 
     QUnit.test('parses payload object from full token with non-ASCII characters ñ å ę', assert => {
-        assert.expect(4);
+        assert.expect(5);
         const token =
             'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIg4p2k77iP8J-UpSIsImlhdCI6MTYyMDY1MzU0OCwiZXhwIjoxNjIwNjU0NzYyLCJhdWQiOiJ3d3cuxJl4w6VtcGxlLmNvbSIsInN1YiI6IiJ9.R2EkocTPJIkhghdJhO5Chv-1ZSFaSzQp3AbKW9tS8MM';
         const result = parseJwtPayload(token);

--- a/test/core/jwt/jwtToken/test.js
+++ b/test/core/jwt/jwtToken/test.js
@@ -45,10 +45,10 @@ define(['core/jwt/jwtToken'], jwtToken => {
     QUnit.test('parses payload object from full token with non-ASCII characters ñ å ę', assert => {
         assert.expect(4);
         const token =
-            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpw7FlIEpXVCBCdWlsZGVyIiwiaWF0IjoxNjIwNjUzNTQ4LCJleHAiOjE2MjA2NTQ3NjIsImF1ZCI6Ind3dy7EmXjDpW1wbGUuY29tIiwic3ViIjoiIn0.a3onjPyUJ-s8DTzOmzvkbco-NzubjNT_0isoahlYElU';
+            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIg4p2k77iP8J-UpSIsImlhdCI6MTYyMDY1MzU0OCwiZXhwIjoxNjIwNjU0NzYyLCJhdWQiOiJ3d3cuxJl4w6VtcGxlLmNvbSIsInN1YiI6IiJ9.R2EkocTPJIkhghdJhO5Chv-1ZSFaSzQp3AbKW9tS8MM';
         const result = parseJwtPayload(token);
         assert.ok(typeof result === 'object', 'parsed payload is an object');
-        assert.equal(result.iss, 'Onliñe JWT Builder', 'iat correctly parsed');
+        assert.equal(result.iss, 'Online JWT Builder ❤️🔥', 'iat correctly parsed');
         assert.equal(result.iat, 1620653548, 'iat correctly parsed');
         assert.equal(result.exp, 1620654762, 'exp correctly parsed');
         assert.equal(result.aud, 'www.ęxåmple.com', 'aud correctly parsed');

--- a/test/core/jwt/jwtToken/test.js
+++ b/test/core/jwt/jwtToken/test.js
@@ -42,15 +42,14 @@ define(['core/jwt/jwtToken'], jwtToken => {
         assert.equal(result.aud, 'www.example.com', 'aud correctly parsed');
     });
 
-    QUnit.test('parses payload object from full token with non-ASCII character ę', assert => {
+    QUnit.test('parses payload object from full token with non-ASCII characters ❤️ ñ å ę 🔥', assert => {
         assert.expect(4);
         const token =
-            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjA2NTM1NDgsImV4cCI6MTYyMDY1NDc2MiwiYXVkIjoid3d3LsSZeGFtcGxlLmNvbSIsInN1YiI6IiJ9.x4y4I7-lD-DsyQ4CAc0xTqSSTArQiHvntIDxwe6nkCA';
+            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpw7FlIEpXVCBCdWlsZGVyIOKdpO-4j_CflKUiLCJpYXQiOjE2MjA2NTM1NDgsImV4cCI6MTYyMDY1NDc2MiwiYXVkIjoid3d3LsSZeMOlbXBsZS5jb20iLCJzdWIiOiIifQ.g9h9kvy39vauIwM4S2i8jSuG0uRIVq0XpH9glMPoxN8';
         const result = parseJwtPayload(token);
         assert.ok(typeof result === 'object', 'parsed payload is an object');
-        assert.equal(result.iat, 1620653548, 'iat correctly parsed');
-        assert.equal(result.exp, 1620654762, 'exp correctly parsed');
-        assert.equal(result.aud, 'www.ęxample.com', 'aud correctly parsed');
+        assert.equal(result.iss, 'Onliñe JWT Builder ❤️🔥', 'iat correctly parsed');
+        assert.equal(result.aud, 'www.ęxåmple.com', 'aud correctly parsed');
     });
 
     QUnit.test('returns null for bad or missing token', assert => {

--- a/test/core/jwt/jwtToken/test.js
+++ b/test/core/jwt/jwtToken/test.js
@@ -45,10 +45,10 @@ define(['core/jwt/jwtToken'], jwtToken => {
     QUnit.test('parses payload object from full token with non-ASCII characters ñ å ę', assert => {
         assert.expect(5);
         const token =
-            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIg4p2k77iP8J-UpSIsImlhdCI6MTYyMDY1MzU0OCwiZXhwIjoxNjIwNjU0NzYyLCJhdWQiOiJ3d3cuxJl4w6VtcGxlLmNvbSIsInN1YiI6IiJ9.R2EkocTPJIkhghdJhO5Chv-1ZSFaSzQp3AbKW9tS8MM';
+            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpw7FlIEpXVCBCdWlsZGVyIOKdpO-4j_CflKUiLCJpYXQiOjE2MjA2NTM1NDgsImV4cCI6MTYyMDY1NDc2MiwiYXVkIjoid3d3LsSZeMOlbXBsZS5jb20iLCJzdWIiOiIifQ.g9h9kvy39vauIwM4S2i8jSuG0uRIVq0XpH9glMPoxN8';
         const result = parseJwtPayload(token);
         assert.ok(typeof result === 'object', 'parsed payload is an object');
-        assert.equal(result.iss, 'Online JWT Builder ❤️🔥', 'iat correctly parsed');
+        assert.equal(result.iss, 'Onliñe JWT Builder ❤️🔥', 'iat correctly parsed');
         assert.equal(result.iat, 1620653548, 'iat correctly parsed');
         assert.equal(result.exp, 1620654762, 'exp correctly parsed');
         assert.equal(result.aud, 'www.ęxåmple.com', 'aud correctly parsed');

--- a/test/core/jwt/jwtToken/test.js
+++ b/test/core/jwt/jwtToken/test.js
@@ -42,13 +42,13 @@ define(['core/jwt/jwtToken'], jwtToken => {
         assert.equal(result.aud, 'www.example.com', 'aud correctly parsed');
     });
 
-    QUnit.test('parses payload object from full token with non-ASCII characters ❤️ ñ å ę 🔥', assert => {
+    QUnit.test('parses payload object from full token with non-ASCII characters ñ å ę', assert => {
         assert.expect(4);
         const token =
-            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpw7FlIEpXVCBCdWlsZGVyIOKdpO-4j_CflKUiLCJpYXQiOjE2MjA2NTM1NDgsImV4cCI6MTYyMDY1NDc2MiwiYXVkIjoid3d3LsSZeMOlbXBsZS5jb20iLCJzdWIiOiIifQ.g9h9kvy39vauIwM4S2i8jSuG0uRIVq0XpH9glMPoxN8';
+            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpw7FlIEpXVCBCdWlsZGVyIiwiaWF0IjoxNjIwNjUzNTQ4LCJleHAiOjE2MjA2NTQ3NjIsImF1ZCI6Ind3dy7EmXjDpW1wbGUuY29tIiwic3ViIjoiIn0.a3onjPyUJ-s8DTzOmzvkbco-NzubjNT_0isoahlYElU';
         const result = parseJwtPayload(token);
         assert.ok(typeof result === 'object', 'parsed payload is an object');
-        // assert.equal(result.iss, 'Onliñe JWT Builder ❤️🔥', 'iat correctly parsed');
+        assert.equal(result.iss, 'Onliñe JWT Builder', 'iat correctly parsed');
         assert.equal(result.iat, 1620653548, 'iat correctly parsed');
         assert.equal(result.exp, 1620654762, 'exp correctly parsed');
         assert.equal(result.aud, 'www.ęxåmple.com', 'aud correctly parsed');

--- a/test/core/jwt/jwtToken/test.js
+++ b/test/core/jwt/jwtToken/test.js
@@ -49,6 +49,8 @@ define(['core/jwt/jwtToken'], jwtToken => {
         const result = parseJwtPayload(token);
         assert.ok(typeof result === 'object', 'parsed payload is an object');
         assert.equal(result.iss, 'Onliñe JWT Builder ❤️🔥', 'iat correctly parsed');
+        assert.equal(result.iat, 1620653548, 'iat correctly parsed');
+        assert.equal(result.exp, 1620654762, 'exp correctly parsed');
         assert.equal(result.aud, 'www.ęxåmple.com', 'aud correctly parsed');
     });
 

--- a/test/core/jwt/jwtToken/test.js
+++ b/test/core/jwt/jwtToken/test.js
@@ -42,7 +42,7 @@ define(['core/jwt/jwtToken'], jwtToken => {
         assert.equal(result.aud, 'www.example.com', 'aud correctly parsed');
     });
 
-    QUnit.test('parses payload object from full token with non-ASCII characters ñ å ę', assert => {
+    QUnit.test('parses payload object from full token with non-ASCII characters ñ å ę ❤️ 🔥', assert => {
         assert.expect(5);
         const token =
             'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpw7FlIEpXVCBCdWlsZGVyIOKdpO-4j_CflKUiLCJpYXQiOjE2MjA2NTM1NDgsImV4cCI6MTYyMDY1NDc2MiwiYXVkIjoid3d3LsSZeMOlbXBsZS5jb20iLCJzdWIiOiIifQ.g9h9kvy39vauIwM4S2i8jSuG0uRIVq0XpH9glMPoxN8';

--- a/test/core/jwt/jwtToken/test.js
+++ b/test/core/jwt/jwtToken/test.js
@@ -33,12 +33,24 @@ define(['core/jwt/jwtToken'], jwtToken => {
 
     QUnit.test('parses payload object from full token', assert => {
         assert.expect(4);
-        const token = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjA2NTM1NDgsImV4cCI6MTYyMDY1NDc2MiwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoiIn0.3j-2RN4OVgDYUVxP9VIaOnpkno8I4LDDzouSzgAdUsw';
+        const token =
+            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjA2NTM1NDgsImV4cCI6MTYyMDY1NDc2MiwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoiIn0.3j-2RN4OVgDYUVxP9VIaOnpkno8I4LDDzouSzgAdUsw';
         const result = parseJwtPayload(token);
         assert.ok(typeof result === 'object', 'parsed payload is an object');
         assert.equal(result.iat, 1620653548, 'iat correctly parsed');
         assert.equal(result.exp, 1620654762, 'exp correctly parsed');
         assert.equal(result.aud, 'www.example.com', 'aud correctly parsed');
+    });
+
+    QUnit.test('parses payload object from full token with non-ASCII character ę', assert => {
+        assert.expect(4);
+        const token =
+            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjA2NTM1NDgsImV4cCI6MTYyMDY1NDc2MiwiYXVkIjoid3d3LsSZeGFtcGxlLmNvbSIsInN1YiI6IiJ9.x4y4I7-lD-DsyQ4CAc0xTqSSTArQiHvntIDxwe6nkCA';
+        const result = parseJwtPayload(token);
+        assert.ok(typeof result === 'object', 'parsed payload is an object');
+        assert.equal(result.iat, 1620653548, 'iat correctly parsed');
+        assert.equal(result.exp, 1620654762, 'exp correctly parsed');
+        assert.equal(result.aud, 'www.ęxample.com', 'aud correctly parsed');
     });
 
     QUnit.test('returns null for bad or missing token', assert => {
@@ -64,13 +76,15 @@ define(['core/jwt/jwtToken'], jwtToken => {
     const jwtPayload2 = { iat: time1 };
     const jwtPayload3 = { exp: time2 };
 
-    QUnit.cases.init([
-        { payload: jwtPayload1, expectedTTL: 750000 },
-        { payload: jwtPayload2, expectedTTL: null },
-        { payload: jwtPayload3, expectedTTL: null },
-        { payload: void 0, expectedTTL: null },
-    ]).test('returns correct TTL', function(data, assert) {
-        assert.expect(1);
-        assert.equal(getJwtTTL(data.payload, data.defaultTTL), data.expectedTTL, JSON.stringify(data));
-    });
+    QUnit.cases
+        .init([
+            { payload: jwtPayload1, expectedTTL: 750000 },
+            { payload: jwtPayload2, expectedTTL: null },
+            { payload: jwtPayload3, expectedTTL: null },
+            { payload: void 0, expectedTTL: null }
+        ])
+        .test('returns correct TTL', function (data, assert) {
+            assert.expect(1);
+            assert.equal(getJwtTTL(data.payload, data.defaultTTL), data.expectedTTL, JSON.stringify(data));
+        });
 });


### PR DESCRIPTION
## Ticket https://oat-sa.atlassian.net/browse/SOLAR-1440

Fix a problem when the jwt token contains non-ASCII characters. See ticket comment for more info.

This solution uses `TextDecoder` to parse a base64 encoded string to utf8. More context [here](https://developer.mozilla.org/en-US/docs/Web/API/Window/btoa#unicode_strings)

In case you want to test the fix: 
```
let s = "eyJleHAiOjE3NDU0MjA0MDcsImlhdCI6MTc0NTQxNjgwNywianRpIjoiYzU5ZTI0YzQtYjIyNC00MDA1LTgzMmYtNGJiMWI0OWFiYzc5IiwiaXNzIjoicG9ydGFsLWNsaWVudC1pZF8xIiwic3ViIjoieWFpMDAwMDEiLCJuYW1lIjoiUG9ydGFsIEZyb250ZW5kIE9BdXRoMiBDbGllbnQiLCJhdWQiOiJuZXh0Z2VuX2VtX2F1dGhfc2VydmVyIiwidXNlciI6eyJhZGRyZXNzZXMiOltdLCJtZXRhZGF0YSI6eyJkbnVtYmVyIjoiMDAwMDExMDAwMDEifSwicm9sZSI6WyJBRE1JTiJdLCJhY3RpdmUiOnRydWUsImxhbmd1YWdlIjoiIiwiaXNMb2dpbk5vdEV4cGVjdGVkIjpmYWxzZSwibG9naW4iOiJ5YWkwMDAwMSIsInRhZ3MiOltdLCJlbWFpbFZlcmlmaWVkIjpmYWxzZSwicHJvdGVjdGVkIjpmYWxzZSwibmFtZSI6InlhaTAwMDAxIiwidGVuYW50SWQiOiJsb2NhbC1kZXYtYWNjLm5leHRnZW4tc3RhY2stbG9jYWwiLCJlbWFpbCI6InlhaXIua3VraWVsa2EreWFpMDAwMDFAdGFvdGVzdGluZy5jb20iLCJsYXN0X3VwZGF0ZV9kYXRlIjoxNzQ1NDE0MzY0NjUxLCJyb2xlcyI6WyJBRE1JTiJdLCJwcm9maWxlTmFtZSI6IldvcmtpbmcgcHJvZmlsZSAxIiwicGVybWlzc2lvbnMiOlt7InJlc291cmNlIjoiYW55Iiwic2NvcGVzIjpbImFsbCJdfV0sInJlc3RyaWN0aW9ucyI6W3sicmVzb3VyY2UiOiJwb3J0YWwubXktc2Vzc2lvbiIsInNjb3BlcyI6WyJ2aWV3Il19LHsicmVzb3VyY2UiOiJwb3J0YWwuc3lzdGVtLXNldHRpbmdzIiwic2NvcGVzIjpbImNyZWF0ZSIsInZpZXciLCJlZGl0IiwiZGVsZXRlIl19XX0sImhpZXJhcmNoeSI6eyJSb290IjoiZmzDpSJ9LCJoaWVyYXJjaHlMZXZlbCI6eyJSb290IjoiTGV2ZWwyIn0sInNjb3BlcyI6W10sInJvbGVzIjpbIkFETUlOIl0sInRlbmFudF9pZCI6ImxvY2FsLWRldi1hY2MubmV4dGdlbi1zdGFjay1sb2NhbCJ9";
console.log(atob(s));
// This wrongly prints ... "hierarchy":{"Root":"flÃ¥"}

// it could be fixed this way
console.log(decodeURIComponent(escape(atob(s))));
// This prints ... "hierarchy":{"Root":"flå"}

// `escape` is deprecated so there is this other way using TextEncoder(), which is the one used in this PR
function base64ToUtf8(base64) {
  const binaryStr = atob(base64);
  const bytes = Uint8Array.from(binaryStr, char => char.charCodeAt(0));
  const decoder = new TextDecoder();
  return decoder.decode(bytes);
}
console.log(base64ToUtf8(s));
// Also prints ... "hierarchy":{"Root":"flå"}
```