### PR TITLE
[ADF-1978] - feat: add stringToSha256 encode utility & refactor cookie.js utility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@oat-sa/tao-core-sdk",
-    "version": "3.4.0",
+    "version": "3.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@oat-sa/tao-core-sdk",
-            "version": "3.4.0",
+            "version": "3.5.0",
             "license": "GPL-2.0",
             "dependencies": {
                 "idb-wrapper": "1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-sdk",
-    "version": "3.4.0",
+    "version": "3.5.0",
     "displayName": "TAO Core SDK",
     "description": "Core libraries of TAO",
     "homepage": "https://github.com/oat-sa/tao-core-sdk-fe#readme",

--- a/src/util/cookies.js
+++ b/src/util/cookies.js
@@ -15,37 +15,49 @@
  *
  * Copyright (c) 2025 Open Assessment Technologies SA;
  *
- * Cookie-based storage utility.
- * Supports JSON-serializable values and persistent cookies.
+ * Factory for creating a cookie‐based storage utility. Each instance
+ * can be initialized with its own default options, but you may override
+ * path, domainLevel, or expires on a per‐method call as needed.
+ *
+ * @param {Object} [defaultOpts={}]
+ * @param {string} [defaultOpts.path='/'] - Default cookie path.
+ * @param {number} [defaultOpts.domainLevel] - Default number of hostname segments to include in `domain=`.
+ * @param {string|number|Date} [defaultOpts.expires] - Default expiration (Date, ISO string, or timestamp). Defaults to +10 years.
+ *
+ * @returns {Object} An object with methods:
+ *   - getItem(key)
+ *   - setItem(key, value, [opts])
+ *   - removeItem(key, [opts])
+ *   - keys()
+ *   - clearAll([opts])
  */
-
-const cookieStorage = {
+export function createCookieStorage(defaultOpts = {}) {
     /**
      * @private
-     * Take the last `n` segments of window.location.hostname, or return null if there aren’t enough segments.
+     * Take the last `n` segments of window.location.hostname,
+     * or return null if there aren’t enough segments.
      * E.g. hostname="foo.bar.example.com", level=2 → "example.com"
      * @param {number} level
      * @returns {string|null}
      */
-    _pickDomain(level) {
+    function pickDomain(level) {
         const parts = window.location.hostname.split('.');
         if (parts.length < level) return null;
         return parts.slice(-level).join('.');
-    },
+    }
 
     /**
      * @private
-     * Given an `expires` option that may be:
+     * Normalize an `expires` option that may be:
      *   • a Date instance
      *   • a parsable string/number
      *   • missing/undefined
-     * Normalize to a Date that represents the correct expiration.
      * Defaults to “10 years from now” if no `expires` was provided.
      *
      * @param {Date|string|number|null|undefined} expires
      * @returns {Date}
      */
-    _normalizeExpires(expires) {
+    function normalizeExpires(expires) {
         if (expires instanceof Date) {
             return expires;
         }
@@ -55,111 +67,117 @@ const cookieStorage = {
         const d = new Date();
         d.setFullYear(d.getFullYear() + 10);
         return d;
-    },
+    }
 
     /**
      * @private
-     * Build a cookie‐option string (expires, path, domain) from the given overrides.
-     * Options:
-     *   • opts.path         → defaults to '/'
-     *   • opts.domainLevel  → if provided, take last N segments of hostname
-     *   • opts.expires      → normalized via _normalizeExpires
+     * Build the cookie‐option string (expires, path, domain) from:
+     *   1) the factory’s default options
+     *   2) any per‐call overrides provided in `opts`
      *
-     * @param {Object} [opts]
-     * @param {string} [opts.path]             - Cookie path (default "/").
-     * @param {number} [opts.domainLevel]      - Domains to include (last N segments of window.location.hostname).
-     * @param {string|number|Date} [opts.expires] - Expiration (Date, ISO string, or timestamp). Defaults to +10 years.
-     * @returns {string}    A string like "; expires=Thu, 01 Jan 2035 12:00:00 GMT; path=/; domain=example.com"
+     * @param {Object} [opts={}]
+     * @param {string} [opts.path]             - Cookie path override.
+     * @param {number} [opts.domainLevel]      - If provided, take last N segments of hostname.
+     * @param {string|number|Date} [opts.expires] - Expiration override. Defaults to factory’s default or +10 years.
+     *
+     * @returns {string} A string like "; expires=Thu, 01 Jan 2035 12:00:00 GMT; path=/; domain=example.com"
      */
-    _buildOptionString(opts = {}) {
-        const path = opts.path ? opts.path : '/';
-        const domain = typeof opts.domainLevel === 'number' ? this._pickDomain(opts.domainLevel) : null;
-        const expiresDate = this._normalizeExpires(opts.expires);
+    function buildOptionString(opts = {}) {
+        // 1. Determine the path: prefer opts.path, fall back to defaultOpts.path, then “/”
+        const path = opts.path != null ? opts.path : defaultOpts.path != null ? defaultOpts.path : '/';
+
+        // 2. Determine domainLevel: prefer opts.domainLevel, fall back to defaultOpts.domainLevel
+        //    (if neither is a number, domainLevel will be undefined)
+        const domainLevelCandidate = opts.domainLevel != null ? opts.domainLevel : defaultOpts.domainLevel;
+        const domain = typeof domainLevelCandidate === 'number' ? pickDomain(domainLevelCandidate) : '';
+
+        // 3. Determine the “expires” source: prefer opts.expires, fall back to defaultOpts.expires
+        //    (if neither is provided, expireSource will be undefined, and normalizeExpires will treat it as “10 years from now”)
+        const expiresSource = opts.expires != null ? opts.expires : defaultOpts.expires;
+        const expiresDate = normalizeExpires(expiresSource);
+
+        // 4. Build the string fragments
         const expiresPart = `; expires=${expiresDate.toUTCString()}`;
         const pathPart = `; path=${path}`;
         const domainPart = domain ? `; domain=${domain}` : '';
+
         return `${expiresPart}${pathPart}${domainPart}`;
-    },
-
-    /**
-     * Retrieve a cookie value by key.
-     * If the stored value is valid JSON, returns the parsed object; otherwise returns the raw string.
-     *
-     * @param {string} key        - The cookie key to read.
-     * @returns {any|null}        - The parsed object or string, or null if not found.
-     */
-    getItem(key) {
-        const all = document.cookie.split('; ');
-        const match = all.find(row => row.startsWith(`${key}=`));
-        if (!match) return null;
-
-        const rawValue = decodeURIComponent(match.split('=')[1]);
-        try {
-            return JSON.parse(rawValue);
-        } catch (error) {
-            return rawValue;
-        }
-    },
-
-    /**
-     * Set a persistent cookie with a JSON-serialized value.
-     *
-     * @param {string} key        - The cookie key to write.
-     * @param {any} value         - Any JSON‐serializable value (will be stringified).
-     * @param {Object} [opts]     - Optional overrides:
-     *   @param {string} [opts.path]           - Cookie path (default "/").
-     *   @param {number} [opts.domainLevel]    - Number of hostname segments to include in `domain=`.
-     *   @param {string|number|Date} [opts.expires] - Expiration (Date / ISO string / timestamp). Defaults to +10 years.
-     */
-    setItem(key, value, opts = {}) {
-        const jsonString = JSON.stringify(value);
-        const encodedValue = encodeURIComponent(jsonString);
-        const optionString = this._buildOptionString(opts);
-        document.cookie = `${key}=${encodedValue}${optionString}`;
-    },
-
-    /**
-     * Remove a cookie by setting its expiry to the past.
-     * Must match the same `path` and `domain` used when it was created.
-     *
-     * @param {string} key      - The cookie key to delete.
-     * @param {Object} [opts]
-     *   @param {string} [opts.path]         - Cookie path (default "/").
-     *   @param {number} [opts.domainLevel]  - Number of hostname segments to match `domain=`.
-     */
-    removeItem(key, opts = {}) {
-        const past = new Date(0).toUTCString(); // "Thu, 01 Jan 1970 00:00:00 GMT"
-        const path = opts.path ? opts.path : '/';
-        const domain = typeof opts.domainLevel === 'number' ? this._pickDomain(opts.domainLevel) : null;
-
-        const pathPart = `; path=${path}`;
-        const domainPart = domain ? `; domain=${domain}` : '';
-        document.cookie = `${key}=; expires=${past}${pathPart}${domainPart}`;
-    },
-
-    /**
-     * List all cookie‐names currently set (for debugging or clearAll).
-     *
-     * @returns {string[]}    - Array of cookie keys (empty array if no cookies).
-     */
-    keys() {
-        if (!document.cookie.length) {
-            return [];
-        }
-        return document.cookie.split('; ').map(pair => pair.split('=')[0]);
-    },
-
-    /**
-     * Remove all cookies currently set (respecting path and domain).
-     * Uses `removeItem` on each key.
-     *
-     * @param {Object} [opts]
-     *   @param {string} [opts.path]         - Cookie path (default "/").
-     *   @param {number} [opts.domainLevel]  - Number of hostname segments to match `domain=`.
-     */
-    clearAll(opts = {}) {
-        this.keys().forEach(keyName => this.removeItem(keyName, opts));
     }
-};
 
-export default cookieStorage;
+    return {
+        /**
+         * Retrieve a cookie value by key.
+         * If the stored value is valid JSON, returns the parsed object;
+         * otherwise returns the raw string.
+         *
+         * @param {string} key - The cookie key to read.
+         * @returns {any|null} - Parsed object/string or null if not found.
+         */
+        getItem(key) {
+            const all = document.cookie.split('; ');
+            const match = all.find(row => row.startsWith(`${key}=`));
+            if (!match) return null;
+            const rawValue = decodeURIComponent(match.split('=')[1]);
+            try {
+                return JSON.parse(rawValue);
+            } catch (err) {
+                return rawValue;
+            }
+        },
+
+        /**
+         * Set a persistent cookie with a JSON‐serialized value.
+         *
+         * @param {string} key    - The cookie key to write.
+         * @param {any} value     - Any JSON‐serializable value (will be stringified).
+         * @param {Object} [opts] - Optional overrides:
+         *   @param {string} [opts.path]           - Cookie path override.
+         *   @param {number} [opts.domainLevel]    - Number of hostname segments for `domain=`.
+         *   @param {string|number|Date} [opts.expires] - Expiration override.
+         */
+        setItem(key, value, opts = {}) {
+            const jsonString = JSON.stringify(value);
+            const encodedValue = encodeURIComponent(jsonString);
+            const optionString = buildOptionString(opts);
+            document.cookie = `${key}=${encodedValue}${optionString}`;
+        },
+
+        /**
+         * Remove a cookie by setting its expiry to the past.
+         * Must match the same `path` and `domain` used when it was created.
+         *
+         * @param {string} key - The cookie key to delete.
+         * @param {Object} [opts] - Optional overrides:
+         *   @param {string} [opts.path]         - Cookie path override.
+         *   @param {number} [opts.domainLevel]  - Hostname segments for `domain=` override.
+         */
+        removeItem(key, opts = {}) {
+            const past = new Date(0).toUTCString(); // “Thu, 01 Jan 1970 00:00:00 GMT”
+            // Reuse `buildOptionString` logic but swap in the past date
+            const override = { ...opts, expires: past };
+            const optionString = buildOptionString(override);
+            // Write an empty value and force expiry in the past
+            document.cookie = `${key}=;${optionString}`;
+        },
+
+        /**
+         * List all cookie names currently set (for debugging or clearAll).
+         *
+         * @returns {string[]} - Array of cookie keys (empty array if no cookies).
+         */
+        keys() {
+            if (!document.cookie.length) return [];
+            return document.cookie.split('; ').map(pair => pair.split('=')[0]);
+        },
+
+        /**
+         * Remove all cookies currently set (respecting factory defaults and any overrides).
+         * Uses `removeItem` on each key.
+         *
+         * @param {Object} [opts] - Optional overrides group(same shape as removeItem opts).
+         */
+        clearAll(opts = {}) {
+            this.keys().forEach(keyName => this.removeItem(keyName, opts));
+        }
+    };
+}

--- a/src/util/cookies.js
+++ b/src/util/cookies.js
@@ -33,7 +33,6 @@
  */
 export function createCookieStorage(defaultOpts = {}) {
     /**
-     * @private
      * Take the last `n` segments of window.location.hostname,
      * or return null if there aren’t enough segments.
      * E.g. hostname="foo.bar.example.com", level=2 → "example.com"
@@ -47,7 +46,6 @@ export function createCookieStorage(defaultOpts = {}) {
     }
 
     /**
-     * @private
      * Normalize an `expires` option that may be:
      *   • a Date instance
      *   • a parsable string/number
@@ -70,7 +68,6 @@ export function createCookieStorage(defaultOpts = {}) {
     }
 
     /**
-     * @private
      * Build the cookie‐option string (expires, path, domain) from:
      *   1) the factory’s default options
      *   2) any per‐call overrides provided in `opts`

--- a/src/util/encode.js
+++ b/src/util/encode.js
@@ -83,9 +83,21 @@ function decodeBase64(str) {
     );
 }
 
+/**
+ * Generate hash from text using SHA-256
+ * @param {String} text
+ * @returns {Promise<String>}
+ */
+async function stringToSha256(text) {
+    const data = new TextEncoder().encode(text);
+    const hash = await crypto.subtle.digest('SHA-256', data);
+    return [...new Uint8Array(hash)].map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
 export default {
     html: encodeHTML,
     attribute: encodeAttribute,
     encodeBase64: encodeBase64,
-    decodeBase64: decodeBase64
+    decodeBase64: decodeBase64,
+    stringToSha256: stringToSha256
 };

--- a/test/util/cookies/test.js
+++ b/test/util/cookies/test.js
@@ -14,61 +14,142 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  * Copyright (c) 2025 Open Assessment Technologies SA;
+ *
+ * Cookie-based storage utility.
+ * Supports JSON-serializable values and persistent cookies.
+ *
+ * @param {Object} [opt] - Optional overrides
+ * @param {string} [opt.path="/"] - Cookie path
+ * @param {number|string|Date} [opt.expires] - Expiration (Date, ISO string, or timestamp). Defaults to +10 years.
+ * @param {number} [opt.domainLevel] - How many hostname segments to include in `; domain=`
+ *                               (e.g. level=2 on "foo.bar.example.com" → "bar.example.com")
+ * @returns {Object} - Cookie storage interface with methods: getItem, setItem, removeItem, keys, clearAll
  */
 
-define(['util/cookies'], function (cookieStorage) {
+define(['util/cookies'], cookieStorageModule => {
     'use strict';
 
+    // The AMD module might export either the function itself or { default: <function> }.
+    const initCookieStorage = cookieStorageModule.default || cookieStorageModule;
+    let store;
+
     QUnit.module('cookieStorage', {
-        beforeEach: function () {
-            cookieStorage.removeItem('testKey');
-            cookieStorage.removeItem('nonexistent');
-            cookieStorage.removeItem('customKey');
-            cookieStorage.removeItem('toBeRemoved');
+        beforeEach() {
+            // Instantiate a fresh store each time:
+            store = initCookieStorage();
+            // Remove any leftover test cookies from previous runs:
+            ['testKey', 'nonexistent', 'customKey', 'toBeRemoved', 'key1', 'key2', 'rawKey', 'dateKey'].forEach(k => {
+                store.removeItem(k);
+            });
         }
     });
 
-    QUnit.test('getItem returns null when cookie is not set', function (assert) {
-        assert.strictEqual(cookieStorage.getItem('nonexistent'), null, 'Returns null for missing key');
+    QUnit.test('getItem returns null when cookie is not set', assert => {
+        assert.strictEqual(store.getItem('nonexistent'), null, 'Returns null for a missing key');
     });
 
-    QUnit.test('setItem sets and getItem retrieves the correct value', function (assert) {
+    QUnit.test('setItem sets and getItem retrieves the correct value', assert => {
         const key = 'testKey';
         const value = { a: 1, b: 'hello' };
 
-        cookieStorage.setItem(key, value);
-        const raw = cookieStorage.getItem(key);
-        const parsed = JSON.parse(raw);
+        store.setItem(key, value);
+        const retrieved = store.getItem(key);
 
-        assert.deepEqual(parsed, value, 'Retrieved value matches stored object');
+        assert.deepEqual(retrieved, value, 'Retrieved value matches the stored object');
     });
 
-    QUnit.test('setItem supports custom path, domain and expires', function (assert) {
+    QUnit.test('setItem supports custom path, domainLevel, and expires as ISO string', assert => {
         const key = 'customKey';
         const value = 'custom';
         const path = '/custom';
-        const domain = location.hostname;
-        const expires = new Date(Date.now() + 1000 * 60 * 60 * 24); // +1 day
+        const domainLevel = 1; // Use the last segment of the hostname
+        // Provide expires as an ISO string (not a Date object),
+        // to cover the branch new Date(opt.expires)
+        const isoString = new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString();
 
-        // The test is only verifying that no error occurs with custom options
+        const customStore = initCookieStorage({
+            path: path,
+            domainLevel: domainLevel,
+            expires: isoString
+        });
+
+        // Setting the cookie should not throw:
         try {
-            cookieStorage.setItem(key, value, { path, domain, expires });
+            customStore.setItem(key, value);
             assert.ok(true, 'Cookie was set without errors using custom options');
         } catch (ex) {
             assert.ok(false, `Error occurred while setting cookie: ${ex.message}`);
         }
+
+        // getItem should still return the correct value (parsed from JSON):
+        const retrieved = customStore.getItem(key);
+        assert.deepEqual(retrieved, value, 'Retrieved value matches stored string');
     });
 
-    QUnit.test('removeItem deletes the cookie', function (assert) {
+    QUnit.test('setItem supports expires as Date object', assert => {
+        const key = 'dateKey';
+        const value = 'val';
+        const tomorrow = new Date(Date.now() + 1000 * 60 * 60 * 24);
+
+        // Pass expires directly as a Date instance to cover the instanceof Date branch
+        const dateStore = initCookieStorage({
+            expires: tomorrow
+        });
+
+        // Setting the cookie should not throw:
+        try {
+            dateStore.setItem(key, value);
+            assert.ok(true, 'Cookie was set without errors when expires is a Date');
+        } catch (ex) {
+            assert.ok(false, `Error occurred while setting cookie: ${ex.message}`);
+        }
+
+        // getItem should return the same string "val":
+        const retrieved = dateStore.getItem(key);
+        assert.strictEqual(retrieved, value, 'Retrieved value matches stored string when expires was Date');
+    });
+
+    QUnit.test('removeItem deletes the cookie', assert => {
         const key = 'toBeRemoved';
         const value = 'bye';
 
-        cookieStorage.setItem(key, value);
-        assert.ok(cookieStorage.getItem(key), 'Cookie is set');
+        store.setItem(key, value);
+        assert.ok(store.getItem(key) !== null, 'Cookie is initially set');
 
-        cookieStorage.removeItem(key);
-        const removed = cookieStorage.getItem(key);
+        store.removeItem(key);
+        const removed = store.getItem(key);
+        assert.strictEqual(removed, null, 'Cookie is removed after removeItem()');
+    });
 
-        assert.strictEqual(removed, null, 'Cookie is removed');
+    QUnit.test('keys and clearAll manage all cookies correctly', assert => {
+        store.setItem('key1', 'val1');
+        store.setItem('key2', { x: 2 });
+
+        const keysBefore = store.keys();
+        assert.ok(
+            keysBefore.includes('key1') && keysBefore.includes('key2'),
+            'keys() returns an array containing both "key1" and "key2"'
+        );
+
+        store.clearAll();
+        assert.strictEqual(store.getItem('key1'), null, '"key1" was cleared by clearAll()');
+        assert.strictEqual(store.getItem('key2'), null, '"key2" was cleared by clearAll()');
+
+        const keysAfter = store.keys();
+        assert.deepEqual(keysAfter, [], 'keys() is empty after clearAll()');
+    });
+
+    QUnit.test('getItem returns raw string when value is not valid JSON', assert => {
+        const rawKey = 'rawKey';
+        const rawValue = 'just_a_plain_string';
+        // Manually insert a non-JSON string cookie:
+        document.cookie = `${rawKey}=${encodeURIComponent(rawValue)}; path=/`;
+
+        // Now getItem should return this raw string, not attempt JSON.parse
+        const retrieved = store.getItem(rawKey);
+        assert.strictEqual(retrieved, rawValue, 'getItem returns raw string when JSON.parse fails');
+
+        // Clean up:
+        store.removeItem(rawKey);
     });
 });

--- a/test/util/cookies/test.js
+++ b/test/util/cookies/test.js
@@ -75,6 +75,7 @@ define(['util/cookies'], cookieStorageModule => {
         // Immediately before calling:
         const before = new Date();
         // If we pass nothing, it should default to now + 10 years
+        // eslint-disable-next-line no-undefined
         const result = normalizeExpires(undefined);
         const after = new Date();
 

--- a/test/util/cookies/test.js
+++ b/test/util/cookies/test.js
@@ -19,157 +19,184 @@
 define(['util/cookies'], cookieStorageModule => {
     'use strict';
 
-    // AMD module might export either the function itself or { default: <function> }.
-    const initCookieStorage = cookieStorageModule.default || cookieStorageModule;
-    let store;
+    // The AMD bundle may export { default: function } or the function itself.
+    const cookieStorage = cookieStorageModule.default || cookieStorageModule;
 
-    QUnit.module('cookieStorage', {
+    // Bind “private” helpers so that `this` points at cookieStorage inside them.
+    const pickDomain = cookieStorage._pickDomain.bind(cookieStorage);
+    const normalizeExpires = cookieStorage._normalizeExpires.bind(cookieStorage);
+    const buildOptionString = cookieStorage._buildOptionString.bind(cookieStorage);
+
+    QUnit.module('cookieStorage (complete coverage)', {
         beforeEach() {
-            // Instantiate a fresh store:
-            store = initCookieStorage();
-
-            // Wipe any lingering test cookies:
-            [
-                'testKey',
-                'nonexistent',
-                'customKey',
-                'toBeRemoved',
-                'key1',
-                'key2',
-                'rawKey',
-                'dateKey',
-                'isoKey',
-                'domainKey'
-            ].forEach(k => {
-                store.removeItem(k);
+            // Wipe any cookies that our tests might create.
+            ['testKey', 'dateKey', 'isoKey', 'removeKey', 'key1', 'key2', 'rawKey'].forEach(name => {
+                // We call without extra opts; removeItem will default to path='/' and no domain.
+                cookieStorage.removeItem(name);
             });
         }
     });
 
-    QUnit.test('getItem returns null when cookie is not set', assert => {
-        assert.strictEqual(store.getItem('nonexistent'), null, 'Returns null for a missing key');
+    QUnit.test('_normalizeExpires: with a Date instance', assert => {
+        const base = new Date(2025, 0, 1, 0, 0, 0);
+        const result = normalizeExpires(base);
+        assert.ok(result instanceof Date, 'Result must be a Date');
+        assert.strictEqual(
+            result.valueOf(),
+            base.valueOf(),
+            'If passed a Date instance, the same timestamp is returned'
+        );
     });
 
-    QUnit.test('setItem sets and getItem retrieves the correct value', assert => {
+    QUnit.test('_normalizeExpires: with an ISO‐string / timestamp', assert => {
+        // Give an ISO string
+        const isoString = '2030-12-31T23:59:59Z';
+        const fromIso = normalizeExpires(isoString);
+        assert.ok(fromIso instanceof Date, 'ISO string → a Date');
+        assert.strictEqual(
+            fromIso.toISOString(),
+            new Date(isoString).toISOString(),
+            'Parsed ISO string yields exact same Date'
+        );
+
+        // Give a numeric timestamp (milliseconds)
+        const nowMs = Date.now();
+        const future = nowMs + 1000 * 60 * 60 * 24;
+        const fromNum = normalizeExpires(future);
+        assert.ok(fromNum instanceof Date, 'Numeric timestamp → a Date');
+        assert.strictEqual(
+            fromNum.valueOf(),
+            new Date(future).valueOf(),
+            'Parsed numeric timestamp yields correct Date'
+        );
+    });
+
+    QUnit.test('_normalizeExpires: with no argument or null → “10 years from now”', assert => {
+        // Immediately before calling:
+        const before = new Date();
+        // If we pass nothing, it should default to now + 10 years
+        const result = normalizeExpires(undefined);
+        const after = new Date();
+
+        assert.ok(result instanceof Date, 'Missing argument → still returns a Date');
+        // Check year difference of exactly 10. We allow a one‐millisecond difference on boundary.
+        const expectedYear = new Date().getFullYear() + 10;
+        assert.strictEqual(result.getFullYear(), expectedYear, 'Year is 10 years ahead');
+        // Ensure it’s ≥ (before + 10 years) and ≤ (after + 10 years + a few ms)
+        const minAllowed = new Date(before.setFullYear(before.getFullYear() + 10)).valueOf();
+        const maxAllowed = new Date(after.setFullYear(after.getFullYear() + 10)).valueOf() + 5;
+
+        assert.ok(
+            result.valueOf() >= minAllowed && result.valueOf() <= maxAllowed,
+            'Timestamp sits between (before +10y) and (after +10y + small)'
+        );
+    });
+
+    QUnit.test('_pickDomain: returns last N hostname segments or null if fewer segments than requested', assert => {
+        // We do not override window.location.hostname; just test logic on the existing hostname.
+        const hostname = window.location.hostname || 'localhost';
+        const parts = hostname.split('.');
+        // If we ask for level = parts.length, we should get the full hostname back.
+        const full = pickDomain(parts.length);
+        assert.strictEqual(
+            full,
+            parts.slice(-parts.length).join('.'),
+            'Asking for exactly all segments returns the entire hostname'
+        );
+
+        // If we ask for level = 1, we get only the last segment
+        const oneSeg = pickDomain(1);
+        assert.strictEqual(oneSeg, parts.slice(-1)[0], 'Asking for one segment yields the last piece');
+
+        // If we ask for a level larger than the number of segments, we get null
+        const tooMany = pickDomain(parts.length + 1);
+        assert.strictEqual(tooMany, null, 'level > number of parts yields null');
+    });
+
+    QUnit.test(
+        '_buildOptionString: default (empty opts) → must at least include path="/" and an expires= string',
+        assert => {
+            // Call with no opts object
+            const str = buildOptionString();
+            assert.ok(str.includes('; path=/'), 'Default opts include path=/');
+            assert.ok(str.match(/; expires=.* GMT/), 'Default opts include a valid expires=… GMT');
+            // Domain is omitted, so there should be no “; domain=” substring
+            assert.notOk(str.includes('; domain='), 'No domain= substring when domainLevel is not provided');
+        }
+    );
+
+    QUnit.test('_buildOptionString: with path + domainLevel + ISO expires', assert => {
+        // Whenever you call buildOptionString with domainLevel=1, that tries to pick
+        // exactly the last hostname segment (e.g. “localhost” in a typical QUnit runner).
+        const futureIso = new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString();
+        const opts = {
+            path: '/foo',
+            domainLevel: 1,
+            expires: futureIso
+        };
+        const str = buildOptionString(opts);
+
+        assert.ok(str.includes(`; path=/foo`), 'Includes the custom path=/foo');
+        // Because we asked for domainLevel=1, it should embed “; domain=…” with exactly the last hostname segment
+        const lastSegment = hostname => hostname.split('.').slice(-1)[0];
+        const expectedDomain = lastSegment(window.location.hostname);
+        assert.ok(
+            str.includes(`; domain=${expectedDomain}`),
+            `Includes the domain= part (last hostname segment = ${expectedDomain})`
+        );
+        // And the expires part should match exactly the toUTCString of the “futureIso”
+        const expectedExpires = new Date(futureIso).toUTCString();
+        assert.ok(str.includes(`; expires=${expectedExpires}`), `Includes the expires part "${expectedExpires}"`);
+    });
+
+    QUnit.test('getItem/setItem: round‐trip JSON‐serializable values', assert => {
         const key = 'testKey';
         const value = { a: 1, b: 'hello' };
 
-        store.setItem(key, value);
-        const retrieved = store.getItem(key);
+        cookieStorage.setItem(key, value);
+        const retrieved = cookieStorage.getItem(key);
 
-        assert.deepEqual(retrieved, value, 'Retrieved value matches the stored object');
+        assert.deepEqual(retrieved, value, 'Storing an object and retrieving it returns the same object');
     });
 
-    QUnit.test('setItem supports expires as Date object', assert => {
-        const key = 'dateKey';
-        const value = 'val';
-        const tomorrow = new Date(Date.now() + 1000 * 60 * 60 * 24);
-
-        // Pass expires directly as a Date instance to cover the instanceof Date branch
-        const dateStore = initCookieStorage({
-            expires: tomorrow
-        });
-
-        // Setting the cookie should not throw:
-        try {
-            dateStore.setItem(key, value);
-            assert.ok(true, 'Cookie was set without errors when expires is a Date');
-        } catch (ex) {
-            assert.ok(false, `Error occurred while setting cookie: ${ex.message}`);
-        }
-
-        // Now getItem should return the same string "val"
-        const retrieved = dateStore.getItem(key);
-        assert.strictEqual(retrieved, value, 'Retrieved value matches stored string when expires was Date');
+    QUnit.test('getItem: returns raw string if cookie value is not JSON', assert => {
+        const key = 'rawKey';
+        const plainVal = 'just_plain';
+        // Manually insert a plain‐string cookie (no JSON.stringify)
+        document.cookie = `${key}=${encodeURIComponent(plainVal)}; path=/`;
+        const retrieved = cookieStorage.getItem(key);
+        assert.strictEqual(retrieved, plainVal, 'If JSON.parse fails, getItem returns the raw string');
+        // Clean up
+        cookieStorage.removeItem(key);
     });
 
-    QUnit.test('setItem supports expires as ISO string (covers new Date(opt.expires))', assert => {
-        const key = 'isoKey';
-        const value = 'isoValue';
-        const isoString = new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString();
+    QUnit.test('removeItem: deleting a cookie makes getItem return null', assert => {
+        const key = 'removeKey';
+        const val = 'to_be_deleted';
 
-        // Pass expires as ISO‐string (not a Date), to hit “else if (opt.expires)” branch
-        const isoStore = initCookieStorage({
-            expires: isoString
-        });
+        cookieStorage.setItem(key, val);
+        assert.ok(cookieStorage.getItem(key) !== null, 'Cookie was initially set');
 
-        // setItem must not throw
-        try {
-            isoStore.setItem(key, value);
-            assert.ok(true, 'Cookie was set without errors using ISO‐string expiration');
-        } catch (ex) {
-            assert.ok(false, `Error occurred while setting cookie with ISO expiry: ${ex.message}`);
-        }
-
-        // We do NOT call getItem(...) here, because some environments
-        // won’t immediately expose a path‐scoped cookie back into document.cookie.
+        cookieStorage.removeItem(key);
+        const afterRemove = cookieStorage.getItem(key);
+        assert.strictEqual(afterRemove, null, 'After removeItem, getItem yields null');
     });
 
-    QUnit.test('setItem supports custom domainLevel (covers getDomainByHostname)', assert => {
-        const key = 'domainKey';
-        const value = 'domainVal';
+    QUnit.test('keys() and clearAll(): enumerates and clears all cookies', assert => {
+        cookieStorage.setItem('key1', 'val1');
+        cookieStorage.setItem('key2', { x: 2 });
 
-        // We know window.location.hostname is something like “127.0.0.1” or “localhost”,
-        // so setting domainLevel = 2 will take the last two segments (e.g. “0.1” or “host.local”).
-        // That exercises getDomainByHostname(...) without redefining hostname.
-        const domainStore = initCookieStorage({
-            domainLevel: 2
-        });
-
-        // If setItem(...) does not throw, we've covered the getDomainByHostname branch.
-        try {
-            domainStore.setItem(key, value);
-            assert.ok(true, 'Cookie was set without errors when domainLevel = 2 (getDomainByHostname executed)');
-        } catch (ex) {
-            assert.ok(false, `Error occurred while setting cookie with domainLevel: ${ex.message}`);
-        }
-
-        // (Again, we do not verify getItem(...) here, since domain‐scoped cookies may not appear
-        // immediately in document.cookie under QUnit’s test environment.)
-    });
-
-    QUnit.test('removeItem deletes the cookie', assert => {
-        const key = 'toBeRemoved';
-        const value = 'bye';
-
-        store.setItem(key, value);
-        assert.ok(store.getItem(key) !== null, 'Cookie is initially set');
-
-        store.removeItem(key);
-        const removed = store.getItem(key);
-        assert.strictEqual(removed, null, 'Cookie is removed after removeItem()');
-    });
-
-    QUnit.test('keys and clearAll manage all cookies correctly', assert => {
-        store.setItem('key1', 'val1');
-        store.setItem('key2', { x: 2 });
-
-        const keysBefore = store.keys();
+        const beforeKeys = cookieStorage.keys();
         assert.ok(
-            keysBefore.includes('key1') && keysBefore.includes('key2'),
-            'keys() returns an array containing both "key1" and "key2"'
+            beforeKeys.includes('key1') && beforeKeys.includes('key2'),
+            'keys() returns all currently set cookie names'
         );
 
-        store.clearAll();
-        assert.strictEqual(store.getItem('key1'), null, '"key1" was cleared by clearAll()');
-        assert.strictEqual(store.getItem('key2'), null, '"key2" was cleared by clearAll()');
+        cookieStorage.clearAll();
+        assert.strictEqual(cookieStorage.getItem('key1'), null, 'key1 was cleared');
+        assert.strictEqual(cookieStorage.getItem('key2'), null, 'key2 was cleared');
 
-        const keysAfter = store.keys();
-        assert.deepEqual(keysAfter, [], 'keys() is empty after clearAll()');
-    });
-
-    QUnit.test('getItem returns raw string when value is not valid JSON', assert => {
-        const rawKey = 'rawKey';
-        const rawValue = 'just_a_plain_string';
-
-        // Manually insert a non-JSON string cookie:
-        document.cookie = `${rawKey}=${encodeURIComponent(rawValue)}; path=/`;
-
-        // Now getItem should return this raw string, not attempt JSON.parse
-        const retrieved = store.getItem(rawKey);
-        assert.strictEqual(retrieved, rawValue, 'getItem returns raw string when JSON.parse fails');
-
-        // Clean up:
-        store.removeItem(rawKey);
+        const afterKeys = cookieStorage.keys();
+        assert.deepEqual(afterKeys, [], 'keys() returns [] after clearAll()');
     });
 });

--- a/test/util/cookies/test.js
+++ b/test/util/cookies/test.js
@@ -16,188 +16,129 @@
  * Copyright (c) 2025 Open Assessment Technologies SA;
  */
 
-define(['util/cookies'], cookieStorageModule => {
+define(['util/cookies'], cookieModule => {
     'use strict';
 
-    // The AMD bundle may export { default: function } or the function itself.
-    const cookieStorage = cookieStorageModule.default || cookieStorageModule;
+    // The AMD bundle may export { createCookieStorage: function } or the function itself.
+    const createCookieStorage = cookieModule.createCookieStorage || cookieModule.default || cookieModule;
 
-    // Bind “private” helpers so that `this` points at cookieStorage inside them.
-    const pickDomain = cookieStorage._pickDomain.bind(cookieStorage);
-    const normalizeExpires = cookieStorage._normalizeExpires.bind(cookieStorage);
-    const buildOptionString = cookieStorage._buildOptionString.bind(cookieStorage);
+    let store;
 
-    QUnit.module('cookieStorage (complete coverage)', {
+    QUnit.module('cookieStorage (public API only)', {
         beforeEach() {
-            // Wipe any cookies that our tests might create.
-            ['testKey', 'dateKey', 'isoKey', 'removeKey', 'key1', 'key2', 'rawKey'].forEach(name => {
-                // We call without extra opts; removeItem will default to path='/' and no domain.
-                cookieStorage.removeItem(name);
+            // Instantiate a fresh storage instance:
+            store = createCookieStorage();
+
+            // Remove any cookies that might remain from previous tests:
+            store.keys().forEach(name => {
+                // removeItem without opts uses default path='/', no domain
+                store.removeItem(name);
             });
         }
     });
 
-    QUnit.test('_normalizeExpires: with a Date instance', assert => {
-        const base = new Date(2025, 0, 1, 0, 0, 0);
-        const result = normalizeExpires(base);
-        assert.ok(result instanceof Date, 'Result must be a Date');
-        assert.strictEqual(
-            result.valueOf(),
-            base.valueOf(),
-            'If passed a Date instance, the same timestamp is returned'
-        );
+    QUnit.test('getItem returns null when no cookie is set', assert => {
+        assert.strictEqual(store.getItem('nonexistent'), null, 'Returns null if key not found');
     });
 
-    QUnit.test('_normalizeExpires: with an ISO‐string / timestamp', assert => {
-        // Give an ISO string
-        const isoString = '2030-12-31T23:59:59Z';
-        const fromIso = normalizeExpires(isoString);
-        assert.ok(fromIso instanceof Date, 'ISO string → a Date');
-        assert.strictEqual(
-            fromIso.toISOString(),
-            new Date(isoString).toISOString(),
-            'Parsed ISO string yields exact same Date'
-        );
-
-        // Give a numeric timestamp (milliseconds)
-        const nowMs = Date.now();
-        const future = nowMs + 1000 * 60 * 60 * 24;
-        const fromNum = normalizeExpires(future);
-        assert.ok(fromNum instanceof Date, 'Numeric timestamp → a Date');
-        assert.strictEqual(
-            fromNum.valueOf(),
-            new Date(future).valueOf(),
-            'Parsed numeric timestamp yields correct Date'
-        );
-    });
-
-    QUnit.test('_normalizeExpires: with no argument or null → “10 years from now”', assert => {
-        // Immediately before calling:
-        const before = new Date();
-        // If we pass nothing, it should default to now + 10 years
-        // eslint-disable-next-line no-undefined
-        const result = normalizeExpires(undefined);
-        const after = new Date();
-
-        assert.ok(result instanceof Date, 'Missing argument → still returns a Date');
-        // Check year difference of exactly 10. We allow a one‐millisecond difference on boundary.
-        const expectedYear = new Date().getFullYear() + 10;
-        assert.strictEqual(result.getFullYear(), expectedYear, 'Year is 10 years ahead');
-        // Ensure it’s ≥ (before + 10 years) and ≤ (after + 10 years + a few ms)
-        const minAllowed = new Date(before.setFullYear(before.getFullYear() + 10)).valueOf();
-        const maxAllowed = new Date(after.setFullYear(after.getFullYear() + 10)).valueOf() + 5;
-
-        assert.ok(
-            result.valueOf() >= minAllowed && result.valueOf() <= maxAllowed,
-            'Timestamp sits between (before +10y) and (after +10y + small)'
-        );
-    });
-
-    QUnit.test('_pickDomain: returns last N hostname segments or null if fewer segments than requested', assert => {
-        // We do not override window.location.hostname; just test logic on the existing hostname.
-        const hostname = window.location.hostname || 'localhost';
-        const parts = hostname.split('.');
-        // If we ask for level = parts.length, we should get the full hostname back.
-        const full = pickDomain(parts.length);
-        assert.strictEqual(
-            full,
-            parts.slice(-parts.length).join('.'),
-            'Asking for exactly all segments returns the entire hostname'
-        );
-
-        // If we ask for level = 1, we get only the last segment
-        const oneSeg = pickDomain(1);
-        assert.strictEqual(oneSeg, parts.slice(-1)[0], 'Asking for one segment yields the last piece');
-
-        // If we ask for a level larger than the number of segments, we get null
-        const tooMany = pickDomain(parts.length + 1);
-        assert.strictEqual(tooMany, null, 'level > number of parts yields null');
-    });
-
-    QUnit.test(
-        '_buildOptionString: default (empty opts) → must at least include path="/" and an expires= string',
-        assert => {
-            // Call with no opts object
-            const str = buildOptionString();
-            assert.ok(str.includes('; path=/'), 'Default opts include path=/');
-            assert.ok(str.match(/; expires=.* GMT/), 'Default opts include a valid expires=… GMT');
-            // Domain is omitted, so there should be no “; domain=” substring
-            assert.notOk(str.includes('; domain='), 'No domain= substring when domainLevel is not provided');
-        }
-    );
-
-    QUnit.test('_buildOptionString: with path + domainLevel + ISO expires', assert => {
-        // Whenever you call buildOptionString with domainLevel=1, that tries to pick
-        // exactly the last hostname segment (e.g. “localhost” in a typical QUnit runner).
-        const futureIso = new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString();
-        const opts = {
-            path: '/foo',
-            domainLevel: 1,
-            expires: futureIso
-        };
-        const str = buildOptionString(opts);
-
-        assert.ok(str.includes(`; path=/foo`), 'Includes the custom path=/foo');
-        // Because we asked for domainLevel=1, it should embed “; domain=…” with exactly the last hostname segment
-        const lastSegment = hostname => hostname.split('.').slice(-1)[0];
-        const expectedDomain = lastSegment(window.location.hostname);
-        assert.ok(
-            str.includes(`; domain=${expectedDomain}`),
-            `Includes the domain= part (last hostname segment = ${expectedDomain})`
-        );
-        // And the expires part should match exactly the toUTCString of the “futureIso”
-        const expectedExpires = new Date(futureIso).toUTCString();
-        assert.ok(str.includes(`; expires=${expectedExpires}`), `Includes the expires part "${expectedExpires}"`);
-    });
-
-    QUnit.test('getItem/setItem: round‐trip JSON‐serializable values', assert => {
+    QUnit.test('setItem + getItem round-trips a JSON-serializable object', assert => {
         const key = 'testKey';
         const value = { a: 1, b: 'hello' };
 
-        cookieStorage.setItem(key, value);
-        const retrieved = cookieStorage.getItem(key);
+        store.setItem(key, value);
+        const retrieved = store.getItem(key);
 
-        assert.deepEqual(retrieved, value, 'Storing an object and retrieving it returns the same object');
+        assert.deepEqual(
+            retrieved,
+            value,
+            'Storing an object with setItem and reading it back returns the same object'
+        );
     });
 
-    QUnit.test('getItem: returns raw string if cookie value is not JSON', assert => {
-        const key = 'rawKey';
-        const plainVal = 'just_plain';
-        // Manually insert a plain‐string cookie (no JSON.stringify)
-        document.cookie = `${key}=${encodeURIComponent(plainVal)}; path=/`;
-        const retrieved = cookieStorage.getItem(key);
-        assert.strictEqual(retrieved, plainVal, 'If JSON.parse fails, getItem returns the raw string');
-        // Clean up
-        cookieStorage.removeItem(key);
+    QUnit.test('setItem with plain string value is retrieved as string', assert => {
+        const key = 'stringKey';
+        const value = 'just_a_string';
+
+        store.setItem(key, value);
+        const retrieved = store.getItem(key);
+
+        assert.strictEqual(retrieved, value, 'Storing a plain string and retrieving returns the raw string');
     });
 
-    QUnit.test('removeItem: deleting a cookie makes getItem return null', assert => {
+    QUnit.test('setItem with expires override does not throw', assert => {
+        const key = 'expiresKey';
+        const futureISO = new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString();
+
+        assert.ok(() => {
+            store.setItem(key, 'value', { expires: futureISO });
+        }, 'Calling setItem with an ISO-string expires override should not throw');
+        // We won’t call getItem here because path-scoped cookies may not appear immediately in QUnit’s environment
+    });
+
+    QUnit.test('removeItem deletes the cookie so getItem returns null', assert => {
         const key = 'removeKey';
         const val = 'to_be_deleted';
 
-        cookieStorage.setItem(key, val);
-        assert.ok(cookieStorage.getItem(key) !== null, 'Cookie was initially set');
+        store.setItem(key, val);
+        assert.ok(store.getItem(key) !== null, 'Cookie is initially set');
 
-        cookieStorage.removeItem(key);
-        const afterRemove = cookieStorage.getItem(key);
-        assert.strictEqual(afterRemove, null, 'After removeItem, getItem yields null');
+        store.removeItem(key);
+        const afterRemove = store.getItem(key);
+        assert.strictEqual(afterRemove, null, 'After removeItem, getItem returns null');
     });
 
-    QUnit.test('keys() and clearAll(): enumerates and clears all cookies', assert => {
-        cookieStorage.setItem('key1', 'val1');
-        cookieStorage.setItem('key2', { x: 2 });
+    QUnit.test('keys() and clearAll() enumerate and clear all cookies', assert => {
+        store.setItem('key1', 'val1');
+        store.setItem('key2', { x: 2 });
 
-        const beforeKeys = cookieStorage.keys();
+        const beforeKeys = store.keys();
         assert.ok(
             beforeKeys.includes('key1') && beforeKeys.includes('key2'),
-            'keys() returns all currently set cookie names'
+            'keys() returns both "key1" and "key2" when they are set'
         );
 
-        cookieStorage.clearAll();
-        assert.strictEqual(cookieStorage.getItem('key1'), null, 'key1 was cleared');
-        assert.strictEqual(cookieStorage.getItem('key2'), null, 'key2 was cleared');
+        store.clearAll();
+        assert.strictEqual(store.getItem('key1'), null, '"key1" was cleared');
+        assert.strictEqual(store.getItem('key2'), null, '"key2" was cleared');
 
-        const afterKeys = cookieStorage.keys();
-        assert.deepEqual(afterKeys, [], 'keys() returns [] after clearAll()');
+        const afterKeys = store.keys();
+        assert.deepEqual(afterKeys, [], 'keys() is empty after clearAll()');
+    });
+
+    QUnit.test('getItem returns raw string when cookie value is not valid JSON', assert => {
+        const key = 'rawKey';
+        const rawValue = 'plain_text_value';
+
+        // Manually set a non-JSON value in document.cookie:
+        document.cookie = `${key}=${encodeURIComponent(rawValue)}; path=/`;
+
+        const retrieved = store.getItem(key);
+        assert.strictEqual(retrieved, rawValue, 'getItem returns the raw string when JSON.parse fails');
+
+        // Clean up:
+        store.removeItem(key);
+    });
+
+    QUnit.test('domainLevel too large: setItem should omit any "; domain=" fragment', assert => {
+        const key = 'domainTestKey';
+        const value = 'blah';
+
+        // How many segments does the current hostname have?
+        const parts = window.location.hostname.split('.');
+        const tooBigLevel = parts.length + 1;
+
+        // Attempt to set a cookie with domainLevel > parts.length
+        store.setItem(key, value, { domainLevel: tooBigLevel });
+
+        // Read the raw `document.cookie` string:
+        const rawCookieString = document.cookie;
+
+        assert.ok(rawCookieString.includes(`${key}=`), 'The cookie name=value pair still appears');
+        assert.notOk(
+            rawCookieString.includes('; domain='),
+            'Since domainLevel was too large, there should be no "; domain=" fragment'
+        );
+        // Clean up:
+        store.removeItem(key);
     });
 });

--- a/test/util/encode/test.js
+++ b/test/util/encode/test.js
@@ -62,7 +62,7 @@ define(['util/encode', 'lodash', 'jquery'], function (encode) {
         }
     ];
 
-        var sha256DataProvider = [
+    var sha256DataProvider = [
         {
             title: 'Simple ASCII text',
             string: 'hello',

--- a/test/util/encode/test.js
+++ b/test/util/encode/test.js
@@ -62,6 +62,14 @@ define(['util/encode', 'lodash', 'jquery'], function (encode) {
         }
     ];
 
+        var sha256DataProvider = [
+        {
+            title: 'Simple ASCII text',
+            string: 'hello',
+            sha256: '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'
+        }
+    ];
+
     QUnit.module('API');
 
     QUnit.cases.init(htmlDataProvider).test('encode HTML ', function (data, assert) {
@@ -86,5 +94,14 @@ define(['util/encode', 'lodash', 'jquery'], function (encode) {
         var result = encode.decodeBase64(data.base64);
         assert.ok(typeof result === 'string', 'The result is a string');
         assert.equal(result, data.string, 'The result is equal to the expected value');
+    });
+
+    QUnit.cases.init(sha256DataProvider).test('stringToSha256 ', function (data, assert) {
+        const done = assert.async();
+        encode.stringToSha256(data.string).then(function (hash) {
+            assert.ok(typeof hash === 'string', 'The result is a string');
+            assert.equal(hash, data.sha256, 'Hash matches expected SHA-256');
+            done();
+        });
     });
 });


### PR DESCRIPTION
### Related to:
https://oat-sa.atlassian.net/browse/ADF-1978

### Description:
Implemented `stringToSha256` utility and added QUnit tests coverage
Updated `cookie.js` to use apply options from set/remove methods and use utility functions to manage domainLevel.

### How to test:

1. `npm run test:cov`
2. `npx nyc report --reporter=text --include "src/util/cookies.js"`