### PR TITLE
FUN-2255 optionally provision the refresh-token to the auth server explicitly

### DIFF
--- a/src/core/jwt/jwtTokenStore.js
+++ b/src/core/jwt/jwtTokenStore.js
@@ -89,10 +89,11 @@ const jwtTokenStoreFactory = function jwtTokenStoreFactory({
         /**
          * Set refresh token
          * @param {string} token
+         * @param {string} id
          * @returns {Promise<Boolean>} token successfully set
          */
-        setRefreshToken(token) {
-            return getRefreshTokenStore().then(storage => storage.setItem(refreshTokenName, token));
+        setRefreshToken(token, id = refreshTokenName) {
+            return getRefreshTokenStore().then(storage => storage.setItem(id, token));
         },
 
         /**


### PR DESCRIPTION
# [FUN-2255](https://oat-sa.atlassian.net/browse/FUN-2255)

The goal of this PR is to read the refresh-token value set by the em-auth-proxy in the LTI launch sequence (see https://github.com/oat-sa/environment-management/pull/1106). With that value set as a special header, the auth server will then produce an access token even when no refresh-token cookie is set.

The cookie-based authorization still works exactly like it did before.



https://github.com/user-attachments/assets/aeaf0437-9b3d-497d-ae04-34699f3976e5


## How to test
Launch an assessment [from here](https://devkit-udir-tst.eps.udir.no/platform/message/launch/lti-resource-link?registration=crossDomainDeliver&user_list=chewbacca&launch_url=https://testrunner-oat-exp.dev.gcp-eu.taocloud.org/api/v1/auth/launch-lti-1p3-battery/5a0c295e-b2ea-4e1f-9297-0814c2b3ae36&claims=%7B%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/roles%22:%20%5B%0D%0A%20%20%20%20%20%20%20%20%22http://purl.imsglobal.org/vocab/lis/v2/membership%23Learner%22%0D%0A%20%20%20%20%5D%0D%0A%7D).

I don't have another cross-domain registration where the auth mode would've been set to `cookie`. But the new code in the cookie auth mode can nevertheless be tested [in here](https://devkit-oat-exp.dev.gcp-eu.taocloud.org/platform/message/launch/lti-resource-link?registration=2_DeliverRegistration_construct2_oat_exp&user_list=c3po&launch_url=https://testrunner-oat-exp.dev.gcp-eu.taocloud.org/api/v1/auth/launch-lti-1p3/52aada43db66&claims=%7B%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/roles%22:%20%5B%0D%0A%20%20%20%20%20%20%20%20%22http://purl.imsglobal.org/vocab/lis/v2/membership%23Learner%22%0D%0A%20%20%20%20%5D%0D%0A%7D).

## Works best with
- https://github.com/oat-sa/environment-management/pull/1106

[FUN-2255]: https://oat-sa.atlassian.net/browse/FUN-2255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ