### PR TITLE
Actualize develop after releasing 3.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@oat-sa/tao-core-sdk",
-    "version": "3.5.0",
+    "version": "3.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@oat-sa/tao-core-sdk",
-            "version": "3.5.0",
+            "version": "3.6.0",
             "license": "GPL-2.0",
             "dependencies": {
                 "idb-wrapper": "1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-sdk",
-    "version": "3.5.0",
+    "version": "3.6.0",
     "displayName": "TAO Core SDK",
     "description": "Core libraries of TAO",
     "homepage": "https://github.com/oat-sa/tao-core-sdk-fe#readme",


### PR DESCRIPTION
Actualize `develop` after https://github.com/oat-sa/tao-core-sdk-fe/pull/209.